### PR TITLE
Add Simple onclickAsync for BlazorComponent

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
@@ -202,6 +202,30 @@ namespace Microsoft.AspNetCore.Blazor.Components
             => RenderTreeFrame.Attribute(0, "onclick", _ => handler());
 
         /// <summary>
+        /// Handles async click events by invoking the async <paramref name="handler"/>
+        /// </summary>
+        /// <param name="handler">The async handler to be invoked when the event occurs.</param>
+        /// <returns></returns>
+        protected RenderTreeFrame onclickAsync(Func<Task> handler)
+        {
+            return RenderTreeFrame.Attribute(0, "onclick", _ =>
+            {
+                // Run handler and handle any exceptions when any occurs.
+                handler().ContinueWith(task =>
+                {
+                    if (task.Exception == null)
+                    {
+                        StateHasChanged();
+                    }
+                    else
+                    {
+                        HandleException(task.Exception);
+                    }
+                });
+            });
+        }
+
+        /// <summary>
         /// Handles change events by invoking <paramref name="handler"/>.
         /// </summary>
         /// <param name="handler">The handler to be invoked when the event occurs. The handler will receive the new value as a parameter.</param>


### PR DESCRIPTION
Added a simple ```@onclickAsync``` on BlazorComponent to support async Task methods for onclick events.

This should at least be enough for use cases on fetching data that is usually async in nature until something better is created.
I'm not sure if webassembly HTTP supports canceling of requests though, should cancellation token be added?

Should be inline with this tracker #1 on the Lifecycle section.