### PR TITLE
Remove binding redirects for missing assemblies

### DIFF
--- a/tooling/Microsoft.VisualStudio.BlazorExtension/Properties/AssemblyInfo.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/Properties/AssemblyInfo.cs
@@ -6,20 +6,6 @@ using Microsoft.VisualStudio.Shell;
 // Add binding redirects for each assembly we ship in VS. This is required so that these assemblies show
 // up in the Load context, which means that we can use ServiceHub and other nice things.
 [assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.AspNetCore.Blazor.AngleSharp",
-    GenerateCodeBase = true,
-    PublicKeyToken = "",
-    OldVersionLowerBound = "0.0.0.0",
-    OldVersionUpperBound = "0.9.9.0",
-    NewVersion = "0.9.9.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.AspNetCore.Blazor.Razor.Extensions",
-    GenerateCodeBase = true,
-    PublicKeyToken = "",
-    OldVersionLowerBound = "0.0.0.0",
-    OldVersionUpperBound = "1.0.0.0",
-    NewVersion = "1.0.0.0")]
-[assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.VisualStudio.LanguageServices.Blazor",
     GenerateCodeBase = true,
     PublicKeyToken = "",


### PR DESCRIPTION
/cc @alexgav 

FYI only to resolve a build break. This worked for me locally because I didn't do a clean build before pushing before. Sorry 😢 