### PR TITLE
Stop IL linker from stripping System.Threading.WasmRuntime. Fixes #239

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Blazor.MonoRuntime.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Blazor.MonoRuntime.targets
@@ -143,6 +143,7 @@
     <PropertyGroup Label="Build properties">
       <_BlazorShouldLinkApplicationAssemblies Condition="$(BlazorLinkOnBuild) == 'false'"></_BlazorShouldLinkApplicationAssemblies>
       <_BlazorShouldLinkApplicationAssemblies Condition="$(BlazorLinkOnBuild) == 'true'">true</_BlazorShouldLinkApplicationAssemblies>
+      <_BlazorBuiltInBclLinkerDescriptor>$(MSBuildThisFileDirectory)BuiltInBclLinkerDescriptor.xml</_BlazorBuiltInBclLinkerDescriptor>
     </PropertyGroup>
 
     <PropertyGroup Label="Blazor HTML inputs">
@@ -329,6 +330,7 @@
   <Target Name="_CollectBlazorLinkerDescriptors">
 
     <ItemGroup Condition="@(BlazorLinkerDescriptor) == ''">
+      <BlazorLinkerDescriptor Include="$(_BlazorBuiltInBclLinkerDescriptor)" />
       <BlazorLinkerDescriptor Include="$(GeneratedBlazorLinkerDescriptor)" />
       <FileWrites Include="$(GeneratedBlazorLinkerDescriptor)" />
     </ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/BuiltInBclLinkerDescriptor.xml
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/BuiltInBclLinkerDescriptor.xml
@@ -1,0 +1,13 @@
+﻿<linker>
+
+  <!-- This file specifies which parts of the BCL or Blazor packages must not be stripped
+  by the IL linker even if they are not referenced by user code. The file format is
+  described at https://github.com/mono/linker/blob/master/linker/README.md#syntax-of-xml-descriptor -->
+
+  <assembly fullname="mscorlib">
+    <!-- Preserve all methods on WasmRuntime, because these are called by JS-side code
+    to implement timers. Fixes https://github.com/aspnet/Blazor/issues/239 -->
+    <type fullname="System.Threading.WasmRuntime" />
+  </assembly>
+
+</linker>


### PR DESCRIPTION
The issue was that, to implement a timer, some of Mono's C code was invoking .NET methods on this type (when the timer fires). The IL linker doesn't know about that, so it was stripping those .NET methods.

Having this new file `BuiltInBclLinkerDescriptor.xml` also gives us a convenient pattern for adding future exclusions.

@javiercn Your work on integrating the linker cleanly is paying off, because this new behavior was extremely easy to add.