### PR TITLE
Publishing

### DIFF
--- a/samples/HostedInAspNet.Client/HostedInAspNet.Client.csproj
+++ b/samples/HostedInAspNet.Client/HostedInAspNet.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/samples/HostedInAspNet.Client/HostedInAspNet.Client.csproj
+++ b/samples/HostedInAspNet.Client/HostedInAspNet.Client.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <!-- TODO: Remove the "PrivateAssets=all" once we no longer have RazorToolingWorkaround.cs -->
     <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Browser\Microsoft.AspNetCore.Blazor.Browser.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Local alternative to <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" /> -->

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/All.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/All.targets
@@ -14,6 +14,7 @@
 
   <Import Project="RazorCompilation.targets" />
   <Import Project="Blazor.MonoRuntime.targets" />
+  <Import Project="Publish.targets" />
   
   <Target Name="GenerateBlazorMetadataFile" BeforeTargets="GetCopyToOutputDirectoryItems">
     <PropertyGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -34,9 +34,17 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="BlazorWriteStandaloneWebConfig" AfterTargets="CopyFilesToPublishDirectory">
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)Standalone.Web.config"
-          DestinationFiles="$(PublishDir)web.config"
-          Condition="!Exists('$(PublishDir)web.config')" />
+  <Target Name="BlazorCompleteStandalonePublish" AfterTargets="CopyFilesToPublishDirectory">
+    <!-- Add a suitable web.config file if there isn't one already -->
+    <ItemGroup>
+      <_StandaloneWebConfigContent Include="$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)Standalone.Web.config'))"/>
+    </ItemGroup>
+    <WriteLinesToFile
+      Condition="!Exists('$(PublishDir)web.config')"
+      File="$(PublishDir)web.config"
+      Lines="@(_StandaloneWebConfigContent->Replace('[ServeSubdirectory]','$(AssemblyName)'))" />
+  
+    <!-- Remove the .blazor.config file, since it's irrelevant for standalone publishing -->
+    <Delete Files="$(PublishDir)$(AssemblyName).blazor.config" />
   </Target>
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -4,6 +4,7 @@
     <RazorCompileOnPublish>false</RazorCompileOnPublish>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
+    <BlazorLinkOnBuild Condition="'$(Configuration)'=='Release' AND '$(BlazorLinkOnBuild)'==''">true</BlazorLinkOnBuild>
   </PropertyGroup>
 
   <Target Name="SetBlazorFilesToPublish" AfterTargets="ComputeRefAssembliesToPublish" BeforeTargets="CopyFilesToPublishDirectory">

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -8,6 +8,9 @@
   </PropertyGroup>
 
   <Target Name="SetBlazorFilesToPublish" AfterTargets="ComputeRefAssembliesToPublish" BeforeTargets="CopyFilesToPublishDirectory">
+    <PropertyGroup>
+      <_AddDefaultWebConfig Condition="'%(ResolvedFileToPublish.Filename)%(ResolvedFileToPublish.Extension)' == 'Web.config'">false</_AddDefaultWebConfig>
+    </PropertyGroup>
     <ItemGroup>
       <!--
         We can't stop the default targets from adding the .dll/.pdb files to ResolvedFileToPublish,
@@ -19,6 +22,13 @@
       <_BlazorFileToPublish Include="$(OutDir)dist\**" />
       <ResolvedFileToPublish Include="@(_BlazorFileToPublish)">
         <RelativePath>wwwroot\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+      </ResolvedFileToPublish>
+
+      <!-- If there's no web.config, add one -->
+      <ResolvedFileToPublish
+        Include="$(MSBuildThisFileDirectory)Standalone.Web.config"
+        Condition="'$(_AddDefaultWebConfig)' != 'false'">
+        <RelativePath>Web.config</RelativePath>
       </ResolvedFileToPublish>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -18,10 +18,15 @@
       -->
       <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="'%(Extension)'=='.dll' OR '%(Extension)'=='.pdb'" />
 
-      <!-- Publish 'dist' files to 'wwwroot' -->
+      <!-- Output 'wwwroot' content at root -->
+      <ResolvedFileToPublish Update="@(ResolvedFileToPublish)" Condition="$([System.String]::new(%(RelativePath)).StartsWith('wwwroot'))">
+        <RelativePath>$([System.String]::new(%(RelativePath)).Substring(8))</RelativePath>
+      </ResolvedFileToPublish>
+
+      <!-- Publish 'dist' files -->
       <_BlazorFileToPublish Include="$(OutDir)dist\**" />
       <ResolvedFileToPublish Include="@(_BlazorFileToPublish)">
-        <RelativePath>wwwroot\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+        <RelativePath>%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
       </ResolvedFileToPublish>
 
       <!-- If there's no web.config, add one -->

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -1,14 +1,15 @@
 ﻿<Project>
   <PropertyGroup>
+    <BlazorLinkOnBuild Condition="'$(Configuration)'=='Release' AND '$(BlazorLinkOnBuild)'==''">true</BlazorLinkOnBuild>
+    <BlazorPublishDistDir>$(AssemblyName)\dist\</BlazorPublishDistDir>
+
     <!-- Disable unwanted parts of the default publish process -->
     <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
-    <PreserveCompilationContext>false</PreserveCompilationContext> <!-- Don't publish all the ref assemblies -->
-
+    <PreserveCompilationContext>false</PreserveCompilationContext>
     <RazorCompileOnPublish>false</RazorCompileOnPublish>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
-    <BlazorLinkOnBuild Condition="'$(Configuration)'=='Release' AND '$(BlazorLinkOnBuild)'==''">true</BlazorLinkOnBuild>
   </PropertyGroup>
 
   <Target Name="BlazorGetCopyToPublishDirectoryItems" BeforeTargets="GetCopyToPublishDirectoryItems">
@@ -18,13 +19,13 @@
 
       <!-- Move wwwroot files to output root -->
       <ContentWithTargetPath Update="@(ContentWithTargetPath)" Condition="$([System.String]::new(%(TargetPath)).StartsWith('wwwroot\'))">
-        <TargetPath>$(AssemblyName)\$([System.String]::new(%(TargetPath)).Substring(8))</TargetPath>
+        <TargetPath>$(BlazorPublishDistDir)$([System.String]::new(%(TargetPath)).Substring(8))</TargetPath>
       </ContentWithTargetPath>
       
       <!-- Publish all the 'dist' files -->
       <_BlazorGCTPDIDistFiles Include="$(OutDir)dist\**" />
       <_BlazorGCTPDI Include="@(_BlazorGCTPDIDistFiles)">
-        <TargetPath>$(AssemblyName)\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+        <TargetPath>$(BlazorPublishDistDir)%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
       </_BlazorGCTPDI>
 
       <ContentWithTargetPath Include="@(_BlazorGCTPDI)">
@@ -32,8 +33,16 @@
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ContentWithTargetPath>
     </ItemGroup>
+
+    <!-- Replace the .blazor.config contents with what we need to serve in production -->
+    <PropertyGroup>
+      <_BlazorConfigPath>$(OutDir)$(AssemblyName).blazor.config</_BlazorConfigPath>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_BlazorConfigPath)" Lines="." Overwrite="true" />
+    <WriteLinesToFile File="$(_BlazorConfigPath)" Lines="$(AssemblyName)\" Overwrite="false" />
   </Target>
 
+  <!-- The following target runs only for standalone publishing -->
   <Target Name="BlazorCompleteStandalonePublish" AfterTargets="CopyFilesToPublishDirectory">
     <!-- Add a suitable web.config file if there isn't one already -->
     <ItemGroup>
@@ -42,7 +51,7 @@
     <WriteLinesToFile
       Condition="!Exists('$(PublishDir)web.config')"
       File="$(PublishDir)web.config"
-      Lines="@(_StandaloneWebConfigContent->Replace('[ServeSubdirectory]','$(AssemblyName)'))" />
+      Lines="@(_StandaloneWebConfigContent->Replace('[ServeSubdirectory]','$(BlazorPublishDistDir)'))" />
   
     <!-- Remove the .blazor.config file, since it's irrelevant for standalone publishing -->
     <Delete Files="$(PublishDir)$(AssemblyName).blazor.config" />

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -23,9 +23,9 @@
       </ContentWithTargetPath>
       
       <!-- Publish all the 'dist' files -->
-      <_BlazorGCTPDIDistFiles Include="$(OutDir)dist\**" />
+      <_BlazorGCTPDIDistFiles Include="@(BlazorItemOutput->'%(TargetOutputPath)')" />
       <_BlazorGCTPDI Include="@(_BlazorGCTPDIDistFiles)">
-        <TargetPath>$(BlazorPublishDistDir)%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+        <TargetPath>$(BlazorPublishDistDir)$([MSBuild]::MakeRelative('$(ProjectDir)$(OutDir)dist\', %(Identity)))</TargetPath>
       </_BlazorGCTPDI>
 
       <ContentWithTargetPath Include="@(_BlazorGCTPDI)">

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -1,40 +1,42 @@
 ﻿<Project>
   <PropertyGroup>
     <!-- Disable unwanted parts of the default publish process -->
+    <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+    <PreserveCompilationContext>false</PreserveCompilationContext> <!-- Don't publish all the ref assemblies -->
+
     <RazorCompileOnPublish>false</RazorCompileOnPublish>
     <GenerateDependencyFile>false</GenerateDependencyFile>
     <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
     <BlazorLinkOnBuild Condition="'$(Configuration)'=='Release' AND '$(BlazorLinkOnBuild)'==''">true</BlazorLinkOnBuild>
   </PropertyGroup>
 
-  <Target Name="SetBlazorFilesToPublish" AfterTargets="ComputeRefAssembliesToPublish" BeforeTargets="CopyFilesToPublishDirectory">
-    <PropertyGroup>
-      <_AddDefaultWebConfig Condition="'%(ResolvedFileToPublish.Filename)%(ResolvedFileToPublish.Extension)' == 'Web.config'">false</_AddDefaultWebConfig>
-    </PropertyGroup>
+  <Target Name="BlazorGetCopyToPublishDirectoryItems" BeforeTargets="GetCopyToPublishDirectoryItems">
     <ItemGroup>
-      <!--
-        We can't stop the default targets from adding the .dll/.pdb files to ResolvedFileToPublish,
-        but we can remove them here. We only want the .dlls from 'dist', not those from the bin root.
-      -->
-      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="'%(Extension)'=='.dll' OR '%(Extension)'=='.pdb'" />
+      <!-- Don't want to publish the assemblies from the regular 'bin' dir. Instead we publish ones from 'dist'. -->
+      <ResolvedAssembliesToPublish Remove="@(ResolvedAssembliesToPublish)" />
 
-      <!-- Output 'wwwroot' content at root -->
-      <ResolvedFileToPublish Update="@(ResolvedFileToPublish)" Condition="$([System.String]::new(%(RelativePath)).StartsWith('wwwroot'))">
-        <RelativePath>$([System.String]::new(%(RelativePath)).Substring(8))</RelativePath>
-      </ResolvedFileToPublish>
+      <!-- Move wwwroot files to output root -->
+      <ContentWithTargetPath Update="@(ContentWithTargetPath)" Condition="$([System.String]::new(%(TargetPath)).StartsWith('wwwroot\'))">
+        <TargetPath>$(AssemblyName)\$([System.String]::new(%(TargetPath)).Substring(8))</TargetPath>
+      </ContentWithTargetPath>
+      
+      <!-- Publish all the 'dist' files -->
+      <_BlazorGCTPDIDistFiles Include="$(OutDir)dist\**" />
+      <_BlazorGCTPDI Include="@(_BlazorGCTPDIDistFiles)">
+        <TargetPath>$(AssemblyName)\%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
+      </_BlazorGCTPDI>
 
-      <!-- Publish 'dist' files -->
-      <_BlazorFileToPublish Include="$(OutDir)dist\**" />
-      <ResolvedFileToPublish Include="@(_BlazorFileToPublish)">
-        <RelativePath>%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
-      </ResolvedFileToPublish>
-
-      <!-- If there's no web.config, add one -->
-      <ResolvedFileToPublish
-        Include="$(MSBuildThisFileDirectory)Standalone.Web.config"
-        Condition="'$(_AddDefaultWebConfig)' != 'false'">
-        <RelativePath>Web.config</RelativePath>
-      </ResolvedFileToPublish>
+      <ContentWithTargetPath Include="@(_BlazorGCTPDI)">
+        <TargetPath>%(TargetPath)</TargetPath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ContentWithTargetPath>
     </ItemGroup>
+  </Target>
+
+  <Target Name="BlazorWriteStandaloneWebConfig" AfterTargets="CopyFilesToPublishDirectory">
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)Standalone.Web.config"
+          DestinationFiles="$(PublishDir)web.config"
+          Condition="!Exists('$(PublishDir)web.config')" />
   </Target>
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -1,0 +1,24 @@
+﻿<Project>
+  <PropertyGroup>
+    <!-- Disable unwanted parts of the default publish process -->
+    <RazorCompileOnPublish>false</RazorCompileOnPublish>
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+    <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
+  </PropertyGroup>
+
+  <Target Name="SetBlazorFilesToPublish" AfterTargets="ComputeRefAssembliesToPublish" BeforeTargets="CopyFilesToPublishDirectory">
+    <ItemGroup>
+      <!--
+        We can't stop the default targets from adding the .dll/.pdb files to ResolvedFileToPublish,
+        but we can remove them here. We only want the .dlls from 'dist', not those from the bin root.
+      -->
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)" Condition="'%(Extension)'=='.dll' OR '%(Extension)'=='.pdb'" />
+
+      <!-- Publish 'dist' files to 'wwwroot' -->
+      <_BlazorFileToPublish Include="$(OutDir)dist\**" />
+      <ResolvedFileToPublish Include="@(_BlazorFileToPublish)">
+        <RelativePath>wwwroot\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
@@ -19,7 +19,8 @@
   <!-- Something quick for input/output tracking - the assumptions here should match what the CLI does -->
   <ItemGroup>
     <BlazorGenerate Include="**\*.cshtml" />
-    <Content Update="@(Content->WithMetadataValue('Extension', '.cshtml'))">
+    <_BlazorGenerateDeclarationContent Include="@(Content->WithMetadataValue('Extension', '.cshtml'))" />
+    <Content Update="@(_BlazorGenerateDeclarationContent)">
       <Generator>MSBuild:BlazorGenerateDeclaration</Generator>
     </Content>
 

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
@@ -22,6 +22,7 @@
     <_BlazorGenerateDeclarationContent Include="@(Content->WithMetadataValue('Extension', '.cshtml'))" />
     <Content Update="@(_BlazorGenerateDeclarationContent)">
       <Generator>MSBuild:BlazorGenerateDeclaration</Generator>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
 
     <ProjectCapability Include="DotNetCoreRazorConfiguration" />

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Standalone.Web.config
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Standalone.Web.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <remove fileExtension=".dll" />
+      <mimeMap fileExtension=".dll" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
+    </staticContent>
+    <httpCompression>
+      <dynamicTypes>
+        <add mimeType="application/octet-stream" enabled="true" />
+        <add mimeType="application/wasm" enabled="true" />
+      </dynamicTypes>
+    </httpCompression>
+    <rewrite>
+      <rules>
+        <rule name="SPA fallback routing" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="/" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Standalone.Web.config
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Standalone.Web.config
@@ -14,12 +14,16 @@
     </httpCompression>
     <rewrite>
       <rules>
+        <rule name="Serve subdir">
+          <match url=".*" />
+          <action type="Rewrite" url="[ServeSubdirectory]/{R:0}" />
+        </rule>
         <rule name="SPA fallback routing" stopProcessing="true">
           <match url=".*" />
           <conditions logicalGrouping="MatchAll">
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
           </conditions>
-          <action type="Rewrite" url="/" />
+          <action type="Rewrite" url="[ServeSubdirectory]/" />
         </rule>
       </rules>
     </rewrite>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Standalone.Web.config
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Standalone.Web.config
@@ -16,14 +16,14 @@
       <rules>
         <rule name="Serve subdir">
           <match url=".*" />
-          <action type="Rewrite" url="[ServeSubdirectory]/{R:0}" />
+          <action type="Rewrite" url="[ServeSubdirectory]{R:0}" />
         </rule>
         <rule name="SPA fallback routing" stopProcessing="true">
           <match url=".*" />
           <conditions logicalGrouping="MatchAll">
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
           </conditions>
-          <action type="Rewrite" url="[ServeSubdirectory]/" />
+          <action type="Rewrite" url="[ServeSubdirectory]" />
         </rule>
       </rules>
     </rewrite>

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.FileProviders;
 using System.IO;
 using System.Net.Mime;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -36,9 +37,15 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder applicationBuilder,
             BlazorOptions options)
         {
+            // TODO: Make the .blazor.config file contents sane
+            // Currently the items in it are bizarre and don't relate to their purpose,
+            // hence all the path manipulation here. We shouldn't be hardcoding 'dist' here either.
+            var env = (IHostingEnvironment)applicationBuilder.ApplicationServices.GetService(typeof(IHostingEnvironment));
             var config = BlazorConfig.Read(options.ClientAssemblyPath);
             var clientAppBinDir = Path.GetDirectoryName(config.SourceOutputAssemblyPath);
-            var clientAppDistDir = Path.Combine(clientAppBinDir, "dist");
+            var clientAppDistDir = Path.Combine(
+                env.ContentRootPath,
+                Path.Combine(clientAppBinDir, "dist"));
             var distDirStaticFiles = new StaticFileOptions
             {
                 FileProvider = new PhysicalFileProvider(clientAppDistDir),

--- a/src/Microsoft.AspNetCore.Blazor.Templates/Microsoft.AspNetCore.Blazor.Templates.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/Microsoft.AspNetCore.Blazor.Templates.csproj
@@ -7,9 +7,4 @@
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <NoWarn>2008</NoWarn>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  </PropertyGroup>
-
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/BlazorHosted.CSharp.Client.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/BlazorHosted.CSharp.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor/2.1.0-preview2-30230">
+<Project Sdk="Microsoft.NET.Sdk.Razor/2.1.0-preview2-30230;Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
This PR means you can just hit "publish" from VS, or run `dotnet publish -c Release` on the command line, and it will produce a working result for both standalone and ASP.NET-hosted app models.

Once we've published updated nupkgs, it should be possible to check whether this works with Kudu as well.

Most of the implementation comes down to changing which files are picked up during the `GetCopyToPublishDirectoryItems` target. I've set it up so we get the exact same set whether it's a standalone app or one being copied to the publish dir of a host app, but there's slightly different postprocessing in the standalone case (e.g., to generate a default `web.config` if you don't have one). A lot of it feels quite nonstandard, but then there's no existing standard for publishing a client-side .NET app.