### PR TITLE
adjust build blazor tooling instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,17 @@ Run `dotnet test test\AllTests.proj`
 ## Build VS Tooling
 
 Prerequisites:
-- Visual Studio 2017 15.5 (or newer)
+- Visual Studio 2017 15.6 (or newer)
 - Visual Studio extension development features (install via Visual Studio Installer)
 
 Open a VS Developer Command Prompt
 
-Run `msbuild BlazorTooling.sln` from the solution directory.
+Run the following instructions from the solution directory.
+
+```shell
+msbuild BlazorTooling.sln /t:Restore
+msbuild BlazorTooling.sln
+```
 
 ## Contributing
 


### PR DESCRIPTION
To build from a command prompt, packages must be restored first.

Adjusted prerequisites as mentioned here: https://github.com/aspnet/Blazor/pull/196#issuecomment-369693763