### PR TITLE
Refactoring middleware configuration API

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.DevHost/Server/Startup.cs
+++ b/src/Microsoft.AspNetCore.Blazor.DevHost/Server/Startup.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Blazor.DevHost.Server
             app.UseDeveloperExceptionPage();
 
             var clientAssemblyPath = FindClientAssemblyPath(app);
-            app.UseBlazorInternal(clientAssemblyPath);
+            app.UseBlazor(new BlazorOptions { ClientAssemblyPath = clientAssemblyPath });
         }
 
         private static string FindClientAssemblyPath(IApplicationBuilder app)

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
@@ -7,27 +7,40 @@ using Microsoft.Extensions.FileProviders;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Mime;
+using System;
 
 namespace Microsoft.AspNetCore.Builder
 {
     public static class BlazorAppBuilderExtensions
     {
+        /// <summary>
+        /// Configures the middleware pipeline to work with Blazor.
+        /// </summary>
+        /// <param name="applicationBuilder"></param>
+        /// <param name="clientAssemblyName"
+        ///     >The name of the client assembly relative to the current bin directory.</param>
         public static void UseBlazor(
             this IApplicationBuilder applicationBuilder,
             string clientAssemblyName)
         {
             var binDir = Path.GetDirectoryName(typeof(BlazorConfig).Assembly.Location);
             var clientAssemblyPath = Path.Combine(binDir, $"{clientAssemblyName}.dll");
-            applicationBuilder.UseBlazorInternal(clientAssemblyPath);
+            applicationBuilder.UseBlazor(new BlazorOptions
+            {
+                ClientAssemblyPath = clientAssemblyPath,
+            });
         }
-        
-        // TODO: Change this combination of APIs to make it possible to supply either
-        // an assembly name (resolved to current bin dir) or full assembly path
-        internal static void UseBlazorInternal(
+
+        /// <summary>
+        /// Configures the middleware pipeline to work with Blazor.
+        /// </summary>
+        /// <param name="applicationBuilder"></param>
+        /// <param name="options"></param>
+        public static void UseBlazor(
             this IApplicationBuilder applicationBuilder,
-            string clientAssemblyPath)
+            BlazorOptions options)
         {
-            var config = BlazorConfig.Read(clientAssemblyPath);
+            var config = BlazorConfig.Read(options.ClientAssemblyPath);
             var clientAppBinDir = Path.GetDirectoryName(config.SourceOutputAssemblyPath);
             var clientAppDistDir = Path.Combine(clientAppBinDir, "dist");
             var distFileProvider = new PhysicalFileProvider(clientAppDistDir);

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorOptions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorOptions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Microsoft.AspNetCore.Blazor.Server
+namespace Microsoft.AspNetCore.Builder
 {
     public class BlazorOptions
     {

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorOptions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorOptions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Blazor.Server
+{
+    public class BlazorOptions
+    {
+        /// <summary>
+        /// Full path to the client assembly.
+        /// </summary>
+        public string ClientAssemblyPath { get; set; }
+    }
+}


### PR DESCRIPTION
Trying to clean up the API for configuring server-side middleware for working with Blazor.

Refactoring the API to mimic the typical middleware options pattern, such as the simple [UseStaticFiles](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.staticfileextensions.usestaticfiles?view=aspnetcore-2.0)
or the [UseExceptionHandler](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.exceptionhandlerextensions.useexceptionhandler) extensions or even the more complex `UsMvc` and all its variations.

This pattern allows for easier growth, as any additional options can simply be added to the options class, and where it makes sense, we can create alternate convenience overloads.  But complete *configurability* can always be accessed by using the options parameter directly.