### PR TITLE
Corrects spelling of some comments, method name and remove an excess flag

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRendererRegistry.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRendererRegistry.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
     /// <summary>
     /// Provides mechanisms for locating <see cref="BrowserRenderer"/> instances
     /// by ID. This is used when receiving incoming events from the browser. It
-    /// implictly ensures that the <see cref="BrowserRenderer"/> instances and
+    /// implicitly ensures that the <see cref="BrowserRenderer"/> instances and
     /// their associated component instances aren't GCed when events may still
     /// be received for them.
     /// </summary>

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/DirectiveRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/DirectiveRazorIntegrationTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
                 $"Hello from @MyService1 and @MyService2").GetType();
 
             // Assert 1: Compiled type has correct properties
-            var propertyFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.NonPublic;
+            var propertyFlags = BindingFlags.Instance | BindingFlags.NonPublic;
             var injectableProperties = componentType.GetProperties(propertyFlags)
                 .Where(p => p.GetCustomAttribute<InjectAttribute>() != null);
             Assert.Collection(injectableProperties.OrderBy(p => p.Name),

--- a/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/ComponentTagHelperDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/ComponentTagHelperDescriptorProviderTest.cs
@@ -85,13 +85,13 @@ namespace Test
             // No documentation in this test
             Assert.Null(component.Documentation);
 
-            // These are all trivally derived from the assembly/namespace/type name
+            // These are all trivially derived from the assembly/namespace/type name
             Assert.Equal("TestAssembly", component.AssemblyName);
             Assert.Equal("Test.MyComponent", component.Name);
             Assert.Equal("Test.MyComponent", component.DisplayName);
             Assert.Equal("Test.MyComponent", component.GetTypeName());
 
-            // Our use of matching rules is also very simple, and derived from the name. Veriying
+            // Our use of matching rules is also very simple, and derived from the name. Verifying
             // it once in detail here and then ignoring it.
             var rule = Assert.Single(component.TagMatchingRules);
             Assert.Empty(rule.Attributes);
@@ -329,7 +329,7 @@ namespace Test
             Assert.True(attribute.IsDelegateProperty());
         }
 
-        // For simplicity in testing, exlude the built-in components. We'll add more and we
+        // For simplicity in testing, exclude the built-in components. We'll add more and we
         // don't want to update the tests when that happens.
         private TagHelperDescriptor[] ExcludeBuiltInComponents(TagHelperDescriptorProviderContext context)
         {

--- a/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             var nestedComponent = (MessageComponent)nestedComponentFrame.Component;
             var nestedComponentId = nestedComponentFrame.ComponentId;
 
-            // Assert: inital render
+            // Assert: initial render
             nestedComponent.Message = "Render 1";
             nestedComponent.TriggerRender();
             var batch = renderer.Batches[1];

--- a/test/Microsoft.AspNetCore.Blazor.Test/Routing/RouteTableTests.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/Routing/RouteTableTests.cs
@@ -279,7 +279,7 @@ namespace Microsoft.AspNetCore.Blazor.Test.Routing
         [InlineData("/{parameter}", "/{parameter}/")]
         [InlineData("/literal/{parameter}", "/Literal/{something}")]
         [InlineData("/{parameter}/literal/{something}", "{param}/Literal/{else}")]
-        public void DetectsAmbigousRoutes(string left, string right)
+        public void DetectsAmbiguousRoutes(string left, string right)
         {
             // Arrange
             var expectedMessage = $@"The following routes are ambiguous:


### PR DESCRIPTION
Fixed several mistakes in the comments
Renamed method Detects**Ambigous**Routes on **DetectsAmbiguousRoutes**
Removed the extra **BindingFlags.NonPublic** flag that was duplicated