### PR TITLE
Temporary workaround for #219 ("data-" attributes don't compile)

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorRuntimeNodeWriter.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorRuntimeNodeWriter.cs
@@ -543,6 +543,15 @@ namespace Microsoft.AspNetCore.Blazor.Razor
 
         public override void BeginWriteAttribute(CodeWriter codeWriter, string key)
         {
+            // Temporary workaround for https://github.com/aspnet/Blazor/issues/219
+            // Remove this logic once the underlying HTML parsing issue is fixed,
+            // as we don't really want special cases like this.
+            const string dataUnderscore = "data_";
+            if (key.StartsWith(dataUnderscore, StringComparison.Ordinal))
+            {
+                key = "data-" + key.Substring(dataUnderscore.Length);
+            }
+
             codeWriter
                 .WriteStartMethodInvocation($"{_scopeStack.BuilderVarName}.{nameof(BlazorApi.RenderTreeBuilder.AddAttribute)}")
                 .Write((_sourceSequence++).ToString())


### PR DESCRIPTION
The problem with compiling `data-` attributes comes down to this in Razor's `HtmlMarkupParser`: https://github.com/aspnet/Razor/blob/dev/src/Microsoft.AspNetCore.Razor.Language/Legacy/HtmlMarkupParser.cs#L934

That is, it specifically detects `data-` as an attribute prefix, and when found outputs different IR that unfortunately doesn't retain information about the fact that it's even an attribute (it just looks like arbitrary HTML markup in the IR). As such, the Blazor node writer doesn't know we're dealing with an attribute and can't produce the correct code.

### Short-term workaround

Since Blazor developers may need to output `data-*` attributes into the DOM (e.g., to control certain Bootstrap features), there has to be a way of doing it.

As a short-term workaround, this PR causes `data_*` attributes to be rendered as `data-*` in the DOM. This at least gives developers a way of producing `data-*`, even it's quite awkward. This workaround is probably preferable over delaying the 0.1.0 release.

We can write it up as a "known issue" in the 0.1.0 release notes.

### Longer-term solution

I understand there will be good reasons the `data-*` special case in `HtmlMarkupParser` for server-side use (based on the HTML semantics of `data-*` attributes), but it's not applicable for client-side execution. So, we'll want some way of disabling that special case in `HtmlMarkupParser` when compiling Blazor components.

Right now I don't see any good way of disabling that special case from the outside. I think we'll need to modify `HtmlMarkupParser.cs` in the Razor repo, giving it some config option or other method to signal we're building client-side code.

@rynowak Do you agree? Can we tell `HtmlMarkupParser` not to treat `data-*` as special if it's doing Blazor compilation? Do you have a preference on how the configuration for that should work?

If it's totally trivial to add and to update Blazor to depend on a newer version of Razor that supports this, we should consider it for 0.1.0. But if it's nontrivial in any way I think we should do it post-0.1.0. We can discuss.