### PR TITLE
Improve JS-side event handling code

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Interop/InternalRegisteredFunction.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Interop/InternalRegisteredFunction.ts
@@ -1,12 +1,12 @@
 ﻿import { invokeWithJsonMarshalling } from './InvokeWithJsonMarshalling';
-import { attachComponentToElement, renderBatch } from '../Rendering/Renderer';
+import { attachRootComponentToElement, renderBatch } from '../Rendering/Renderer';
 
 /**
  * The definitive list of internal functions invokable from .NET code.
  * These function names are treated as 'reserved' and cannot be passed to registerFunction.
  */
 export const internalRegisteredFunctions = {
-  attachComponentToElement,
+  attachRootComponentToElement,
   invokeWithJsonMarshalling,
   renderBatch,
 };

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventDelegator.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventDelegator.ts
@@ -1,0 +1,156 @@
+﻿import { EventForDotNet, UIEventArgs } from './EventForDotNet';
+
+export interface OnEventCallback {
+  (event: Event, componentId: number, eventHandlerId: number, eventArgs: EventForDotNet<UIEventArgs>): void;
+}
+
+// Responsible for adding/removing the eventInfo on an expando property on DOM elements, and
+// calling an EventInfoStore that deals with registering/unregistering the underlying delegated
+// event listeners as required (and also maps actual events back to the given callback).
+export class EventDelegator {
+  private static nextEventDelegatorId = 0;
+  private eventsCollectionKey: string;
+  private eventInfoStore: EventInfoStore;
+
+  constructor(private onEvent: OnEventCallback) {
+    const eventDelegatorId = ++EventDelegator.nextEventDelegatorId;
+    this.eventsCollectionKey = `_blazorEvents_${eventDelegatorId}`;
+    this.eventInfoStore = new EventInfoStore(this.onGlobalEvent.bind(this));
+  }
+
+  public setListener(element: Element, eventName: string, componentId: number, eventHandlerId: number) {
+    // Ensure we have a place to store event info for this element
+    let infoForElement: EventHandlerInfosForElement = element[this.eventsCollectionKey];
+    if (!infoForElement) {
+      infoForElement = element[this.eventsCollectionKey] = {};
+    }
+
+    if (infoForElement.hasOwnProperty(eventName)) {
+      // We can cheaply update the info on the existing object and don't need any other housekeeping
+      const oldInfo = infoForElement[eventName];
+      this.eventInfoStore.update(oldInfo.eventHandlerId, eventHandlerId);
+    } else {
+      // Go through the whole flow which might involve registering a new global handler
+      const newInfo = { element, eventName, componentId, eventHandlerId };
+      this.eventInfoStore.add(newInfo);
+      infoForElement[eventName] = newInfo;
+    }
+  }
+
+  public removeListener(eventHandlerId: number) {
+    // This method gets called whenever the .NET-side code reports that a certain event handler
+    // has been disposed. However we will already have disposed the info about that handler if
+    // the eventHandlerId for the (element,eventName) pair was replaced during diff application.
+    const info = this.eventInfoStore.remove(eventHandlerId);
+    if (info) {
+      // Looks like this event handler wasn't already disposed
+      // Remove the associated data from the DOM element
+      const element = info.element;
+      if (element.hasOwnProperty(this.eventsCollectionKey)) {
+        const elementEventInfos: EventHandlerInfosForElement = element[this.eventsCollectionKey];
+        delete elementEventInfos[info.eventName];
+        if (Object.getOwnPropertyNames(elementEventInfos).length === 0) {
+          delete element[this.eventsCollectionKey];
+        }
+      }
+    }
+  }
+
+  private onGlobalEvent(evt: Event) {
+    if (!(evt.target instanceof Element)) {
+      return;
+    }
+
+    // Scan up the element hierarchy, looking for any matching registered event handlers
+    let candidateElement = evt.target as Element | null;
+    let eventArgs: EventForDotNet<UIEventArgs> | null = null; // Populate lazily
+    while (candidateElement) {
+      if (candidateElement.hasOwnProperty(this.eventsCollectionKey)) {
+        const handlerInfos = candidateElement[this.eventsCollectionKey];
+        if (handlerInfos.hasOwnProperty(evt.type)) {
+          // We are going to raise an event for this element, so prepare info needed by the .NET code
+          if (!eventArgs) {
+            eventArgs = EventForDotNet.fromDOMEvent(evt);
+          }
+
+          const handlerInfo = handlerInfos[evt.type];
+          this.onEvent(evt, handlerInfo.componentId, handlerInfo.eventHandlerId, eventArgs);
+        }
+      }
+
+      candidateElement = candidateElement.parentElement;
+    }
+  }
+}
+
+// Responsible for adding and removing the global listener when the number of listeners
+// for a given event name changes between zero and nonzero
+class EventInfoStore {
+  private infosByEventHandlerId: { [eventHandlerId: number]: EventHandlerInfo } = {};
+  private countByEventName: { [eventName: string]: number } = {};
+
+  constructor(private globalListener: EventListener) {
+  }
+
+  public add(info: EventHandlerInfo) {
+    if (this.infosByEventHandlerId[info.eventHandlerId]) {
+      // Should never happen, but we want to know if it does
+      throw new Error(`Event ${info.eventHandlerId} is already tracked`);
+    }
+
+    this.infosByEventHandlerId[info.eventHandlerId] = info;
+
+    const eventName = info.eventName;
+    if (this.countByEventName.hasOwnProperty(eventName)) {
+      this.countByEventName[eventName]++;
+    } else {
+      this.countByEventName[eventName] = 1;
+      document.addEventListener(eventName, this.globalListener);
+    }
+  }
+
+  public update(oldEventHandlerId: number, newEventHandlerId: number) {
+    if (this.infosByEventHandlerId.hasOwnProperty(newEventHandlerId)) {
+      // Should never happen, but we want to know if it does
+      throw new Error(`Event ${newEventHandlerId} is already tracked`);
+    }
+
+    // Since we're just updating the event handler ID, there's no need to update the global counts
+    const info = this.infosByEventHandlerId[oldEventHandlerId];
+    delete this.infosByEventHandlerId[oldEventHandlerId];
+    info.eventHandlerId = newEventHandlerId;
+    this.infosByEventHandlerId[newEventHandlerId] = info;
+  }
+
+  public remove(eventHandlerId: number): EventHandlerInfo {
+    const info = this.infosByEventHandlerId[eventHandlerId];
+    if (info) {
+      delete this.infosByEventHandlerId[eventHandlerId];
+
+      const eventName = info.eventName;
+      if (--this.countByEventName[eventName] === 0) {
+        delete this.countByEventName[eventName];
+        document.removeEventListener(eventName, this.globalListener);
+      }
+    }
+
+    return info;
+  }
+}
+
+interface EventHandlerInfosForElement {
+  // Although we *could* track multiple event handlers per (element, eventName) pair
+  // (since they have distinct eventHandlerId values), there's no point doing so because
+  // our programming model is that you declare event handlers as attributes. An element
+  // can only have one attribute with a given name, hence only one event handler with
+  // that name at any one time.
+  // So to keep things simple, only track one EventHandlerInfo per (element, eventName)
+  [eventName: string]: EventHandlerInfo
+}
+
+interface EventHandlerInfo {
+  element: Element;
+  eventName: string;
+  componentId: number;
+  eventHandlerId: number;
+}

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
@@ -1,0 +1,46 @@
+﻿export class EventForDotNet<TData extends UIEventArgs> {
+  constructor(public readonly type: EventArgsType, public readonly data: TData) {
+  }
+
+  static fromDOMEvent(event: Event): EventForDotNet<UIEventArgs> {
+    const element = event.target as Element;
+    switch (event.type) {
+      case 'click':
+      case 'mousedown':
+      case 'mouseup':
+        return new EventForDotNet<UIMouseEventArgs>('mouse', { Type: event.type });
+      case 'change': {
+        const targetIsCheckbox = isCheckbox(element);
+        const newValue = targetIsCheckbox ? !!element['checked'] : element['value'];
+        return new EventForDotNet<UIChangeEventArgs>('change', { Type: event.type, Value: newValue });
+      }
+      case 'keypress':
+        return new EventForDotNet<UIKeyboardEventArgs>('keyboard', { Type: event.type, Key: (event as any).key });
+      default:
+        return new EventForDotNet<UIEventArgs>('unknown', { Type: event.type });
+    }
+  }
+}
+
+function isCheckbox(element: Element | null) {
+  return element && element.tagName === 'INPUT' && element.getAttribute('type') === 'checkbox';
+}
+
+// The following interfaces must be kept in sync with the UIEventArgs C# classes
+
+type EventArgsType = 'mouse' | 'keyboard' | 'change' | 'unknown';
+
+export interface UIEventArgs {
+  Type: string;
+}
+
+interface UIMouseEventArgs extends UIEventArgs {
+}
+
+interface UIKeyboardEventArgs extends UIEventArgs {
+  Key: string;
+}
+
+interface UIChangeEventArgs extends UIEventArgs {
+  Value: string | boolean;
+}

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/RenderBatch.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/RenderBatch.ts
@@ -9,6 +9,7 @@ export const renderBatch = {
   updatedComponents: (obj: RenderBatchPointer) => platform.readStructField<ArrayRangePointer<RenderTreeDiffPointer>>(obj, 0),
   referenceFrames: (obj: RenderBatchPointer) => platform.readStructField<ArrayRangePointer<RenderTreeFramePointer>>(obj, arrayRangeStructLength),
   disposedComponentIds: (obj: RenderBatchPointer) => platform.readStructField<ArrayRangePointer<number>>(obj, arrayRangeStructLength + arrayRangeStructLength),
+  disposedEventHandlerIds: (obj: RenderBatchPointer) => platform.readStructField<ArrayRangePointer<number>>(obj, arrayRangeStructLength + arrayRangeStructLength + arrayRangeStructLength),
 };
 
 const arrayRangeStructLength = 8;

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/Renderer.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/Renderer.ts
@@ -6,7 +6,7 @@ import { BrowserRenderer } from './BrowserRenderer';
 type BrowserRendererRegistry = { [browserRendererId: number]: BrowserRenderer };
 const browserRenderers: BrowserRendererRegistry = {};
 
-export function attachComponentToElement(browserRendererId: number, elementSelector: System_String, componentId: number) {
+export function attachRootComponentToElement(browserRendererId: number, elementSelector: System_String, componentId: number) {
   const elementSelectorJs = platform.toJavaScriptString(elementSelector);
   const element = document.querySelector(elementSelectorJs);
   if (!element) {
@@ -17,7 +17,7 @@ export function attachComponentToElement(browserRendererId: number, elementSelec
   if (!browserRenderer) {
     browserRenderer = browserRenderers[browserRendererId] = new BrowserRenderer(browserRendererId);
   }
-  browserRenderer.attachComponentToElement(componentId, element);
+  browserRenderer.attachRootComponentToElement(componentId, element);
   clearElement(element);
 }
 
@@ -52,6 +52,15 @@ export function renderBatch(browserRendererId: number, batch: RenderBatchPointer
     const componentIdPtr = platform.getArrayEntryPtr(disposedComponentIdsArray, i, 4);
     const componentId = platform.readInt32Field(componentIdPtr);
     browserRenderer.disposeComponent(componentId);
+  }
+
+  const disposedEventHandlerIds = renderBatchStruct.disposedEventHandlerIds(batch);
+  const disposedEventHandlerIdsLength = arrayRange.count(disposedEventHandlerIds);
+  const disposedEventHandlerIdsArray = arrayRange.array(disposedEventHandlerIds);
+  for (let i = 0; i < disposedEventHandlerIdsLength; i++) {
+    const eventHandlerIdPtr = platform.getArrayEntryPtr(disposedEventHandlerIdsArray, i, 4);
+    const eventHandlerId = platform.readInt32Field(eventHandlerIdPtr);
+    browserRenderer.disposeEventHandler(eventHandlerId);
   }
 }
 

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
             var component = InstantiateComponent(componentType);
             var componentId = AssignComponentId(component);
             RegisteredFunction.InvokeUnmarshalled<int, string, int, object>(
-                "attachComponentToElement",
+                "attachRootComponentToElement",
                 _browserRendererId,
                 domElementSelector,
                 componentId);

--- a/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
@@ -213,7 +213,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// <returns>A <see cref="RenderTreeFrame"/> that represents the event handler.</returns>
         protected RenderTreeFrame onclick(Action handler)
             // Note that the 'sequence' value is updated later when inserted into the tree
-            => RenderTreeFrame.Attribute(0, "onclick", _ => handler());
+            => RenderTreeFrame.Attribute(0, "onclick", handler != null ? (_ => handler()) : (UIEventHandler)null);
 
         /// <summary>
         /// Handles change events by invoking <paramref name="handler"/>.

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/RenderBatch.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/RenderBatch.cs
@@ -27,14 +27,21 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// </summary>
         public ArrayRange<int> DisposedComponentIDs { get; }
 
+        /// <summary>
+        /// Gets the IDs of the event handlers that were disposed.
+        /// </summary>
+        public ArrayRange<int> DisposedEventHandlerIDs { get; }
+
         internal RenderBatch(
             ArrayRange<RenderTreeDiff> updatedComponents,
             ArrayRange<RenderTreeFrame> referenceFrames,
-            ArrayRange<int> disposedComponentIDs)
+            ArrayRange<int> disposedComponentIDs,
+            ArrayRange<int> disposedEventHandlerIDs)
         {
             UpdatedComponents = updatedComponents;
             ReferenceFrames = referenceFrames;
             DisposedComponentIDs = disposedComponentIDs;
+            DisposedEventHandlerIDs = disposedEventHandlerIDs;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/RenderBatchBuilder.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/RenderBatchBuilder.cs
@@ -45,6 +45,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
             => new RenderBatch(
                 UpdatedComponentDiffs.ToRange(),
                 ReferenceFramesBuffer.ToRange(),
-                DisposedComponentIds.ToRange());
+                DisposedComponentIds.ToRange(),
+                DisposedEventHandlerIds.ToRange());
     }
 }

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
@@ -82,6 +82,30 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         }
 
         [Fact]
+        public void CanAddAndRemoveEventHandlersDynamically()
+        {
+            var appElement = MountTestComponent<CounterComponent>();
+            var countDisplayElement = appElement.FindElement(By.TagName("p"));
+            var incrementButton = appElement.FindElement(By.TagName("button"));
+            var toggleClickHandlerCheckbox = appElement.FindElement(By.CssSelector("[type=checkbox]"));
+
+            // Initial count is zero; clicking button increments count
+            Assert.Equal("Current count: 0", countDisplayElement.Text);
+            incrementButton.Click();
+            Assert.Equal("Current count: 1", countDisplayElement.Text);
+
+            // We can remove an event handler
+            toggleClickHandlerCheckbox.Click();
+            incrementButton.Click();
+            Assert.Equal("Current count: 1", countDisplayElement.Text);
+
+            // We can add an event handler
+            toggleClickHandlerCheckbox.Click();
+            incrementButton.Click();
+            Assert.Equal("Current count: 2", countDisplayElement.Text);
+        }
+
+        [Fact]
         public void CanRenderChildComponents()
         {
             var appElement = MountTestComponent<ParentChildComponent>();

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
@@ -434,7 +434,8 @@ namespace Microsoft.AspNetCore.Blazor.Test
             newTree.CloseElement();
 
             // Act
-            var (result, referenceFrames) = GetSingleUpdatedComponent();
+            var (result, referenceFrames, batch) = GetSingleUpdatedComponentWithBatch(initializeFromFrames: true);
+            var removedEventHandlerFrame = oldTree.GetFrames().Array[2];
 
             // Assert
             Assert.Collection(result.Edits,
@@ -444,6 +445,10 @@ namespace Microsoft.AspNetCore.Blazor.Test
                     Assert.Equal(0, entry.ReferenceFrameIndex);
                 });
             AssertFrame.Attribute(referenceFrames[0], "will change", addedHandler);
+            Assert.NotEqual(0, removedEventHandlerFrame.AttributeEventHandlerId);
+            Assert.Equal(
+                new[] { removedEventHandlerFrame.AttributeEventHandlerId },
+                batch.DisposedEventHandlerIDs);
         }
 
         [Fact]
@@ -1163,7 +1168,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             newTree.CloseElement();
 
             // Act
-            var (result, referenceFrames) = GetSingleUpdatedComponent(initializeFromFrames: true);
+            var (result, referenceFrames, batch) = GetSingleUpdatedComponentWithBatch(initializeFromFrames: true);
             var oldAttributeFrame = oldTree.GetFrames().Array[1];
             var newAttributeFrame = newTree.GetFrames().Array[1];
 
@@ -1173,6 +1178,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             AssertFrame.Attribute(newAttributeFrame, "will remain", retainedHandler);
             Assert.NotEqual(0, oldAttributeFrame.AttributeEventHandlerId);
             Assert.Equal(oldAttributeFrame.AttributeEventHandlerId, newAttributeFrame.AttributeEventHandlerId);
+            Assert.Empty(batch.DisposedEventHandlerIDs);
         }
 
         [Fact]
@@ -1189,7 +1195,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             newTree.CloseElement();
 
             // Act
-            var (result, referenceFrames) = GetSingleUpdatedComponent(initializeFromFrames: true);
+            var (result, referenceFrames, batch) = GetSingleUpdatedComponentWithBatch(initializeFromFrames: true);
             var oldAttributeFrame = oldTree.GetFrames().Array[1];
             var newAttributeFrame = newTree.GetFrames().Array[2];
 
@@ -1199,6 +1205,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             AssertFrame.Attribute(newAttributeFrame, "will remain", retainedHandler);
             Assert.NotEqual(0, oldAttributeFrame.AttributeEventHandlerId);
             Assert.Equal(oldAttributeFrame.AttributeEventHandlerId, newAttributeFrame.AttributeEventHandlerId);
+            Assert.Empty(batch.DisposedEventHandlerIDs);
         }
 
         [Fact]
@@ -1318,10 +1325,16 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
         private (RenderTreeDiff, RenderTreeFrame[]) GetSingleUpdatedComponent(bool initializeFromFrames = false)
         {
+            var result = GetSingleUpdatedComponentWithBatch(initializeFromFrames);
+            return (result.Item1, result.Item2);
+        }
+
+        private (RenderTreeDiff, RenderTreeFrame[], RenderBatch) GetSingleUpdatedComponentWithBatch(bool initializeFromFrames = false)
+        {
             var batch = GetRenderedBatch(initializeFromFrames);
             var diffsInBatch = batch.UpdatedComponents;
             Assert.Equal(1, diffsInBatch.Count);
-            return (diffsInBatch.Array[0], batch.ReferenceFrames.ToArray());
+            return (diffsInBatch.Array[0], batch.ReferenceFrames.ToArray(), batch);
         }
 
         private RenderBatch GetRenderedBatch(bool initializeFromFrames = false)

--- a/test/testapps/BasicTestApp/CounterComponent.cshtml
+++ b/test/testapps/BasicTestApp/CounterComponent.cshtml
@@ -1,9 +1,15 @@
 ﻿<h1>Counter</h1>
 <p>Current count: @currentCount</p>
-<button @onclick(IncrementCount)>Click me</button>
+<p><button @onclick(handleClicks ? IncrementCount : (Action)null)>Click me</button></p>
+
+<label>
+    <input type="checkbox" @bind(handleClicks) />
+    Toggle click handler registration
+</label>
 
 @functions {
     int currentCount = 0;
+    bool handleClicks = true;
 
     void IncrementCount()
     {


### PR DESCRIPTION
Previously the JS-side event-handling code was very rough and temporary. This new version:

 * Supports arbitrary event names
 * Has a cleaner system for us adding event-type-specific data extraction logic corresponding to the .NET side code (see `EventForDotNet.ts`)
 * No longer has to register separate DOM event handlers for every (element,eventName) pair. Now it contains an event delegation system so that each `BrowserRenderer` only has at most one real DOM event handler for each eventName, and dispatches the events based on expando info stored on the DOM elements. It also takes care of registering/unregistering the DOM event handlers according to whether there are any active listeners for that event name. Overall this is much less resource-heavy. It also gives us an easy way to plug in our own event bubbling/cancellation logic later if we want.

**Not yet handled**: We still don't properly handle nested event handlers. For example, if element A contains element B in the DOM, and both A and B have `click` handlers, and you click on `B`, then you'd expect both handlers to run followed by a single render. What actually happens is that the handler for `B` runs, then it does a first render, then it tries to run `A`'s handler which *might* run (if it hasn't been disposed) or it might crash (if it has been disposed). What we should do to to fix this is change the event dispatching logic so that we send an array of all the event handler IDs to be invoked, and then the .NET-side code should run all of them, followed by a single re-render.