### PR TITLE
Fixed issue #44 with build when using a directory path with a space in it

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/All.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/All.targets
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <BlazorBuildExe>dotnet $(MSBuildThisFileDirectory)../tools/Microsoft.AspNetCore.Blazor.Build.dll</BlazorBuildExe>
+    <BlazorBuildExe>dotnet &quot;$(MSBuildThisFileDirectory)../tools/Microsoft.AspNetCore.Blazor.Build.dll&quot;</BlazorBuildExe>
   </PropertyGroup>
 
   <Import Project="RazorCompilation.targets" />
@@ -21,9 +21,9 @@
     <PropertyGroup>
       <WebRootName>wwwroot</WebRootName>
       <WebRootPath>$(ProjectDir)$(WebRootName)</WebRootPath>
-      <WebRootParam Condition="Exists('$(WebRootPath)')">--webroot $(WebRootPath)</WebRootParam>
+      <WebRootParam Condition="Exists('$(WebRootPath)')">--webroot &quot;$(WebRootPath)&quot;</WebRootParam>
     </PropertyGroup>
     <!-- TODO: Find the correct time to run this (right after assemblies were written) -->
-    <Exec Command="$(BlazorBuildExe) build $(ProjectDir)$(OutDir)$(AssemblyName).dll $(WebRootParam)" />
+    <Exec Command="$(BlazorBuildExe) build &quot;$(ProjectDir)$(OutDir)$(AssemblyName).dll&quot; $(WebRootParam)" />
   </Target>
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
@@ -4,8 +4,9 @@
       <BlazorComponentsNamespace>$(RootNamespace)</BlazorComponentsNamespace>
       <IsDesignTimeBuild Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'">true</IsDesignTimeBuild>
       <GeneratedFilePath>$(IntermediateOutputPath)BlazorRazorComponents.g.cs</GeneratedFilePath>
+      <SourceDir>$(ProjectDir.TrimEnd('\'))</SourceDir>
     </PropertyGroup>
-    <Exec Command="$(BlazorBuildExe) buildrazor --source $(ProjectDir) --namespace $(BlazorComponentsNamespace) --output $(GeneratedFilePath)" />
+    <Exec Command="$(BlazorBuildExe) buildrazor --source &quot;$(SourceDir)&quot; --namespace $(BlazorComponentsNamespace) --output &quot;$(GeneratedFilePath)&quot;" />
     <ItemGroup>
       <Compile Include="$(GeneratedFilePath)" />
     </ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.BuildTools/ReferenceFromSource.props
+++ b/src/Microsoft.AspNetCore.Blazor.BuildTools/ReferenceFromSource.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <BlazorBuildToolsExe>dotnet $(MSBuildThisFileDirectory)tools\Microsoft.AspNetCore.Blazor.BuildTools.dll</BlazorBuildToolsExe>
+    <BlazorBuildToolsExe>dotnet &quot;$(MSBuildThisFileDirectory)tools\Microsoft.AspNetCore.Blazor.BuildTools.dll&quot;</BlazorBuildToolsExe>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.BuildTools/ReferenceFromSource.props
+++ b/src/Microsoft.AspNetCore.Blazor.BuildTools/ReferenceFromSource.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <BlazorBuildToolsExe>dotnet &quot;$(MSBuildThisFileDirectory)tools\Microsoft.AspNetCore.Blazor.BuildTools.dll&quot;</BlazorBuildToolsExe>
+    <BlazorBuildToolsExe>dotnet &quot;$(MSBuildThisFileDirectory)tools/Microsoft.AspNetCore.Blazor.BuildTools.dll&quot;</BlazorBuildToolsExe>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added **\&quot;** characters to the paths in the build targets and properties to take into account directory paths with a space in them

Trimmed any trailing backslashes from the ProjectDir path as this would escape the quotemark.

Also, fixed a backslash that was missed in #43

Addresses #44 

Tested on:

- Windows 10 / DotNet SDK 2.1.4
- Ubuntu 16.04 / DotNet SDK 2.1.4

And tested with a directory without a space.