### PR TITLE
Split Razor extensibility into its own assembly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/
 obj/
 *.user
+launchSettings.json

--- a/Blazor.sln
+++ b/Blazor.sln
@@ -62,7 +62,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicTestApp", "test\testap
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "anglesharp", "anglesharp", "{4E3BD19A-6159-4548-A88F-700443E6D934}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AngleSharpBuilder", "src\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj", "{36706AC2-C851-4038-B161-9C1E44B668C8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AngleSharpBuilder", "src\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj", "{36706AC2-C851-4038-B161-9C1E44B668C8}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Blazor.Razor.Extensions", "src\Microsoft.AspNetCore.Blazor.Razor.Extensions\Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj", "{D652A019-B765-4922-B7B8-3AB1C58338D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -154,6 +156,10 @@ Global
 		{36706AC2-C851-4038-B161-9C1E44B668C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36706AC2-C851-4038-B161-9C1E44B668C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36706AC2-C851-4038-B161-9C1E44B668C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D652A019-B765-4922-B7B8-3AB1C58338D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D652A019-B765-4922-B7B8-3AB1C58338D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D652A019-B765-4922-B7B8-3AB1C58338D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D652A019-B765-4922-B7B8-3AB1C58338D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -185,6 +191,7 @@ Global
 		{2838CB6F-D2C7-4C0A-A994-C72E56F16984} = {4AE0D35B-D97A-44D0-8392-C9240377DCCE}
 		{4E3BD19A-6159-4548-A88F-700443E6D934} = {B867E038-B3CE-43E3-9292-61568C46CDEB}
 		{36706AC2-C851-4038-B161-9C1E44B668C8} = {4E3BD19A-6159-4548-A88F-700443E6D934}
+		{D652A019-B765-4922-B7B8-3AB1C58338D7} = {B867E038-B3CE-43E3-9292-61568C46CDEB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {504DA352-6788-4DC0-8705-82167E72A4D3}

--- a/BlazorTooling.sln
+++ b/BlazorTooling.sln
@@ -18,6 +18,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{91810C0E-892
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AngleSharpBuilder", "src\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj", "{E5067AD8-3AE7-442A-86C5-D19DBC48E961}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "anglesharp", "anglesharp", "{9DEA0869-2F17-419F-8F6A-53DCA898D3D6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Blazor.Razor.Extensions", "src\Microsoft.AspNetCore.Blazor.Razor.Extensions\Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj", "{319463A4-64C8-4A96-BEFD-2952BBD5FF67}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,6 +68,18 @@ Global
 		{E5067AD8-3AE7-442A-86C5-D19DBC48E961}.Release|x64.Build.0 = Release|Any CPU
 		{E5067AD8-3AE7-442A-86C5-D19DBC48E961}.Release|x86.ActiveCfg = Release|Any CPU
 		{E5067AD8-3AE7-442A-86C5-D19DBC48E961}.Release|x86.Build.0 = Release|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Debug|x64.Build.0 = Debug|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Debug|x86.Build.0 = Debug|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|x64.ActiveCfg = Release|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|x64.Build.0 = Release|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|x86.ActiveCfg = Release|Any CPU
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -71,7 +87,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{9088E4E4-B855-457F-AE9E-D86709A5E1F4} = {1AC24BB5-AEBD-4D5B-B86F-8C606EFFFFFB}
 		{5884589D-4A06-4F5B-B983-8F8D34696550} = {1AC24BB5-AEBD-4D5B-B86F-8C606EFFFFFB}
-		{E5067AD8-3AE7-442A-86C5-D19DBC48E961} = {91810C0E-892D-40EF-BDC0-5470B37E255F}
+		{E5067AD8-3AE7-442A-86C5-D19DBC48E961} = {9DEA0869-2F17-419F-8F6A-53DCA898D3D6}
+		{9DEA0869-2F17-419F-8F6A-53DCA898D3D6} = {91810C0E-892D-40EF-BDC0-5470B37E255F}
+		{319463A4-64C8-4A96-BEFD-2952BBD5FF67} = {91810C0E-892D-40EF-BDC0-5470B37E255F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {248760B5-9F71-4110-8DBC-DDAB615AD88E}

--- a/src/Microsoft.AspNetCore.Blazor.Build/Core/RazorCompilation/RazorCompiler.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Build/Core/RazorCompilation/RazorCompiler.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine;
-using Microsoft.AspNetCore.Blazor.Components;
-using Microsoft.AspNetCore.Blazor.RenderTree;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.CodeDom.Compiler;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Blazor.Components;
+using Microsoft.AspNetCore.Blazor.Razor;
+using Microsoft.AspNetCore.Blazor.RenderTree;
 
 namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation
 {

--- a/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.csproj
@@ -22,9 +22,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor.Browser.JS\Microsoft.AspNetCore.Blazor.Browser.JS.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor.Mono\Microsoft.AspNetCore.Blazor.Mono.csproj" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Blazor.Razor.Extensions\Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0" />
@@ -33,8 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj" ReferenceOutputAssembly="false" />
-    <Reference Include="Microsoft.AspNetCore.Blazor.AngleSharp" HintPath="..\anglesharp\AngleSharpBuilder\dist\Microsoft.AspNetCore.Blazor.AngleSharp.dll" />
+    <ProjectReference Include="..\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj">
+      <Name>AngleSharpBuilder</Name>
+      <Private>False</Private>
+      <SetTargetFramework>TargetFramework=netcoreapp2.0</SetTargetFramework>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <Reference Include="..\anglesharp\AngleSharpBuilder\dist\Microsoft.AspNetCore.Blazor.AngleSharp.dll" />
   </ItemGroup>
-
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorCodeDocItems.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorCodeDocItems.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine
+namespace Microsoft.AspNetCore.Blazor.Razor
 {
-    internal static class BlazorCodeDocItems
+    public static class BlazorCodeDocItems
     {
         public static object ClassName = new object();
         public static object Namespace = new object();

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorCodeTarget.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorCodeTarget.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using System;
+using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 
-namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine
+namespace Microsoft.AspNetCore.Blazor.Razor
 {
     /// <summary>
     /// Directs a <see cref="DocumentWriter"/> to use <see cref="BlazorIntermediateNodeWriter"/>.

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorComponent.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Blazor.Razor
+{
+    internal static class BlazorComponent
+    {
+        public static readonly string FullTypeName = "Microsoft.AspNetCore.Blazor.Components.BlazorComponent";
+
+        public static readonly string BuildRenderTree = nameof(BuildRenderTree);
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorIntermediateNodeWriter.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorIntermediateNodeWriter.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using AngleSharp;
 using AngleSharp.Html;
 using AngleSharp.Parser.Html;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Blazor.RenderTree;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine
+namespace Microsoft.AspNetCore.Blazor.Razor
 {
     /// <summary>
     /// Generates the C# code corresponding to Razor source document contents.

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorLoweringPhase.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorLoweringPhase.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Blazor.Components;
+using System;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using System;
 
-namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine
+namespace Microsoft.AspNetCore.Blazor.Razor
 {
     /// <summary>
     /// A <see cref="RazorEngine"/> phase that builds the C# document corresponding to
@@ -42,7 +41,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine
             // from here. We inject the parameter later in RazorCompiler.
             var primaryMethod = documentNode.FindPrimaryMethod();
             primaryMethod.ReturnType = "void";
-            primaryMethod.MethodName = BlazorComponent.BuildRenderTreeMethodName;
+            primaryMethod.MethodName = BlazorComponent.BuildRenderTree;
             primaryMethod.Modifiers.Clear();
             primaryMethod.Modifiers.Add("protected");
             primaryMethod.Modifiers.Add("override");

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorRazorEngine.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorRazorEngine.cs
@@ -1,17 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
-using Microsoft.AspNetCore.Blazor.Components;
-using System.Linq;
 
-namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine
+namespace Microsoft.AspNetCore.Blazor.Razor
 {
     /// <summary>
     /// Wraps <see cref="RazorEngine"/>, configuring it to compile Blazor components.
     /// </summary>
-    internal class BlazorRazorEngine
+    public class BlazorRazorEngine
     {
         private readonly RazorEngine _engine;
         private readonly RazorCodeGenerationOptions _codegenOptions;
@@ -24,7 +23,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine
             {
                 FunctionsDirective.Register(configure);
 
-                configure.SetBaseType(typeof(BlazorComponent).FullName);
+                configure.SetBaseType(BlazorComponent.FullTypeName);
 
                 configure.Phases.Remove(
                     configure.Phases.OfType<IRazorCSharpLoweringPhase>().Single());

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/CodeWriterExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/CodeWriterExtensions.cs
@@ -12,7 +12,7 @@ using System.Linq;
 // Copied directly from https://github.com/aspnet/Razor/blob/ff40124594b58b17988d50841175430a4b73d1a9/src/Microsoft.AspNetCore.Razor.Language/CodeGeneration/CodeWriterExtensions.cs
 // (other than the namespace change) because it's internal
 
-namespace Microsoft.AspNetCore.Blazor.Build.Core.RazorCompilation.Engine
+namespace Microsoft.AspNetCore.Blazor.Razor
 {
     internal static class CodeWriterExtensions
     {

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <RootNamespace>Microsoft.AspNetCore.Blazor.Razor</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="2.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj">
+      <Name>AngleSharpBuilder</Name>
+      <Private>False</Private>
+      <SetTargetFramework>TargetFramework=netcoreapp2.0</SetTargetFramework>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <Reference Include="..\anglesharp\AngleSharpBuilder\dist\Microsoft.AspNetCore.Blazor.AngleSharp.dll" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/RenderTreeBuilder.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/RenderTreeBuilder.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Blazor.Razor
+{
+    // Constants for method names used in code-generation
+    // Keep these in sync with the actual RenderTreeBuilder definitions
+    internal static class RenderTreeBuilder
+    {
+        public static readonly string OpenElement = nameof(OpenElement);
+
+        public static readonly string CloseElement = nameof(CloseElement);
+
+        public static readonly string OpenComponent = nameof(OpenComponent);
+
+        public static readonly string CloseComponent = nameof(CloseElement);
+
+        public static readonly string AddText = nameof(AddText);
+
+        public static readonly string AddAttribute = nameof(AddAttribute);
+        
+        public static readonly string Clear = nameof(Clear);
+
+        public static readonly string GetFrames = nameof(GetFrames);
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
@@ -7,6 +7,11 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Blazor.Components
 {
+    // IMPORTANT
+    //
+    // Many of these names are used in code generation. Keep these in sync with the code generation code
+    // See: src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorComponent.cs
+
     /// <summary>
     /// Optional base class for Blazor components. Alternatively, Blazor components may
     /// implement <see cref="IComponent"/> directly.

--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeBuilder.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeBuilder.cs
@@ -8,6 +8,11 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Blazor.RenderTree
 {
+    // IMPORTANT
+    //
+    // Many of these names are used in code generation. Keep these in sync with the code generation code
+    // See: src/Microsoft.AspNetCore.Blazor.Razor.Extensions/RenderTreeBuilder.cs
+
     /// <summary>
     /// Provides methods for building a collection of <see cref="RenderTreeFrame"/> entries.
     /// </summary>

--- a/src/anglesharp/AngleSharpBuilder/Program.cs
+++ b/src/anglesharp/AngleSharpBuilder/Program.cs
@@ -41,6 +41,7 @@ namespace AngleSharpBuilder
             var moduleDefinition = ModuleDefinition.ReadModule(assemblyLocation);
 
             AddInternalsVisibleTo(moduleDefinition, "Microsoft.AspNetCore.Blazor.Build");
+            AddInternalsVisibleTo(moduleDefinition, "Microsoft.AspNetCore.Blazor.Razor.Extensions");
             RemoveStrongName(moduleDefinition);
             SetAssemblyName(moduleDefinition, "Microsoft.AspNetCore.Blazor.AngleSharp");
 

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/BrowserFixture.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/BrowserFixture.cs
@@ -26,7 +26,17 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure
                 Console.WriteLine($"Set {nameof(ChromeOptions)}.{nameof(opts.BinaryLocation)} to {binaryLocation}");
             }
 
-            Browser = new RemoteWebDriver(opts);
+            try
+            {
+                Browser = new RemoteWebDriver(opts);
+            }
+            catch (WebDriverException ex)
+            {
+                var message =
+                    "Failed to connect to the web driver. Please see the readme and follow the instructions to install selenium." +
+                    "Remember to start the web driver with `selenium-standalone start` before running the end-to-end tests.";
+                throw new InvalidOperationException(message, ex);
+            }
         }
 
         public void Dispose()

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/ServerFixtures/WebHostServerFixture.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/ServerFixtures/WebHostServerFixture.cs
@@ -22,6 +22,8 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
 
         public override void Dispose()
         {
+            // This can be null if creating the webhost throws, we don't want to throw here and hide
+            // the original exception.
             _host?.StopAsync();
         }
 

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
@@ -4,13 +4,6 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <UseCodebase>true</UseCodebase>
-    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-  </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyOriginatorKeyFile>..\..\build\Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <!--
@@ -21,6 +14,12 @@
     
     BEGIN INTERESTING STUFF
   -->
+  <PropertyGroup>
+    <!-- VSIXes are always signed. This is the same key that ASP.NET uses for OSS signing -->
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\build\Key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
   <PropertyGroup>
     <!-- Following VS convention of using the VS release # as a convention for the vsix version. -->
     <VsixVersion>15.7</VsixVersion>
@@ -91,7 +90,7 @@
     <SuppressFromVsix Include="Microsoft.CodeAnalysis.Razor.dll" />
     <SuppressFromVsix Include="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <!--
       Let's continue our parade of gross workarounds. 
@@ -100,6 +99,18 @@
       this problem, we're only using the P2P references to force build ordering. Then we include the build
       output of those projects as content.
     -->
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Razor.Extensions\Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj">
+      <Name>Microsoft.AspNetCore.Blazor.Razor.Extensions</Name>
+      <Private>False</Private>
+      <IncludeOutputGroupsInVSIX></IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
+    </ProjectReference>
+    <Content Include="..\..\src\Microsoft.AspNetCore.Blazor.Razor.Extensions\bin\$(Configuration)\net461\Microsoft.AspNetCore.Blazor.Razor.Extensions.dll">
+      <Link>Microsoft.AspNetCore.Blazor.Razor.Extensions.dll</Link>
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServices.Blazor\Microsoft.VisualStudio.LanguageServices.Blazor.csproj">
       <Project>{b9f7f502-6dd2-4e77-8fd1-cbd76f695b26}</Project>
       <Name>Microsoft.VisualStudio.LanguageServices.Blazor</Name>
@@ -125,12 +136,12 @@
       <Visible>false</Visible>
     </Content>
   </ItemGroup>
-  <!-- 
+  <!--
   
     END INTERESTING STUFF 
     
   -->
-  
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/Properties/AssemblyInfo.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/Properties/AssemblyInfo.cs
@@ -13,6 +13,13 @@ using Microsoft.VisualStudio.Shell;
     OldVersionUpperBound = "0.9.9.0",
     NewVersion = "0.9.9.0")]
 [assembly: ProvideBindingRedirection(
+    AssemblyName = "Microsoft.AspNetCore.Blazor.Razor.Extensions",
+    GenerateCodeBase = true,
+    PublicKeyToken = "",
+    OldVersionLowerBound = "0.0.0.0",
+    OldVersionUpperBound = "1.0.0.0",
+    NewVersion = "1.0.0.0")]
+[assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.VisualStudio.LanguageServices.Blazor",
     GenerateCodeBase = true,
     PublicKeyToken = "",

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/source.extension.vsixmanifest
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/source.extension.vsixmanifest
@@ -20,6 +20,7 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Microsoft.VisualStudio.LanguageServices.Blazor.dll" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.AspNetCore.Blazor.AngleSharp.dll" />
+        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.AspNetCore.Blazor.Razor.Extensions.dll" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.VisualStudio.LanguageServices.Blazor.dll" />
     </Assets>
     <Prerequisites>

--- a/tooling/Microsoft.VisualStudio.LanguageServices.Blazor/Microsoft.VisualStudio.LanguageServices.Blazor.csproj
+++ b/tooling/Microsoft.VisualStudio.LanguageServices.Blazor/Microsoft.VisualStudio.LanguageServices.Blazor.csproj
@@ -3,13 +3,14 @@
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj">
-      <Name>AngleSharpBuild</Name>
+      <Name>AngleSharpBuilder</Name>
       <Private>False</Private>
       <SetTargetFramework>TargetFramework=netcoreapp2.0</SetTargetFramework>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Razor.Extensions\Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This functionality will need to cross-compile to desktop framework
(net461) so that we can use it in VS. VS doesn't yet have netstandard2.0
support.