### PR TITLE
Double-quote attribute values

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/Shared/MainLayout.cshtml
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/Shared/MainLayout.cshtml
@@ -1,11 +1,11 @@
-﻿@implements ILayoutComponent
+@implements ILayoutComponent
 
-<div class='container-fluid'>
-    <div class='row'>
-        <div class='col-sm-3'>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-sm-3">
             <NavMenu />
         </div>
-        <div class='col-sm-9'>
+        <div class="col-sm-9">
             @Body
         </div>
     </div>


### PR DESCRIPTION
Singles are perfectly valid under HTML5 ... but inconsistent with our doc samples.

Why do I have the sneaky feeling this was done on purpose to solve a problem?? :smile:

If so, this is a throw-away PR. 🗑 Sorry for the trouble.