### PR TITLE
Specify Expand-Archive cmd module explicitly

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -103,7 +103,7 @@ function Get-KoreBuild {
             Get-RemoteFile $remotePath $tmpfile $ToolsSourceSuffix
             if (Get-Command -Name 'Expand-Archive' -ErrorAction Ignore) {
                 # Use built-in commands where possible as they are cross-plat compatible
-                Expand-Archive -Path $tmpfile -DestinationPath $korebuildPath
+                Microsoft.PowerShell.Archive\Expand-Archive -Path $tmpfile -DestinationPath $korebuildPath
             }
             else {
                 # Fallback to old approach for old installations of PowerShell


### PR DESCRIPTION
Recommendation: Specify the `Expand-Archive` command module (`Microsoft.PowerShell.Archive`) explicitly in the *run.ps1* script. Anyone who has the [PowerShell Community Extensions (Pscx)](https://github.com/Pscx/Pscx) installed gets a big 'ole :boom: if it isn't specified ...

```
Expand-Archive : A parameter cannot be found that matches parameter name 'DestinationPath'.
At C:\Users\xxxxxxx\Documents\GitHub\Blazor\run.ps1:106 char:47
 ...                Expand-Archive -Path $tmpfile -DestinationPath $korebu ...
                                                  ~~~~~~~~~~~~~~~~
     CategoryInfo          : InvalidArgument: (:) [Expand-Archive], ParentContainsErrorRecordException
     FullyQualifiedErrorId : NamedParameterNotFound,Pscx.Commands.IO.Compression.ExpandArchiveCommand
```