### PR TITLE
Make build target path platform agnostic

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/All.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/All.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <BlazorBuildExe>dotnet $(MSBuildThisFileDirectory)..\tools\Microsoft.AspNetCore.Blazor.Build.dll</BlazorBuildExe>
+    <BlazorBuildExe>dotnet $(MSBuildThisFileDirectory)../tools/Microsoft.AspNetCore.Blazor.Build.dll</BlazorBuildExe>
   </PropertyGroup>
 
   <Import Project="RazorCompilation.targets" />


### PR DESCRIPTION
This fixes building Blazor on file systems and platforms that use the forward-slash character as a path separator.

Tested with

* ArchLinux / DotNet SDK 2.1.4
* Windows 10 / DotNet SDK 2.1.4
* Windows 10 / Visual Studio 2017 version 15.5.6