### PR TITLE
Improve dependencies of the Blazor VSIX

### DIFF
--- a/tooling/Microsoft.VisualStudio.BlazorExtension/source.extension.vsixmanifest
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/source.extension.vsixmanifest
@@ -12,11 +12,10 @@
         <PreviewImage>Content\WebConfiguration.png</PreviewImage>
     </Metadata>
     <Installation AllUsers="true">
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.26228.04,)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27512, 16.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6.1,)" />
-        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.RazorExtension" DisplayName="Razor Language Services" Version="[15.6.31169,15.8)" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
@@ -27,6 +26,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" Path="Templates.pkgdef" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Web" Version="[15.7.27520.0,16.0)" DisplayName="ASP.NET and web development tools" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
This should now correctly require VS 15.7-preview1 or newer with the
ASP.NET and web development tools to installed.

Removed the Razor Language Servcies dependency since it's prompting an
install of the wrong tools from the VS gallery.