### PR TITLE
[WIP] Codegen partial classes. Implements #278

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/ComponentDocumentClassifierPass.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/ComponentDocumentClassifierPass.cs
@@ -66,6 +66,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             @class.ClassName = computedClass;
             @class.Modifiers.Clear();
             @class.Modifiers.Add("public");
+            @class.Modifiers.Add("partial");
 
             method.ReturnType = "void";
             method.MethodName = BlazorApi.BlazorComponent.BuildRenderTree;

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/DesignTimeCodeGenerationRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/DesignTimeCodeGenerationRazorIntegrationTest.cs
@@ -57,7 +57,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -142,7 +142,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -211,7 +211,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -290,7 +290,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -385,7 +385,7 @@ using Microsoft.AspNetCore.Blazor;
 
 #line default
 #line hidden
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
@@ -468,7 +468,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RuntimeCodeGenerationRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RuntimeCodeGenerationRazorIntegrationTest.cs
@@ -43,7 +43,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
@@ -104,7 +104,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
@@ -158,7 +158,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
@@ -208,7 +208,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
@@ -270,7 +270,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
@@ -338,7 +338,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
@@ -398,7 +398,7 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
@@ -460,7 +460,7 @@ namespace Test
     using System.Threading.Tasks;
     [Microsoft.AspNetCore.Blazor.Components.RouteAttribute(""/MyPage"")]
     [Microsoft.AspNetCore.Blazor.Components.RouteAttribute(""/AnotherRoute/{id}"")]
-    public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
+    public partial class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
@@ -82,6 +82,19 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         }
 
         [Fact]
+        public void CanRenderComponentsWithCodeInOtherPartialClasses()
+        {
+            // Initial count is 10
+            var appElement = MountTestComponent<CounterComponentWithSeparateCodeFile>();
+            var countDisplayElement = appElement.FindElement(By.TagName("p"));
+            Assert.Equal("Current count: 10", countDisplayElement.Text);
+
+            // Clicking button increments count
+            appElement.FindElement(By.TagName("button")).Click();
+            Assert.Equal("Current count: 11", countDisplayElement.Text);
+        }
+
+        [Fact]
         public void CanRenderChildComponents()
         {
             var appElement = MountTestComponent<ParentChildComponent>();

--- a/test/testapps/BasicTestApp/CounterComponentWithSeparateCodeFile.cshtml
+++ b/test/testapps/BasicTestApp/CounterComponentWithSeparateCodeFile.cshtml
@@ -1,0 +1,3 @@
+﻿<h1>Counter</h1>
+<p>Current count: @currentCount</p>
+<button @onclick(IncrementCount)>Click me</button>

--- a/test/testapps/BasicTestApp/CounterComponentWithSeparateCodeFile.cshtml.cs
+++ b/test/testapps/BasicTestApp/CounterComponentWithSeparateCodeFile.cshtml.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace BasicTestApp
+{
+    public partial class CounterComponentWithSeparateCodeFile
+    {
+        int currentCount = 0;
+
+        // Just to show that we OnInit still works
+        protected override void OnInit()
+        {
+            currentCount = 10;
+        }
+
+        void IncrementCount()
+        {
+            currentCount++;
+        }
+    }
+}

--- a/test/testapps/BasicTestApp/wwwroot/index.html
+++ b/test/testapps/BasicTestApp/wwwroot/index.html
@@ -12,6 +12,7 @@
       <option value="">Choose...</option>
       <option value="BasicTestApp.AddRemoveChildComponents">Add/remove child components</option>
       <option value="BasicTestApp.CounterComponent">Counter</option>
+      <option value="BasicTestApp.CounterComponentWithSeparateCodeFile">Counter with separate code file</option>  
       <option value="BasicTestApp.CounterComponentUsingChild">Counter using child component</option>
       <option value="BasicTestApp.CounterComponentWrapper">Counter wrapped in parent</option>
       <option value="BasicTestApp.KeyPressEventComponent">Key press event</option>


### PR DESCRIPTION
Although this works fine at compile time and runtime, it doesn't work correctly at design time in VS:

![image](https://user-images.githubusercontent.com/1101362/37594107-3269c45a-2b6c-11e8-830b-d713dc75a771.png)

I'm unsure why partial classes from the same project aren't included in the design-time compilation that VS is getting these errors from, especially given that things like `@inherits SomeClass` works fine.

@rynowak, do you know why this is, and if there's any straightforward thing we can do in this repo to fix it?

**Not urgent!** This doesn't need to be included in 0.1.0.