### PR TITLE
Added fast activator for generic and types

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser/Interop/Json.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Interop/Json.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.AspNetCore.Blazor.Activators;
 
 namespace Microsoft.AspNetCore.Blazor.Browser.Interop
 {
@@ -32,7 +33,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Interop
                 // Return default value for type
                 if (typeOfT.GetTypeInfo().IsValueType)
                 {
-                    return Activator.CreateInstance(typeOfT);
+                    return FastActivator.CreateInstance(typeOfT);
                 }
                 else
                 {
@@ -112,7 +113,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Interop
             }
             else if (deserializedValue is Dictionary<string, object>)
             {
-                var result = Activator.CreateInstance(typeOfT);
+                var result = FastActivator.CreateInstance(typeOfT);
                 var deserializedPropertyDict = (Dictionary<string, object>)deserializedValue;
                 foreach (var propInfo in typeOfT.GetRuntimeProperties())
                 {

--- a/src/Microsoft.AspNetCore.Blazor/Activators/DynamicModuleLambdaCompiler.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Activators/DynamicModuleLambdaCompiler.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection.Emit;
+
+namespace Microsoft.AspNetCore.Blazor.Activators
+{
+	public static class DynamicModuleLambdaCompiler
+	{
+		public static Func<T> GenerateFactory<T>() where T : new()
+		{
+			Expression<Func<T>> expr = () => new T();
+			NewExpression newExpr = (NewExpression)expr.Body;
+
+			var method = new DynamicMethod(
+				name: "lambda",
+				returnType: newExpr.Type,
+				parameterTypes: new Type[0],
+				m: typeof(DynamicModuleLambdaCompiler).Module,
+				skipVisibility: true);
+
+			ILGenerator ilGen = method.GetILGenerator();
+			// Constructor for value types could be null
+			if (newExpr.Constructor != null)
+			{
+				ilGen.Emit(OpCodes.Newobj, newExpr.Constructor);
+			}
+			else
+			{
+				LocalBuilder temp = ilGen.DeclareLocal(newExpr.Type);
+				ilGen.Emit(OpCodes.Ldloca, temp);
+				ilGen.Emit(OpCodes.Initobj, newExpr.Type);
+				ilGen.Emit(OpCodes.Ldloc, temp);
+			}
+
+			ilGen.Emit(OpCodes.Ret);
+
+			return (Func<T>)method.CreateDelegate(typeof(Func<T>));
+		}
+
+		public static Func<object> GenerateFactory(Type type)
+		{
+			var method = new DynamicMethod(
+				name: "lambda",
+				returnType: type,
+				parameterTypes: new Type[0],
+				m: typeof(DynamicModuleLambdaCompiler).Module,
+				skipVisibility: true);
+
+			ILGenerator ilGen = method.GetILGenerator();
+			var constructors = type.GetConstructors();
+
+			ilGen.Emit(OpCodes.Newobj, constructors[0]);
+			ilGen.Emit(OpCodes.Ret);
+
+			return (Func<object>)method.CreateDelegate(typeof(Func<object>));
+		}
+	}
+}

--- a/src/Microsoft.AspNetCore.Blazor/Activators/FastActivator.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Activators/FastActivator.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+
+namespace Microsoft.AspNetCore.Blazor.Activators
+{
+	public class FastActivator
+	{
+		private static ConcurrentDictionary<Type, Lazy<Func<object>>> factoryCache = new ConcurrentDictionary<Type, Lazy<Func<object>>>();
+
+		public static T CreateInstance<T>() where T : new()
+		{
+			return FastActivatorImpl<T>.Create();
+		}
+
+		public static object CreateInstance(Type type)
+		{
+			var lazy = factoryCache.GetOrAdd(type,
+				k => new Lazy<Func<object>>(() => DynamicModuleLambdaCompiler.GenerateFactory(k)));
+			return lazy.Value();
+		}
+
+		private static class FastActivatorImpl<T> where T : new()
+		{
+			public static readonly Func<T> Create =
+				DynamicModuleLambdaCompiler.GenerateFactory<T>();
+		}
+	}
+}

--- a/src/Microsoft.AspNetCore.Blazor/Microsoft.AspNetCore.Blazor.csproj
+++ b/src/Microsoft.AspNetCore.Blazor/Microsoft.AspNetCore.Blazor.csproj
@@ -5,4 +5,8 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeDiffBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using Microsoft.AspNetCore.Blazor.Activators;
 using Microsoft.AspNetCore.Blazor.Components;
 using Microsoft.AspNetCore.Blazor.Rendering;
 
@@ -270,7 +271,7 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
         {
             var propertyInfo = GetChildComponentPropertyInfo(component.GetType(), componentPropertyName);
             var defaultValue = propertyInfo.PropertyType.IsValueType
-                ? Activator.CreateInstance(propertyInfo.PropertyType)
+                ? FastActivator.CreateInstance(propertyInfo.PropertyType)
                 : null;
             SetChildComponentProperty(component, componentPropertyName, defaultValue);
         }

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Microsoft.AspNetCore.Blazor.Activators;
 
 namespace Microsoft.AspNetCore.Blazor.Rendering
 {
@@ -148,7 +149,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
                 throw new ArgumentException($"The frame already has a non-null component instance", nameof(frame));
             }
 
-            var newComponent = (IComponent)Activator.CreateInstance(frame.ComponentType);
+            var newComponent = (IComponent)FastActivator.CreateInstance(frame.ComponentType);
             var newComponentId = AssignComponentId(newComponent);
             frame = frame.WithComponentInstance(newComponentId, newComponent);
         }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorCompilerTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorCompilerTest.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Microsoft.AspNetCore.Blazor.Activators;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Blazor.Build.Test
@@ -379,7 +380,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             var assemblyResult = CompileToAssembly("c:\\ignored", $"{testComponentTypeName}.cshtml", cshtmlSource, testComponentNamespace);
             Assert.Empty(assemblyResult.Diagnostics);
             var testComponentType = assemblyResult.Assembly.GetType($"{testComponentNamespace}.{testComponentTypeName}");
-            return (IComponent)Activator.CreateInstance(testComponentType);
+            return (IComponent)FastActivator.CreateInstance(testComponentType);
         }
 
         private static CompileToAssemblyResult CompileToAssembly(string cshtmlRootPath, string cshtmlRelativePath, string cshtmlContent, string outputNamespace)

--- a/test/testapps/BasicTestApp/Program.cs
+++ b/test/testapps/BasicTestApp/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Blazor.Browser.Interop;
 using Microsoft.AspNetCore.Blazor.Browser.Rendering;
 using Microsoft.AspNetCore.Blazor.Components;
 using System;
+using Microsoft.AspNetCore.Blazor.Activators;
 
 namespace BasicTestApp
 {
@@ -19,7 +20,7 @@ namespace BasicTestApp
         public static void MountTestComponent(string componentTypeName)
         {
             var componentType = Type.GetType(componentTypeName);
-            var componentInstance = (IComponent)Activator.CreateInstance(componentType);
+            var componentInstance = (IComponent)FastActivator.CreateInstance(componentType);
             new BrowserRenderer().AddComponent("app", componentInstance);
         }
     }


### PR DESCRIPTION
Added FastActivator implementation. This implementation two-time faster than standart 
```
Activator.CreateInstance(typeof(A))
```
I think this changes will help for up performance
```
BenchmarkDotNet=v0.10.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-3632QM CPU 2.20GHz, ProcessorCount=8
Frequency=2143575 Hz, Resolution=466.5104 ns, Timer=TSC
Host Runtime=Clr 4.0.30319.42000, Arch=32-bit RELEASE [AttachedDebugger]
GC=Concurrent Workstation
JitModules=clrjit-v4.7.2600.0
Job Runtime(s):
Clr 4.0.30319.42000, Arch=32-bit RELEASE


               Method |       Mean |    StdDev |     Median |
--------------------- |----------- |---------- |----------- |
  FastActivatorByType | 47.5745 ns | 1.3975 ns | 47.2293 ns |
 GenericFastActivator | 10.7458 ns | 0.3119 ns | 10.6596 ns |
    StandartActivator | 92.7500 ns | 2.3080 ns | 92.2107 ns 
```