### PR TITLE
[WIP] injecting blazor boot code and/or config data more intelligently

### DIFF
--- a/samples/HostedInAspNet.Client/wwwroot/index.html
+++ b/samples/HostedInAspNet.Client/wwwroot/index.html
@@ -6,5 +6,6 @@
 </head>
 <body>
   <app>Loading...</app>
+  <script type="blazor-boot"></script>
 </body>
 </html>

--- a/samples/MonoSanity/wwwroot/index.html
+++ b/samples/MonoSanity/wwwroot/index.html
@@ -57,6 +57,7 @@
 
   <p id="loadingIndicator">Loading...</p>
 
+  <script type="blazor-boot"></script>
   <script src="loader.js"></script>
   <script>
     initMono(['/_framework/_bin/MonoSanityClient.dll'], function () {

--- a/samples/StandaloneApp/wwwroot/index.html
+++ b/samples/StandaloneApp/wwwroot/index.html
@@ -5,6 +5,7 @@
     <title>Blazor standalone</title>
 </head>
 <body>
-  <app>Loading...</app>
+    <app>Loading...</app>
+    <script type="blazor-boot"></script>
 </body>
 </html>

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Boot.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Boot.ts
@@ -6,13 +6,15 @@ import './GlobalExports';
 async function boot() {
   // Read startup config from the <script> element that's importing this file
   const allScriptElems = document.getElementsByTagName('script');
-  const thisScriptElem = allScriptElems[allScriptElems.length - 1];
-  const entryPoint = thisScriptElem.getAttribute('main');
+  const thisScriptElem = document.currentScript || allScriptElems[allScriptElems.length - 1];
+  // Try to find the script element that has our bootstrap configuration, or default to this
+  const configScriptElem = document.querySelector('script[type=="blazor-config"]') || thisScriptElem;
+  const entryPoint = configScriptElem.getAttribute('main');
   if (!entryPoint) {
-    throw new Error('Missing "main" attribute on Blazor script tag.');
+    throw new Error('Missing "main" attribute on Blazor Config script tag.');
   }
   const entryPointAssemblyName = getAssemblyNameFromUrl(entryPoint);
-  const referenceAssembliesCommaSeparated = thisScriptElem.getAttribute('references') || '';
+  const referenceAssembliesCommaSeparated = configScriptElem.getAttribute('references') || '';
   const referenceAssemblies = referenceAssembliesCommaSeparated
     .split(',')
     .map(s => s.trim())

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Boot.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Boot.ts
@@ -7,14 +7,12 @@ async function boot() {
   // Read startup config from the <script> element that's importing this file
   const allScriptElems = document.getElementsByTagName('script');
   const thisScriptElem = document.currentScript || allScriptElems[allScriptElems.length - 1];
-  // Try to find the script element that has our bootstrap configuration, or default to this
-  const configScriptElem = document.querySelector('script[type="blazor-config"]') || thisScriptElem;
-  const entryPoint = configScriptElem.getAttribute('main');
+  const entryPoint = thisScriptElem.getAttribute('main');
   if (!entryPoint) {
     throw new Error('Missing "main" attribute on Blazor Config script tag.');
   }
   const entryPointAssemblyName = getAssemblyNameFromUrl(entryPoint);
-  const referenceAssembliesCommaSeparated = configScriptElem.getAttribute('references') || '';
+  const referenceAssembliesCommaSeparated = thisScriptElem.getAttribute('references') || '';
   const referenceAssemblies = referenceAssembliesCommaSeparated
     .split(',')
     .map(s => s.trim())

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Boot.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Boot.ts
@@ -8,7 +8,7 @@ async function boot() {
   const allScriptElems = document.getElementsByTagName('script');
   const thisScriptElem = document.currentScript || allScriptElems[allScriptElems.length - 1];
   // Try to find the script element that has our bootstrap configuration, or default to this
-  const configScriptElem = document.querySelector('script[type=="blazor-config"]') || thisScriptElem;
+  const configScriptElem = document.querySelector('script[type="blazor-config"]') || thisScriptElem;
   const entryPoint = configScriptElem.getAttribute('main');
   if (!entryPoint) {
     throw new Error('Missing "main" attribute on Blazor Config script tag.');

--- a/src/Microsoft.AspNetCore.Blazor.Build/Core/FileSystem/IndexHtmlFileProvider.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Build/Core/FileSystem/IndexHtmlFileProvider.cs
@@ -35,10 +35,11 @@ namespace Microsoft.AspNetCore.Blazor.Build.Core.FileSystem
         /// </summary>
         /// <remarks>
         /// <para>
-        /// If the template already contains a &lt;script&gt; tag that has a type of
-        /// <c>blazor-boot</c>, then it is expected that the tag is responsible for
-        /// loading the Blazor boot script.  In this case a script element containing
-        /// only boot configuration is inserted at the very top of the body.
+        /// If the template already contains a &lt;script&gt; tag that has a
+        /// <c>blazor</c> attribute with a value of <c>boot</c>, then
+        /// it is expected that the tag is responsible for loading the Blazor
+        /// boot script.  In this case a script element containing only boot
+        /// configuration is inserted at the very top of the body.
         /// </para><para>
         /// Otherwise, we inject a new script tag that includes both the configuration
         /// data and the Blazor boot code and we inject just before the first user-owned
@@ -73,7 +74,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Core.FileSystem
             // First see if the user has declared a 'boot' script,
             // then it's their responsibility to load blazor.js
             var bootScript = dom.Body?.QuerySelectorAll("script")
-                   .Where(x => x.Attributes["type"]?.Value == "blazor-boot").FirstOrDefault();
+                   .Where(x => x.Attributes["blazor"]?.Value == "boot").FirstOrDefault();
             if (bootScript != null)
             {
                 // We just insert only blazor config data at the top
@@ -113,16 +114,16 @@ namespace Microsoft.AspNetCore.Blazor.Build.Core.FileSystem
                 .Select(file => file.Name);
             var referencesAttribute = string.Join(",", referenceNames.ToArray());
 
-            var scriptSrc = string.Empty;
-            var scriptType = "blazor-config";
+            var scriptSrcOrType = "type=\"blazor-config\"";
+            var scriptType = "config";
             if (loadJs)
             {
-                scriptSrc = $"src=\"/_framework/blazor.js\"";
-                scriptType = "blazor-boot";
+                scriptSrcOrType = $"src=\"/_framework/blazor.js\"";
+                scriptType = "boot";
             }
 
-            return $"<script {scriptSrc}" +
-                   $" type=\"{scriptType}\"" +
+            return $"<script {scriptSrcOrType}" +
+                   $" blazor=\"{scriptType}\"" +
                    $" main=\"{assemblyNameWithExtension}\"" +
                    $" references=\"{referencesAttribute}\"></script>";
         }

--- a/test/testapps/BasicTestApp/wwwroot/index.html
+++ b/test/testapps/BasicTestApp/wwwroot/index.html
@@ -7,6 +7,7 @@
 <body>
   <app>Loading...</app>
 
+  <script type="blazor-boot"></script>
   <script>
     // The client-side .NET code calls this when it is ready to be called from test code
     // The Xunit test code polls until it sees the flag is set


### PR DESCRIPTION
Taking a stab at this TODO:

This allows for either scenario in the TODO comments -- it injects either the boot loader or just the boot config data.

* If their exists a user-owned `script` tag with a attribute `blazor="boot"` it is assumed the user has the responsibility of loading the boot script and we inject a new script tag at the very top of body that contains only the boot config data (`type="blazor-config"`).
* Otherwise, we inject the full blazor boot + config data script tag (same as before), 
  * just before the first user-owned script tag, or
  * at the very end of the body if there is none, to prevent blocking.

I've tested this out in the 3 supported scenarios, seems to work as expected.

Looking for feedback.
