### PR TITLE
Correct the handling of List<T> in PocoJsonSerializerStrategy

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Json/SimpleJson/SimpleJson.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Json/SimpleJson/SimpleJson.cs
@@ -1272,7 +1272,9 @@ namespace SimpleJson
 
         internal virtual ReflectionUtils.ConstructorDelegate ContructorDelegateFactory(Type key)
         {
-            return ReflectionUtils.GetContructor(key, key.IsArray ? ArrayConstructorParameterTypes : EmptyTypes);
+            // We need List<T>(int) constructor so that DeserializeObject method will work for generating IList-declared values
+            var needsCapacityArgument = key.IsArray || key.IsConstructedGenericType && key.GetGenericTypeDefinition() == typeof(List<>);
+            return ReflectionUtils.GetContructor(key, needsCapacityArgument ? ArrayConstructorParameterTypes : EmptyTypes);
         }
 
         internal virtual IDictionary<string, ReflectionUtils.GetDelegate> GetterValueFactory(Type type)


### PR DESCRIPTION
`List<>` is used for all the `IList`-implementing types except for arrays, and in the following snippet, the caller expects the generated `List<T>` constructor should accept one parameter (`int` of capacity).
https://github.com/aspnet/Blazor/blob/e4b977bc9b5efad6ff13b3b898d805e005a43a30/src/Microsoft.AspNetCore.Blazor/Json/SimpleJson/SimpleJson.cs#L1456-L1462
But in the 
`ContructorDelegateFactory`, such constructor is only offered for arrays (`int` of length), so I think this special case need to be extended to `List<T>`.

This PR should address this problem and fix #225.