### PR TITLE
remove mpf

### DIFF
--- a/tooling/Microsoft.VisualStudio.BlazorExtension/source.extension.vsixmanifest
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/source.extension.vsixmanifest
@@ -14,7 +14,6 @@
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6.1,)" />
         <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.RazorExtension" DisplayName="Razor Language Services" Version="[15.6.31169,15.8)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.6, 15.8)" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
MPF seems like an unnecessary dependency. While it is present you cannot install the vsix on its own. 