### PR TITLE
VSIX Changes to have Blazor templates included into VSIX and show up …

### DIFF
--- a/BlazorTooling.sln
+++ b/BlazorTooling.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "anglesharp", "anglesharp", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Blazor.Razor.Extensions", "src\Microsoft.AspNetCore.Blazor.Razor.Extensions\Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj", "{319463A4-64C8-4A96-BEFD-2952BBD5FF67}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Blazor.Templates", "src\Microsoft.AspNetCore.Blazor.Templates\Microsoft.AspNetCore.Blazor.Templates.csproj", "{EDD21533-C6E6-4F85-BE4F-10E06756E24C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,18 @@ Global
 		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|x64.Build.0 = Release|Any CPU
 		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|x86.ActiveCfg = Release|Any CPU
 		{319463A4-64C8-4A96-BEFD-2952BBD5FF67}.Release|x86.Build.0 = Release|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Debug|x64.Build.0 = Debug|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Debug|x86.Build.0 = Debug|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Release|x64.ActiveCfg = Release|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Release|x64.Build.0 = Release|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Release|x86.ActiveCfg = Release|Any CPU
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +104,7 @@ Global
 		{E5067AD8-3AE7-442A-86C5-D19DBC48E961} = {9DEA0869-2F17-419F-8F6A-53DCA898D3D6}
 		{9DEA0869-2F17-419F-8F6A-53DCA898D3D6} = {91810C0E-892D-40EF-BDC0-5470B37E255F}
 		{319463A4-64C8-4A96-BEFD-2952BBD5FF67} = {91810C0E-892D-40EF-BDC0-5470B37E255F}
+		{EDD21533-C6E6-4F85-BE4F-10E06756E24C} = {91810C0E-892D-40EF-BDC0-5470B37E255F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {248760B5-9F71-4110-8DBC-DDAB615AD88E}

--- a/src/Microsoft.AspNetCore.Blazor.Templates/Microsoft.AspNetCore.Blazor.Templates.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/Microsoft.AspNetCore.Blazor.Templates.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard20</TargetFramework>
     <NuspecFile>Microsoft.AspNetCore.Blazor.Templates.nuspec</NuspecFile>
     <EnableDefaultItems>False</EnableDefaultItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/Microsoft.AspNetCore.Blazor.Templates.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/Microsoft.AspNetCore.Blazor.Templates.csproj
@@ -1,10 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <NuspecFile>Microsoft.AspNetCore.Blazor.Templates.nuspec</NuspecFile>
     <EnableDefaultItems>False</EnableDefaultItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <NoWarn>2008</NoWarn>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
 </Project>

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
@@ -19,7 +19,6 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-
   <PropertyGroup>
     <!-- 
       Following VS convention of using the VS release # as a convention for the vsix version.
@@ -65,6 +64,14 @@
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
   </PropertyGroup>
+  <Target Name="PreCreateVsixContainer" BeforeTargets="CreateVsixContainer">
+    <ItemGroup>
+      <VSIXSourceItem Include="..\..\Artifacts\Build\Microsoft.AspNetCore.Blazor.Templates.*.nupkg">
+        <VSIXSubPath>ProjectTemplates\</VSIXSubPath>
+      </VSIXSourceItem>
+      <VSIXSourceItem Include="Templates.pkgdef" />
+    </ItemGroup>
+  </Target>
   <!--
     This is needed to support our infrastructure's automatic upload of symbols to the symbol server
     for debugging. 
@@ -94,7 +101,6 @@
     <SuppressFromVsix Include="Microsoft.CodeAnalysis.Razor.dll" />
     <SuppressFromVsix Include="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
   </ItemGroup>
-
   <ItemGroup>
     <!--
       Let's continue our parade of gross workarounds. 
@@ -103,12 +109,24 @@
       this problem, we're only using the P2P references to force build ordering. Then we include the build
       output of those projects as content.
     -->
+    <Content Include="Templates.pkgdef" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Templates\Microsoft.AspNetCore.Blazor.Templates.csproj">
+      <Project>{edd21533-c6e6-4f85-be4f-10e06756e24c}</Project>
+      <Name>Microsoft.AspNetCore.Blazor.Templates</Name>
+      <Private>False</Private>
+      <IncludeOutputGroupsInVSIX>
+      </IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>
+      </IncludeOutputGroupsInVSIXLocalOnly>
+    </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServices.Blazor\Microsoft.VisualStudio.LanguageServices.Blazor.csproj">
       <Project>{b9f7f502-6dd2-4e77-8fd1-cbd76f695b26}</Project>
       <Name>Microsoft.VisualStudio.LanguageServices.Blazor</Name>
       <Private>False</Private>
-      <IncludeOutputGroupsInVSIX></IncludeOutputGroupsInVSIX>
-      <IncludeOutputGroupsInVSIXLocalOnly></IncludeOutputGroupsInVSIXLocalOnly>
+      <IncludeOutputGroupsInVSIX>
+      </IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>
+      </IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <Content Include="..\Microsoft.VisualStudio.LanguageServices.Blazor\bin\$(Configuration)\net461\Microsoft.VisualStudio.LanguageServices.Blazor.dll">
       <Link>Microsoft.VisualStudio.LanguageServices.Blazor.dll</Link>

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/Templates.pkgdef
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/Templates.pkgdef
@@ -1,0 +1,2 @@
+﻿[$RootKey$\TemplateEngine\Templates\Blazor\0.1.0]
+"InstalledPath"="$PackageFolder$\ProjectTemplates"

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/source.extension.vsixmanifest
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/source.extension.vsixmanifest
@@ -19,6 +19,7 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Microsoft.VisualStudio.LanguageServices.Blazor.dll" />
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Microsoft.VisualStudio.LanguageServices.Blazor.dll" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" Path="Templates.pkgdef" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
…in One ASP.NET Dialog. Changing the template project target to 4.6 to be able to reference it from VSIX (shouldn't be a problem AFAIK, Phil?). Adding template nuget to the VSIX. Adding pkgdef file with a regkey to allow template discovery. 