### PR TITLE
Resolution for "The path must be absolute" on published projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ launchSettings.json
 artifacts/
 msbuild.binlog
 .vscode/
-src/Microsoft.AspNetCore.Blazor.Browser.JS/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ launchSettings.json
 artifacts/
 msbuild.binlog
 .vscode/
+src/Microsoft.AspNetCore.Blazor.Browser.JS/package-lock.json

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorConfig.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorConfig.cs
@@ -29,6 +29,9 @@ namespace Microsoft.AspNetCore.Blazor.Server
             var configLines = File.ReadLines(configFilePath).ToList();
             SourceMSBuildPath = configLines[0];
 
+            if (string.IsNullOrEmpty(SourceMSBuildPath) || SourceMSBuildPath == ".")
+                SourceMSBuildPath = assemblyPath;
+
             var sourceMsBuildDir = Path.GetDirectoryName(SourceMSBuildPath);
             SourceOutputAssemblyPath = Path.Combine(sourceMsBuildDir, configLines[1]);
 

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorConfig.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorConfig.cs
@@ -29,8 +29,10 @@ namespace Microsoft.AspNetCore.Blazor.Server
             var configLines = File.ReadLines(configFilePath).ToList();
             SourceMSBuildPath = configLines[0];
 
-            if (string.IsNullOrEmpty(SourceMSBuildPath) || SourceMSBuildPath == ".")
+            if (SourceMSBuildPath == ".")
+            {
                 SourceMSBuildPath = assemblyPath;
+            }
 
             var sourceMsBuildDir = Path.GetDirectoryName(SourceMSBuildPath);
             SourceOutputAssemblyPath = Path.Combine(sourceMsBuildDir, configLines[1]);


### PR DESCRIPTION
Trying to replace the internal "." folder with the local assembly path in order to have an absolute path for the PhysicalFileStorage class at startup ("The path must be absolute" error at startup for published projects)

May resolve the issue of #376  on dev

_Also apology if (maybe) you see something related to me in commit history on aspnet/Blazor (internally ?), i'm pretty new to Github and Git._