### PR TITLE
Correct the use of a parameter 'autoSpace' in the constructor

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/CodeWriterExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/CodeWriterExtensions.cs
@@ -545,7 +545,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             public CSharpCodeWritingScope(CodeWriter writer, int tabSize = 4, bool autoSpace = true)
             {
                 _writer = writer;
-                _autoSpace = true;
+                _autoSpace = autoSpace;
                 _tabSize = tabSize;
                 _startIndent = -1; // Set in WriteStartScope
 


### PR DESCRIPTION
Constructor parameter '**autoSpace**' is not used. It has default **true** value too.