### PR TITLE
Fix the Blazor about dialog

### DIFF
--- a/tooling/Microsoft.VisualStudio.BlazorExtension/AboutDialogInfoAttribute.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/AboutDialogInfoAttribute.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.BlazorExtension
+{
+    public class AboutDialogInfoAttribute : RegistrationAttribute
+    {
+        private readonly string _detailsId;
+        private readonly string _name;
+        private readonly string _nameId;
+        private readonly string _packageGuid;
+
+        // nameId and detailsId are resource IDs, they should start with #
+        public AboutDialogInfoAttribute(string packageGuid, string name, string nameId, string detailsId)
+        {
+            _packageGuid = packageGuid;
+            _name = name;
+            _nameId = nameId;
+            _detailsId = detailsId;
+        }
+
+        private string GetKeyName()
+        {
+            return "InstalledProducts\\" + _name;
+        }
+
+        public override void Register(RegistrationContext context)
+        {
+            var version = typeof(AboutDialogInfoAttribute).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+            using (var key = context.CreateKey(GetKeyName()))
+            {
+                key.SetValue(null, _nameId);
+                key.SetValue("Package", Guid.Parse(_packageGuid).ToString("B"));
+                key.SetValue("ProductDetails", _detailsId);
+                key.SetValue("UseInterface", false);
+                key.SetValue("UseVSProductID", false);
+
+                if (version != null)
+                {
+                    key.SetValue("PID", version);
+                }
+            }
+        }
+
+        public override void Unregister(RegistrationContext context)
+        {
+            context.RemoveKey(GetKeyName());
+        }
+    }
+}

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/BlazorPackage.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/BlazorPackage.cs
@@ -7,9 +7,9 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.BlazorExtension
 {
-    // We mainly have a package so we can have an "About" dialog entry. 
+    // We mainly have a package so we can have an "About" dialog entry.
     [PackageRegistration(UseManagedResourcesOnly = true)]
-    [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)]
+    [AboutDialogInfo(PackageGuidString, "ASP.NET Core Blazor Language Services", "#110", "112")]
     [Guid(BlazorPackage.PackageGuidString)]
     public sealed class BlazorPackage : Package
     {

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
@@ -4,8 +4,13 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <UseCodebase>true</UseCodebase>
+
+    <!-- Don't import the directory props and targets, they aren't compatible with an old-style csproj -->
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\version.props" />
   <!--
     Since the VSSDK doeesn't support SDK-based projects, we have to use the long/verbose version.
     
@@ -18,10 +23,6 @@
     <!-- VSIXes are always signed. This is the same key that ASP.NET uses for OSS signing -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\Key.snk</AssemblyOriginatorKeyFile>
-
-    <!-- Don't import the directory props and targets, they aren't compatible with an old-style csproj -->
-    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
-    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
   </PropertyGroup>
   <PropertyGroup>
     <!-- 
@@ -163,6 +164,59 @@
       <Visible>false</Visible>
     </Content>
   </ItemGroup>
+
+  <!--
+    We need to generate the assembly attributes for our assembly using the version from the build, so 
+    we can flow it to the about dialog.
+  -->
+  <ItemGroup>
+    <_VSIXAssemblyAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute">
+      <_Parameter1>$(VersionPrefix)-$(VersionSuffix)</_Parameter1>
+    </_VSIXAssemblyAttribute>
+  </ItemGroup>
+
+  <Target 
+    Name="_GenerateVSIXAssemblyAttributesHash" 
+    DependsOnTargets="PrepareForBuild"
+    Condition="'@(_VSIXAssemblyAttribute)' != ''">
+
+    <!-- We only use up to _Parameter1 for most attributes, but other targets may add additional assembly attributes with multiple parameters. -->
+    <Hash ItemsToHash="@(_VSIXAssemblyAttribute->'%(Identity)%(_Parameter1)%(_Parameter2)%(_Parameter3)%(_Parameter4)%(_Parameter5)%(_Parameter6)%(_Parameter7)%(_Parameter8)')">
+      <Output TaskParameter="HashResult" PropertyName="_VSIXAssemblyAttributesHash" />
+    </Hash>
+
+    <WriteLinesToFile
+      Lines="$(_VSIXAssemblyAttributesHash)"
+      File="$(_GeneratedVSIXAssemblyInfoInputsCacheFile)"
+      Overwrite="True"
+      WriteOnlyWhenDifferent="True" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_GeneratedVSIXAssemblyInfoInputsCacheFile)" />
+    </ItemGroup>
+  </Target>
+
+  <Target
+    Name="_GenerateVSIXAssemblyAttributes"
+    DependsOnTargets="_GenerateVSIXAssemblyAttributesHash"
+    Inputs="$(_GeneratedVSIXAssemblyInfoInputsCacheFile)"
+    Outputs="$(_GeneratedVSIXAssemblyInfoFile)"
+    BeforeTargets="CoreCompile">
+
+    <ItemGroup>
+      <Compile Include="$(_GeneratedVSIXAssemblyInfoFile)">
+        <Visible>false</Visible>
+      </Compile>
+    </ItemGroup>
+
+    <WriteCodeFragment AssemblyAttributes="@(_VSIXAssemblyAttribute)" Language="C#" OutputFile="$(_GeneratedVSIXAssemblyInfoFile)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_GeneratedVSIXAssemblyInfoFile)" />
+    </ItemGroup>
+  </Target>
+
+
   <!--
   
     END INTERESTING STUFF 
@@ -219,6 +273,7 @@
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.100" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AboutDialogInfoAttribute.cs" />
     <Compile Include="BlazorPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -278,4 +333,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+
+  <!-- Must be defined after the CSharp.targets -->
+  <PropertyGroup>
+    <_GeneratedVSIXAssemblyInfoInputsCacheFile>$(IntermediateOutputPath)$(MSBuildProjectName).VSIXAssemblyInfo.cache.txt</_GeneratedVSIXAssemblyInfoInputsCacheFile>
+    <_GeneratedVSIXAssemblyInfoFile>$(IntermediateOutputPath)$(MSBuildProjectName).VSIXAssemblyInfo.cs</_GeneratedVSIXAssemblyInfoFile>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Have to do some gritty work to be able to show a proper version in the
about dialog. The generation of the proper assembly attributes is part
of the new-style csproj, so we don't get to use it for free.