### PR TITLE
Get rid of error about package version

### DIFF
--- a/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
@@ -18,6 +18,10 @@
     <!-- VSIXes are always signed. This is the same key that ASP.NET uses for OSS signing -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\Key.snk</AssemblyOriginatorKeyFile>
+
+    <!-- Don't import the directory props and targets, they aren't compatible with an old-style csproj -->
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>
   <PropertyGroup>
     <!-- 


### PR DESCRIPTION
The Directory.Build.{props targets} files are designed for a new-style
csproj. Old-style csproj, which the VSIX uses don't support
PackageReference where the version is a variable.