### PR TITLE
Fix incremental builds

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Blazor.MonoRuntime.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Blazor.MonoRuntime.targets
@@ -351,7 +351,10 @@
   <Target
       Name="_LinkBlazorApplication"
       Condition="$(_BlazorShouldLinkApplicationAssemblies) != ''"
-      Inputs="$(BlazorBuildLinkerInputsCache)"
+      Inputs="$(BlazorBuildLinkerInputsCache);
+              @(IntermediateAssembly);
+              @(ReferenceCopyLocalPaths->WithMetadataValue('Extension','.dll'));
+              @(BlazorLinkerDescriptor)"
       Outputs="$(BlazorIntermediateLinkerResultFilePath)"
     >
     <!--
@@ -454,7 +457,9 @@
   <Target
     Name="_ResolveBlazorApplicationAssemblies"
     Condition="'$(_BlazorShouldLinkApplicationAssemblies)' == ''"
-    Inputs="$(BlazorBuildCommonInputsCache)"
+    Inputs="$(BlazorBuildCommonInputsCache);
+            @(IntermediateAssembly);
+            @(ReferenceCopyLocalPaths->WithMetadataValue('Extension','.dll'))"
     Outputs="$(BlazorResolvedAssembliesOutputPath)"
   >
     <ItemGroup>


### PR DESCRIPTION
Adds additional inputs needed for incremental builds to work, but at the same time breaks them, because they are broken at an earlier point. What's happening is that the assembly info file is being generated every time even though the inputs don't change.

![new](https://user-images.githubusercontent.com/6995051/37316236-2f65a9d2-261b-11e8-88e5-89c1f08449e3.PNG)
![old](https://user-images.githubusercontent.com/6995051/37316237-2f7c7e82-261b-11e8-99cb-54931937fe90.PNG)
