### PR TITLE
Add DI extension method namespace to Program.cs in templates

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/Program.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Blazor.Browser.Rendering;
 using Microsoft.AspNetCore.Blazor.Browser.Services;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 
 namespace BlazorHosted.CSharp.Client

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/Program.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/Program.cs
@@ -9,7 +9,7 @@ namespace BlazorHosted.CSharp.Client
     {
         static void Main(string[] args)
         {
-            var serviceProvider = new BrowserServiceProvider(configure =>
+            var serviceProvider = new BrowserServiceProvider(services =>
             {
                 // Add any custom services here
             });

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/Program.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Blazor.Browser.Rendering;
 using Microsoft.AspNetCore.Blazor.Browser.Services;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 
 namespace BlazorStandalone.CSharp

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/Program.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/Program.cs
@@ -9,7 +9,7 @@ namespace BlazorStandalone.CSharp
     {
         static void Main(string[] args)
         {
-            var serviceProvider = new BrowserServiceProvider(configure =>
+            var serviceProvider = new BrowserServiceProvider(services =>
             {
                 // Add any custom services here
             });


### PR DESCRIPTION
Adding a `using` for `Microsoft.Extensions.DependencyInjection` so that you can use common DI extension methods like `AddSingleton`.