### PR TITLE
Go back to NuGet.config in project templates. Fixes #267.

### DIFF
--- a/Blazor.sln
+++ b/Blazor.sln
@@ -69,6 +69,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorStandalone.CSharp", "src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorStandalone.CSharp\BlazorStandalone.CSharp.csproj", "{A092FA91-856B-4ACA-B1C2-10BDBA366185}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BlazorHosted.CSharp", "BlazorHosted.CSharp", "{73DA1DFD-79F0-4BA2-B0B6-4F3A21D2C3F8}"
+	ProjectSection(SolutionItems) = preProject
+		src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted.CSharp\NuGet.config = src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted.CSharp\NuGet.config
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHosted.CSharp.Client", "src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted.CSharp\BlazorHosted.CSharp.Client\BlazorHosted.CSharp.Client.csproj", "{7549444A-9C81-44DE-AD0D-2C55501EAAC7}"
 EndProject

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/BlazorHosted.CSharp.Client.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/BlazorHosted.CSharp.Client.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Exe</OutputType>
-
-    <!-- Temporarily, fetch Blazor packages from the blazor-dev feed -->
-    <RestoreSources>$(RestoreSources);https://dotnet.myget.org/f/blazor-dev/api/v3/index.json</RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Server/BlazorHosted.CSharp.Server.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Server/BlazorHosted.CSharp.Server.csproj
@@ -2,9 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
-    <!-- Temporarily, fetch Blazor packages from the blazor-dev feed -->
-    <RestoreSources>$(RestoreSources);https://dotnet.myget.org/f/blazor-dev/api/v3/index.json</RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/NuGet.config
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="blazor-dev" value="https://dotnet.myget.org/F/blazor-dev/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/BlazorStandalone.CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/BlazorStandalone.CSharp.csproj
@@ -4,9 +4,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RunCommand>dotnet</RunCommand>
     <RunArguments>blazor serve</RunArguments>
-
-    <!-- Temporarily, fetch Blazor packages from the blazor-dev feed -->
-    <RestoreSources>$(RestoreSources);https://dotnet.myget.org/f/blazor-dev/api/v3/index.json</RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/NuGet.config
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="blazor-dev" value="https://dotnet.myget.org/F/blazor-dev/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
I'm reverting the change where we put `<RestoreSources>` in the csproj files because it's not sufficient in all cases (#267).

@pranavkm Since you implied there wasn't any strict reason why we shouldn't use NuGet.config files, I expect this is OK, but please let me know if you have any concerns.

Will merge immediately, but /CC @rynowak @javiercn in case this raises any concerns.