### PR TITLE
Workaround for VS publishing failures for hosted scenario

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -12,6 +12,19 @@
     <IsWebConfigTransformDisabled>true</IsWebConfigTransformDisabled>
   </PropertyGroup>
 
+  <!-- Ideally, this should have DependsOnTargets="PrepareBlazorOutputs" and then
+       populate _BlazorGCTPDIDistFiles using @(BlazorItemOutput) instead of using
+       the wildcard that publishes whatever's currently on disk. However that
+       doesn't currently work because PrepareBlazorOutputs assumes the build will
+       already have run and hence @(ReferenceCopyLocalPaths) will already be
+       populated. The assumption is correct for regular builds and command-line
+       publishes, but it's *not* correct for VS publishes. Somehow we'd need
+       PrepareBlazorOutputs to also depend on Build or at least ResolveReferences,
+       but that alone doesn't cause @(ReferenceCopyLocalPaths) to be populated,
+       because ResolveReferences specifically behaves differently when
+       '$(BuildingProject)'!='true'. Hackily overriding that flag to true still
+       somehow isn't sufficient, but even if it was it's not a good solution as
+       it might have other side-effects. -->
   <Target Name="BlazorGetCopyToPublishDirectoryItems" BeforeTargets="GetCopyToPublishDirectoryItems">
     <ItemGroup>
       <!-- Don't want to publish the assemblies from the regular 'bin' dir. Instead we publish ones from 'dist'. -->
@@ -23,9 +36,14 @@
       </ContentWithTargetPath>
       
       <!-- Publish all the 'dist' files -->
-      <_BlazorGCTPDIDistFiles Include="@(BlazorItemOutput->'%(TargetOutputPath)')" />
+      <!-- By using a wildcard here and just publishing whatever happens to be on disk,
+           we're assuming that a build for this project has already run and the output
+           is up-to-date (which does happen automatically for command-line and VS publish
+           actions, at least by default). This is a workaround for the issue described above.
+           We should not keep doing this permanently. -->
+      <_BlazorGCTPDIDistFiles Include="$(OutDir)dist\**" />
       <_BlazorGCTPDI Include="@(_BlazorGCTPDIDistFiles)">
-        <TargetPath>$(BlazorPublishDistDir)$([MSBuild]::MakeRelative('$(ProjectDir)$(OutDir)dist\', %(Identity)))</TargetPath>
+        <TargetPath>$(BlazorPublishDistDir)%(RecursiveDir)%(Filename)%(Extension)</TargetPath>
       </_BlazorGCTPDI>
 
       <ContentWithTargetPath Include="@(_BlazorGCTPDI)">


### PR DESCRIPTION
Although publishing worked correctly from the command line (for both standalone and hosted-style solutions), and it worked in VS for standalone Blazor projects, I discovered it does **not** work in VS for hosted Blazor projects.

### The problem

The original reason was:

 1. `BlazorGetCopyToPublishDirectoryItems` did not declare a dependency on `PrepareBlazorOutputs`, so it wasn't guaranteeing that `@(BlazorItemOutput)` would be populated yet.
 2. When the publish runs in VS, a different set of targets gets run. It seems that VS does a regular build first, then runs publish in some kind of "don't build first" mode. The result was that `PrepareBlazorOutputs` did not run, hence `@(BlazorItemOutput)` was empty, hence we didn't know what files to publish.

I thought I could fix it by making `BlazorGetCopyToPublishDirectoryItems` depend on `PrepareBlazorOutputs`, but this opens up a whole different set of problems. Although `PrepareBlazorOutputs` relies on `@(ReferenceCopyLocalPaths)` being populated, it doesn't explicitly take a dependency on `ResolveReferences`. Again, in the VS publish scenario, no regular build is occurring, so `@(ReferenceCopyLocalPaths)` is empty and `PrepareBlazorOutputs` fails.

I thought I could fix it by making `PrepareBlazorOutputs` depend on `ResolveReferences` (or even `Build`), but this opens up a whole different set of problems. The `ResolveReferences` target knows that no regular build is taking place, so it only collects a subset of the regular references list. This means that it doesn't populate `@(ReferenceCopyLocalPaths)` with what we need. And if we try making `PrepareBlazorOutputs` depend on `Build`, then the build fails because it's not referencing the full set of assemblies.

### Workaround

In practice, a build of the client app always *does* get run prior to the publish phase (both for VS and command-line publishes). Therefore the client app `dist` directory is always up to date. As a cheap workaround, then, I've just reverted the "don't use wildcards" change from before so now it publishes whatever's in the `dist` directory on disk without needing to declare a dependency on `PrepareBlazorOutputs`.

### Longer-term proper fix

@javiercn, do you think the `PrepareBlazorOutputs` target *should* be able to run during a VS publish? If so, would you be able to look into wiring up the correct dependencies so that it does succeed? Not this week of course!

If not, we might have to review more broadly how the build/publish works.