### PR TITLE
Fixing build instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Prerequisites:
 - [.NET Core SDK](https://dot.net/core) (>2.1.4)
 - [Node.js](https://nodejs.org/) (>8.3)
 
-Run `dotnet build` from the solution directory.
+Run `dotnet build Blazor.sln` from the solution directory.
 
 ## Run tests
 


### PR DESCRIPTION
The current build instructions the readme do not work as there are two solution files in the directory, so I've included the `Blazor.sln` onto the end of the build command.