### PR TITLE
Auto rebuilds

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/All.props
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/All.props
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <DefaultWebContentItemExcludes>$(DefaultWebContentItemExcludes);wwwroot\**</DefaultWebContentItemExcludes>
 
+    <!-- By default, enable auto rebuilds for debug builds. Note that the server will not enable it in production environments regardless. -->
+    <BlazorRebuildOnFileChange Condition="'$(Configuration)' == 'Debug'">true</BlazorRebuildOnFileChange>
+    
     <!-- We can remove this after updating to newer Razor tooling, where it's enabled by default -->
     <UseRazorBuildServer>true</UseRazorBuildServer>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/All.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/All.targets
@@ -23,6 +23,7 @@
     </PropertyGroup>
     <WriteLinesToFile File="$(BlazorMetadataFilePath)" Lines="$(MSBuildProjectFullPath)" Overwrite="true" Encoding="Unicode"/>
     <WriteLinesToFile File="$(BlazorMetadataFilePath)" Lines="$(OutDir)$(AssemblyName).dll" Overwrite="false" Encoding="Unicode"/>
+    <WriteLinesToFile File="$(BlazorMetadataFilePath)" Condition="'$(BlazorRebuildOnFileChange)'=='true'" Lines="autorebuild:true" Overwrite="false" Encoding="Unicode"/>
     <ItemGroup>
       <ContentWithTargetPath Include="$(BlazorMetadataFilePath)" TargetPath="$(BlazorMetadataFileName)" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/AutoRebuildExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/AutoRebuildExtensions.cs
@@ -46,9 +46,11 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     if (compilationTaskMustBeRefreshedIfNotBuiltSince.HasValue)
                     {
+                        var rebuildIfNotBuiltSince = compilationTaskMustBeRefreshedIfNotBuiltSince.Value;
+                        compilationTaskMustBeRefreshedIfNotBuiltSince = null;
                         currentCompilationTask = rebuildService.PerformRebuildAsync(
                             config.SourceMSBuildPath,
-                            compilationTaskMustBeRefreshedIfNotBuiltSince.Value);
+                            rebuildIfNotBuiltSince);
                     }
 
                     await currentCompilationTask;
@@ -60,10 +62,6 @@ namespace Microsoft.AspNetCore.Builder
                     // There's nowhere useful to log this information so if people report
                     // problems we'll just have to get a repro and debug it.
                     // If it was an error on the VS side, it logs to the output window.
-                }
-                finally
-                {
-                    compilationTaskMustBeRefreshedIfNotBuiltSince = null;
                 }
 
                 await next();

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/AutoRebuildExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/AutoRebuildExtensions.cs
@@ -46,7 +46,6 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     if (compilationTaskMustBeRefreshedIfNotBuiltSince.HasValue)
                     {
-                        compilationTaskMustBeRefreshedIfNotBuiltSince = null;
                         currentCompilationTask = rebuildService.PerformRebuildAsync(
                             config.SourceMSBuildPath,
                             compilationTaskMustBeRefreshedIfNotBuiltSince.Value);
@@ -61,6 +60,10 @@ namespace Microsoft.AspNetCore.Builder
                     // There's nowhere useful to log this information so if people report
                     // problems we'll just have to get a repro and debug it.
                     // If it was an error on the VS side, it logs to the output window.
+                }
+                finally
+                {
+                    compilationTaskMustBeRefreshedIfNotBuiltSince = null;
                 }
 
                 await next();

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/AutoRebuildExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/AutoRebuildExtensions.cs
@@ -46,10 +46,10 @@ namespace Microsoft.AspNetCore.Builder
                 {
                     if (compilationTaskMustBeRefreshedIfNotBuiltSince.HasValue)
                     {
+                        compilationTaskMustBeRefreshedIfNotBuiltSince = null;
                         currentCompilationTask = rebuildService.PerformRebuildAsync(
                             config.SourceMSBuildPath,
                             compilationTaskMustBeRefreshedIfNotBuiltSince.Value);
-                        compilationTaskMustBeRefreshedIfNotBuiltSince = null;
                     }
 
                     await currentCompilationTask;

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/IRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/IRebuildService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
+{
+    /// <summary>
+    /// Represents a mechanism for rebuilding a .NET project. For example, it
+    /// could be a way of signalling to a VS process to perform a build.
+    /// </summary>
+    internal interface IRebuildService
+    {
+        Task<bool> PerformRebuildAsync(string projectFullPath);
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/IRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/IRebuildService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
@@ -11,6 +12,6 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
     /// </summary>
     internal interface IRebuildService
     {
-        Task<bool> PerformRebuildAsync(string projectFullPath);
+        Task<bool> PerformRebuildAsync(string projectFullPath, DateTime ifNotBuiltSince);
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/ProcessUtils.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/ProcessUtils.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
+{
+    internal static class ProcessUtils
+    {
+        // Based on https://stackoverflow.com/a/3346055
+
+        public static Process GetParent(Process process)
+        {
+            var result = new ProcessBasicInformation();
+            var handle = process.Handle;
+            var status = NtQueryInformationProcess(handle, 0, ref result, Marshal.SizeOf(result), out var returnLength);
+            if (status != 0)
+            {
+                throw new Win32Exception(status);
+            }
+
+            try
+            {
+                var parentProcessId = result.InheritedFromUniqueProcessId.ToInt32();
+                return parentProcessId > 0 ? Process.GetProcessById(parentProcessId) : null;
+            }
+            catch (ArgumentException)
+            {
+                return null; // Process not found
+            }
+        }
+
+        [DllImport("ntdll.dll")]
+        private static extern int NtQueryInformationProcess(IntPtr processHandle, int processInformationClass, ref ProcessBasicInformation processInformation, int processInformationLength, out int returnLength);
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct ProcessBasicInformation
+        {
+            // These members must match PROCESS_BASIC_INFORMATION
+            public IntPtr Reserved1;
+            public IntPtr PebBaseAddress;
+            public IntPtr Reserved2_0;
+            public IntPtr Reserved2_1;
+            public IntPtr UniqueProcessId;
+            public IntPtr InheritedFromUniqueProcessId;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/StreamProtocolExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/StreamProtocolExtensions.cs
@@ -29,5 +29,12 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
             await stream.ReadAsync(responseBuf, 0, 1);
             return responseBuf[0] == 1;
         }
+
+        public static async Task<int> ReadIntAsync(this Stream stream)
+        {
+            var responseBuf = new byte[4];
+            await stream.ReadAsync(responseBuf, 0, 4);
+            return BitConverter.ToInt32(responseBuf, 0);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/StreamProtocolExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/StreamProtocolExtensions.cs
@@ -17,6 +17,12 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
             await stream.WriteAsync(utf8Bytes, 0, utf8Bytes.Length);
         }
 
+        public static async Task WriteDateTimeAsync(this Stream stream, DateTime value)
+        {
+            var ticksBytes = BitConverter.GetBytes(value.Ticks);
+            await stream.WriteAsync(ticksBytes, 0, 8);
+        }
+
         public static async Task<bool> ReadBoolAsync(this Stream stream)
         {
             var responseBuf = new byte[1];

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/StreamProtocolExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/StreamProtocolExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
+{
+    internal static class StreamProtocolExtensions
+    {
+        public static async Task WriteStringAsync(this Stream stream, string str)
+        {
+            var utf8Bytes = Encoding.UTF8.GetBytes(str);
+            await stream.WriteAsync(BitConverter.GetBytes(utf8Bytes.Length), 0, 4);
+            await stream.WriteAsync(utf8Bytes, 0, utf8Bytes.Length);
+        }
+
+        public static async Task<bool> ReadBoolAsync(this Stream stream)
+        {
+            var responseBuf = new byte[1];
+            await stream.ReadAsync(responseBuf, 0, 1);
+            return responseBuf[0] == 1;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
     /// </summary>
     internal class VSForWindowsRebuildService : IRebuildService
     {
-        private const int _connectionTimeoutMilliseconds = 1000;
+        private const int _connectionTimeoutMilliseconds = 3000;
         private readonly Process _vsProcess;
 
         public static bool TryCreate(out VSForWindowsRebuildService result)

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
             }
 
             var candidateProcess = Process.GetCurrentProcess();
-            while (candidateProcess != null)
+            while (candidateProcess != null && !candidateProcess.HasExited)
             {
                 // It's unlikely that anyone's going to have a non-VS process in the process
                 // hierarchy called 'devenv', but if that turns out to be a scenario, we could

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
     /// </summary>
     internal class VSForWindowsRebuildService : IRebuildService
     {
+        private const int _connectionTimeoutMilliseconds = 1000;
         private readonly Process _vsProcess;
 
         public static bool TryCreate(out VSForWindowsRebuildService result)
@@ -37,7 +38,7 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
             var pipeName = $"BlazorAutoRebuild\\{_vsProcess.Id}";
             using (var pipeClient = new NamedPipeClientStream(pipeName))
             {
-                await pipeClient.ConnectAsync();
+                await pipeClient.ConnectAsync(_connectionTimeoutMilliseconds);
 
                 // Very simple protocol:
                 //   1. Send the project path to the VS listener

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
+{
+    /// <summary>
+    /// Finds the VS process that launched this app process (if any), and uses
+    /// named pipes to communicate with its AutoRebuild listener (if any).
+    /// </summary>
+    internal class VSForWindowsRebuildService : IRebuildService
+    {
+        private readonly Process _vsProcess;
+
+        public static bool TryCreate(out VSForWindowsRebuildService result)
+        {
+            var vsProcess = FindAncestorVSProcess();
+            if (vsProcess != null)
+            {
+                result = new VSForWindowsRebuildService(vsProcess);
+                return true;
+            }
+            else
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        public async Task<bool> PerformRebuildAsync(string projectFullPath)
+        {
+            var pipeName = $"BlazorAutoRebuild\\{_vsProcess.Id}";
+            using (var pipeClient = new NamedPipeClientStream(pipeName))
+            {
+                await pipeClient.ConnectAsync();
+
+                // Very simple protocol:
+                //   1. Send the project path to the VS listener
+                //   2. Wait for it to send back a bool representing the result
+                // Keep in sync with AutoRebuildService.cs in the BlazorExtension project
+                // In the future we may extend this to getting back build error details
+                await pipeClient.WriteStringAsync(projectFullPath);
+                return await pipeClient.ReadBoolAsync();
+            }
+        }
+
+        private VSForWindowsRebuildService(Process vsProcess)
+        {
+            _vsProcess = vsProcess ?? throw new ArgumentNullException(nameof(vsProcess));
+        }
+
+        private static Process FindAncestorVSProcess()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
+
+            var candidateProcess = Process.GetCurrentProcess();
+            while (candidateProcess != null)
+            {
+                // It's unlikely that anyone's going to have a non-VS process in the process
+                // hierarchy called 'devenv', but if that turns out to be a scenario, we could
+                // (for example) write the VS PID to the obj directory during build, and then
+                // only consider processes with that ID. We still want to be sure there really
+                // is such a process in our ancestor chain, otherwise if you did "dotnet run"
+                // in a command prompt, we'd be confused and think it was launched from VS.
+                if (candidateProcess.ProcessName.Equals("devenv", StringComparison.OrdinalIgnoreCase))
+                {
+                    return candidateProcess;
+                }
+
+                try
+                {
+                    candidateProcess = ProcessUtils.GetParent(candidateProcess);
+                }
+                catch (Exception)
+                {
+                    // There's probably some permissions issue that prevents us from seeing
+                    // further up the ancestor list, so we have to stop looking here.
+                    break;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
             }
         }
 
-        public async Task<bool> PerformRebuildAsync(string projectFullPath)
+        public async Task<bool> PerformRebuildAsync(string projectFullPath, DateTime ifNotBuiltSince)
         {
             var pipeName = $"BlazorAutoRebuild\\{_vsProcess.Id}";
             using (var pipeClient = new NamedPipeClientStream(pipeName))
@@ -41,10 +41,12 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
 
                 // Very simple protocol:
                 //   1. Send the project path to the VS listener
-                //   2. Wait for it to send back a bool representing the result
+                //   2. Send the 'if not rebuilt since' timestamp to the VS listener
+                //   3. Wait for it to send back a bool representing the result
                 // Keep in sync with AutoRebuildService.cs in the BlazorExtension project
                 // In the future we may extend this to getting back build error details
                 await pipeClient.WriteStringAsync(projectFullPath);
+                await pipeClient.WriteDateTimeAsync(ifNotBuiltSince);
                 return await pipeClient.ReadBoolAsync();
             }
         }

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRecompilation.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRecompilation.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Blazor.Server
+{
+    internal static class AutoRecompilation
+    {
+        // TODO: Make this configurable in csproj
+        private static string[] _watchedExtensions = new[] { ".cs", ".cshtml" };
+        private static string[] _excludeSubdirectories = new[] { "obj", "bin" };
+
+        public static void UseAutoRecompilation(this IApplicationBuilder appBuilder, BlazorConfig config)
+        {
+            var currentCompilationTask = Task.CompletedTask;
+            var compilationTaskMustBeRefreshed = false;
+
+            WatchFileSystem(config, () =>
+            {
+                // Don't start the recompilation immediately. We only start it when the next
+                // HTTP request arrives, because it's annoying if the IDE is constantly rebuilding
+                // when you're making changes to multiple files and aren't ready to reload
+                // in the browser yet.
+                compilationTaskMustBeRefreshed = true;
+            });
+
+            appBuilder.Use(async (context, next) =>
+            {
+                if (compilationTaskMustBeRefreshed)
+                {
+                    currentCompilationTask = Recompile(config);
+                    compilationTaskMustBeRefreshed = false;
+                }
+
+                await currentCompilationTask;
+                await next();
+            });
+        }
+
+        private static Task Recompile(BlazorConfig config)
+        {
+            var tcs = new TaskCompletionSource<object>();
+
+            new Thread(() =>
+            {
+                // TODO: Perform the build inside VS instead of as a command-line build
+                // TODO: Capture build errors/timeouts and show them in the browser
+                var proc = Process.Start(new ProcessStartInfo
+                {
+                    WorkingDirectory = Path.GetDirectoryName(config.SourceMSBuildPath),
+                    FileName = "dotnet",
+                    Arguments = "build --no-restore --no-dependencies " + Path.GetFileName(config.SourceMSBuildPath),
+                });
+                proc.WaitForExit(60 * 1000);
+                tcs.SetResult(new object());
+            }).Start();
+
+            return tcs.Task;
+        }
+
+        private static void WatchFileSystem(BlazorConfig config, Action onWrite)
+        {
+            var clientAppRootDir = Path.GetDirectoryName(config.SourceMSBuildPath);
+            var excludePathPrefixes = _excludeSubdirectories.Select(subdir
+                => Path.Combine(clientAppRootDir, subdir) + Path.DirectorySeparatorChar);
+
+            var fsw = new FileSystemWatcher(clientAppRootDir);
+            fsw.Created += OnEvent;
+            fsw.Changed += OnEvent;
+            fsw.Deleted += OnEvent;
+            fsw.Renamed += OnEvent;
+            fsw.IncludeSubdirectories = true;
+            fsw.EnableRaisingEvents = true;
+
+            void OnEvent(object sender, FileSystemEventArgs eventArgs)
+            {
+                if (!File.Exists(eventArgs.FullPath))
+                {
+                    // It's probably a directory rather than a file
+                    return;
+                }
+
+                if (!_watchedExtensions.Any(ext => eventArgs.Name.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+                {
+                    // Not a candiate file type
+                    return;
+                }
+
+                if (excludePathPrefixes.Any(prefix => eventArgs.FullPath.StartsWith(prefix, StringComparison.Ordinal)))
+                {
+                    // In an excluded subdirectory
+                    return;
+                }
+
+                onWrite();
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
@@ -49,9 +49,7 @@ namespace Microsoft.AspNetCore.Builder
                 OnPrepareResponse = SetCacheHeaders
             };
 
-            // TODO: Make it toggleable in the client app's csproj, e.g., by writing the setting
-            // to BlazorConfig. Also keep the IsDevelopment check.
-            if (env.IsDevelopment())
+            if (env.IsDevelopment() && config.EnableAutoRebuilding)
             {
                 applicationBuilder.UseAutoRebuild(config);
             }

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
@@ -49,6 +49,13 @@ namespace Microsoft.AspNetCore.Builder
                 OnPrepareResponse = SetCacheHeaders
             };
 
+            // TODO: Make it toggleable in the client app's csproj, e.g., by writing the setting
+            // to BlazorConfig. Also keep the IsDevelopment check.
+            if (env.IsDevelopment())
+            {
+                applicationBuilder.UseAutoRecompilation(config);
+            }
+
             // First, match the request against files in the client app dist directory
             applicationBuilder.UseStaticFiles(distDirStaticFiles);
 

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Builder
             // to BlazorConfig. Also keep the IsDevelopment check.
             if (env.IsDevelopment())
             {
-                applicationBuilder.UseAutoRecompilation(config);
+                applicationBuilder.UseAutoRebuild(config);
             }
 
             // First, match the request against files in the client app dist directory

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorConfig.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorConfig.cs
@@ -14,6 +14,7 @@ namespace Microsoft.AspNetCore.Blazor.Server
         public string WebRootPath { get; }
         public string DistPath
             => Path.Combine(Path.GetDirectoryName(SourceOutputAssemblyPath), "dist");
+        public bool EnableAutoRebuilding { get; }
 
         public static BlazorConfig Read(string assemblyPath)
             => new BlazorConfig(assemblyPath);
@@ -41,6 +42,8 @@ namespace Microsoft.AspNetCore.Blazor.Server
             {
                 WebRootPath = webRootPath;
             }
+
+            EnableAutoRebuilding = configLines.Contains("autorebuild:true", StringComparer.Ordinal);
         }
     }
 }

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/AutoRebuildService.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/AutoRebuildService.cs
@@ -3,10 +3,11 @@
 
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Package = Microsoft.VisualStudio.Shell.Package;
@@ -20,18 +21,11 @@ namespace Microsoft.VisualStudio.BlazorExtension
     /// </summary>
     internal class AutoRebuildService
     {
-        private readonly IVsSolution _vsSolution;
-        private readonly IVsSolutionBuildManager _vsBuildManager;
         private readonly BuildEventsWatcher _buildEventsWatcher;
         private readonly string _pipeName;
 
-        public AutoRebuildService(
-            IVsSolution vsSolution,
-            IVsSolutionBuildManager vsBuildManager,
-            BuildEventsWatcher buildEventsWatcher)
+        public AutoRebuildService(BuildEventsWatcher buildEventsWatcher)
         {
-            _vsSolution = vsSolution ?? throw new ArgumentNullException(nameof(vsSolution));
-            _vsBuildManager = vsBuildManager ?? throw new ArgumentNullException(nameof(vsBuildManager));
             _buildEventsWatcher = buildEventsWatcher ?? throw new ArgumentNullException(nameof(buildEventsWatcher));
             _pipeName = $"BlazorAutoRebuild\\{Process.GetCurrentProcess().Id}";
         }
@@ -69,54 +63,14 @@ namespace Microsoft.VisualStudio.BlazorExtension
         {
             // Very simple protocol:
             //   1. Receive the project path from the server instance
-            //   2. Perform the build, then send back the success/failure result flag
+            //   2. Receive the "if not built since" timestamp from the server instance
+            //   3. Perform the build, then send back the success/failure result flag
             // Keep in sync with VSForWindowsRebuildService.cs in the Blazor.Server project
             // In the future we may extend this to getting back build error details
             var projectPath = await stream.ReadStringAsync();
-            var buildResult = await PerformBuildAsync(projectPath);
+            var allowExistingBuildsSince = await stream.ReadDateTimeAsync();
+            var buildResult = await _buildEventsWatcher.PerformBuildAsync(projectPath, allowExistingBuildsSince);
             await stream.WriteBoolAsync(buildResult);
-        }
-
-        private async Task<bool> PerformBuildAsync(string projectPath)
-        {
-            // First get a task that represents the next build completion for this project.
-            // We do this before asking for the build in case the build completes instantly.
-            var projectBuildTask = _buildEventsWatcher.GetNextBuildResultAsync(projectPath);
-
-            // Now switch to the UI thread and request the build
-            var didStartBuild = await ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                var hr = _vsSolution.GetProjectOfUniqueName(projectPath, out var hierarchy);
-                if (hr != VSConstants.S_OK)
-                {
-                    return false;
-                }
-
-                hr = _vsBuildManager.StartSimpleUpdateProjectConfiguration(
-                    hierarchy,
-                    /* not used */ null,
-                    /* not used */ null,
-                    (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD,
-                    /* other flags */ 0,
-                    /* suppress dialogs */ 1);
-                if (hr != VSConstants.S_OK)
-                {
-                    return false;
-                }
-
-                return true;
-            });
-
-            // If we didn't manage to start a build, then there's no point continuing to
-            // hold the pending build task in memory
-            if (!didStartBuild)
-            {
-                _buildEventsWatcher.DiscardPendingBuildTask(projectBuildTask);
-            }
-
-            return didStartBuild && await projectBuildTask;
         }
 
         private async Task AttemptLogErrorAsync(string message)

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/AutoRebuildService.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/AutoRebuildService.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Package = Microsoft.VisualStudio.Shell.Package;
+using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
+
+namespace Microsoft.VisualStudio.BlazorExtension
+{
+    /// <summary>
+    /// The counterpart to VSForWindowsRebuildService.cs in the Blazor.Server project.
+    /// Listens for named pipe connections and rebuilds projects on request.
+    /// </summary>
+    internal class AutoRebuildService
+    {
+        private readonly IVsSolution _vsSolution;
+        private readonly IVsSolutionBuildManager _vsBuildManager;
+        private readonly BuildEventsWatcher _buildEventsWatcher;
+        private readonly string _pipeName;
+
+        public AutoRebuildService(
+            IVsSolution vsSolution,
+            IVsSolutionBuildManager vsBuildManager,
+            BuildEventsWatcher buildEventsWatcher)
+        {
+            _vsSolution = vsSolution ?? throw new ArgumentNullException(nameof(vsSolution));
+            _vsBuildManager = vsBuildManager ?? throw new ArgumentNullException(nameof(vsBuildManager));
+            _buildEventsWatcher = buildEventsWatcher ?? throw new ArgumentNullException(nameof(buildEventsWatcher));
+            _pipeName = $"BlazorAutoRebuild\\{Process.GetCurrentProcess().Id}";
+        }
+
+        public void Listen()
+        {
+            AddBuildServiceNamedPipeServer();
+        }
+
+        private void AddBuildServiceNamedPipeServer()
+        {
+            Task.Factory.StartNew(async () =>
+            {
+                try
+                {
+                    using (var serverPipe = new NamedPipeServerStream(_pipeName, PipeDirection.InOut, NamedPipeServerStream.MaxAllowedServerInstances))
+                    {
+                        // As soon as we receive a connection, spin up another background
+                        // listener to wait for the next connection
+                        await serverPipe.WaitForConnectionAsync();
+                        AddBuildServiceNamedPipeServer();
+
+                        await HandleRequestAsync(serverPipe);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    await AttemptLogErrorAsync(
+                        $"Error in Blazor AutoRebuildService:\n{ex.Message}\n{ex.StackTrace}");
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        private async Task HandleRequestAsync(Stream stream)
+        {
+            // Very simple protocol:
+            //   1. Receive the project path from the server instance
+            //   2. Perform the build, then send back the success/failure result flag
+            // Keep in sync with VSForWindowsRebuildService.cs in the Blazor.Server project
+            // In the future we may extend this to getting back build error details
+            var projectPath = await stream.ReadStringAsync();
+            var buildResult = await PerformBuildAsync(projectPath);
+            await stream.WriteBoolAsync(buildResult);
+        }
+
+        private async Task<bool> PerformBuildAsync(string projectPath)
+        {
+            // First get a task that represents the next build completion for this project.
+            // We do this before asking for the build in case the build completes instantly.
+            var projectBuildTask = _buildEventsWatcher.GetNextBuildResultAsync(projectPath);
+
+            // Now switch to the UI thread and request the build
+            var didStartBuild = await ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                var hr = _vsSolution.GetProjectOfUniqueName(projectPath, out var hierarchy);
+                if (hr != VSConstants.S_OK)
+                {
+                    return false;
+                }
+
+                hr = _vsBuildManager.StartSimpleUpdateProjectConfiguration(
+                    hierarchy,
+                    /* not used */ null,
+                    /* not used */ null,
+                    (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD,
+                    /* other flags */ 0,
+                    /* suppress dialogs */ 1);
+                if (hr != VSConstants.S_OK)
+                {
+                    return false;
+                }
+
+                return true;
+            });
+
+            // If we didn't manage to start a build, then there's no point continuing to
+            // hold the pending build task in memory
+            if (!didStartBuild)
+            {
+                _buildEventsWatcher.DiscardPendingBuildTask(projectBuildTask);
+            }
+
+            return didStartBuild && await projectBuildTask;
+        }
+
+        private async Task AttemptLogErrorAsync(string message)
+        {
+            if (!ThreadHelper.CheckAccess())
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            }
+
+            var outputWindow = (IVsOutputWindow)Package.GetGlobalService(typeof(SVsOutputWindow));
+            if (outputWindow != null)
+            {
+                outputWindow.GetPane(VSConstants.OutputWindowPaneGuid.BuildOutputPane_guid, out var pane);
+                if (pane != null)
+                {
+                    pane.OutputString(message);
+                    pane.Activate();
+                }
+            }
+        }
+    }
+}

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/BuildEventsWatcher.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/BuildEventsWatcher.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.BlazorExtension
+{
+    internal class BuildEventsWatcher : IVsUpdateSolutionEvents2
+    {
+        // TODO: Also track "last build" timestamp for each project, and then amend
+        // the protocol to "build project <path> if not built since <timestamp>"
+        // where <timestamp> comes from the FSW change event (so that if you build
+        // manually, you don't have to wait for a further rebuild)
+
+        private object pendingBuildResultTasksLock = new object();
+        private List<PendingBuildResultTask> pendingBuildResultTasks = new List<PendingBuildResultTask>();
+
+        public int UpdateSolution_Begin(ref int pfCancelUpdate)
+           => VSConstants.S_OK;
+
+        public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
+           => VSConstants.S_OK;
+
+        public int UpdateSolution_StartUpdate(ref int pfCancelUpdate)
+           => VSConstants.S_OK;
+
+        public int UpdateSolution_Cancel()
+           => VSConstants.S_OK;
+
+        public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy)
+           => VSConstants.S_OK;
+
+        public int UpdateProjectCfg_Begin(IVsHierarchy pHierProj, IVsCfg pCfgProj, IVsCfg pCfgSln, uint dwAction, ref int pfCancel)
+           => VSConstants.S_OK;
+
+        public int UpdateProjectCfg_Done(IVsHierarchy pHierProj, IVsCfg pCfgProj, IVsCfg pCfgSln, uint dwAction, int fSuccess, int fCancel)
+        {
+            var buildResult = fSuccess == 1;
+            var ctx = (IVsBrowseObjectContext)pCfgProj;
+            var projectPath = ctx.UnconfiguredProject.FullPath;
+            foreach (var pendingBuildTask in GetAndRemovePendingBuildTasks(projectPath))
+            {
+                pendingBuildTask.TaskCompletionSource.SetResult(buildResult);
+            }
+
+            return VSConstants.S_OK;
+        }
+
+        private IEnumerable<PendingBuildResultTask> GetAndRemovePendingBuildTasks(string projectPath)
+        {
+            lock (pendingBuildResultTasksLock)
+            {
+                if (pendingBuildResultTasks.Count == 0)
+                {
+                    return Enumerable.Empty<PendingBuildResultTask>();
+                }
+
+                var result = new List<PendingBuildResultTask>();
+
+                for (var index = 0; index < pendingBuildResultTasks.Count; index++)
+                {
+                    var candidate = pendingBuildResultTasks[index];
+                    if (candidate.ProjectPath.Equals(projectPath, StringComparison.Ordinal))
+                    {
+                        result.Add(candidate);
+                        pendingBuildResultTasks.RemoveAt(index);
+                        index--;
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        public Task<bool> GetNextBuildResultAsync(string projectPath)
+        {
+            var pendingBuildResultTask = new PendingBuildResultTask(projectPath);
+            lock (pendingBuildResultTasksLock)
+            {
+                pendingBuildResultTasks.Add(pendingBuildResultTask);
+            }
+            return pendingBuildResultTask.TaskCompletionSource.Task;
+        }
+
+        public void DiscardPendingBuildTask(Task<bool> projectBuildTask)
+        {
+            lock (pendingBuildResultTasksLock)
+            {
+                pendingBuildResultTasks.RemoveAll(x => x.TaskCompletionSource.Task == projectBuildTask);
+            }
+        }
+
+        class PendingBuildResultTask
+        {
+            public string ProjectPath { get; }
+            public TaskCompletionSource<bool> TaskCompletionSource { get; }
+
+            public PendingBuildResultTask(string projectPath)
+            {
+                ProjectPath = projectPath;
+                TaskCompletionSource = new TaskCompletionSource<bool>();
+            }
+        }
+    }
+}

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/BuildEventsWatcher.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/BuildEventsWatcher.cs
@@ -19,7 +19,8 @@ namespace Microsoft.VisualStudio.BlazorExtension
         private readonly IVsSolution _vsSolution;
         private readonly IVsSolutionBuildManager _vsBuildManager;
         private readonly object mostRecentBuildInfosLock = new object();
-        private readonly Dictionary<string, BuildInfo> mostRecentBuildInfos = new Dictionary<string, BuildInfo>();
+        private readonly Dictionary<string, BuildInfo> mostRecentBuildInfos
+            = new Dictionary<string, BuildInfo>(StringComparer.OrdinalIgnoreCase);
 
         public BuildEventsWatcher(IVsSolution vsSolution, IVsSolutionBuildManager vsBuildManager)
         {

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/StreamProtocolExtensions.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/StreamProtocolExtensions.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.BlazorExtension
+{
+    internal static class StreamProtocolExtensions
+    {
+        public static async Task<string> ReadStringAsync(this Stream stream)
+        {
+            var length = BitConverter.ToInt32(await ReadBytesAsync(stream, 4), 0);
+            var utf8Bytes = await ReadBytesAsync(stream, length);
+            return Encoding.UTF8.GetString(utf8Bytes);
+        }
+
+        public static async Task WriteBoolAsync(this Stream stream, bool value)
+        {
+            var byteVal = value ? (byte)1 : (byte)0;
+            await stream.WriteAsync(new[] { byteVal }, 0, 1);
+        }
+
+        private static async Task<byte[]> ReadBytesAsync(Stream stream, int exactLength)
+        {
+            var buf = new byte[exactLength];
+            var bytesRead = 0;
+            while (bytesRead < exactLength)
+            {
+                bytesRead += await stream.ReadAsync(buf, bytesRead, exactLength - bytesRead);
+            }
+            return buf;
+        }
+    }
+}

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/StreamProtocolExtensions.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/StreamProtocolExtensions.cs
@@ -30,6 +30,11 @@ namespace Microsoft.VisualStudio.BlazorExtension
             await stream.WriteAsync(new[] { byteVal }, 0, 1);
         }
 
+        public static async Task WriteIntAsync(this Stream stream, int value)
+        {
+            await stream.WriteAsync(BitConverter.GetBytes(value), 0, 4);
+        }
+
         private static async Task<byte[]> ReadBytesAsync(Stream stream, int exactLength)
         {
             var buf = new byte[exactLength];

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/StreamProtocolExtensions.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/AutoRebuild/StreamProtocolExtensions.cs
@@ -17,6 +17,13 @@ namespace Microsoft.VisualStudio.BlazorExtension
             return Encoding.UTF8.GetString(utf8Bytes);
         }
 
+        public static async Task<DateTime> ReadDateTimeAsync(this Stream stream)
+        {
+            var ticksBytes = await ReadBytesAsync(stream, 8);
+            var ticks = BitConverter.ToInt64(ticksBytes, 0);
+            return new DateTime(ticks);
+        }
+
         public static async Task WriteBoolAsync(this Stream stream, bool value)
         {
             var byteVal = value ? (byte)1 : (byte)0;

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/BlazorPackage.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/BlazorPackage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.BlazorExtension
 {
@@ -11,8 +12,30 @@ namespace Microsoft.VisualStudio.BlazorExtension
     [PackageRegistration(UseManagedResourcesOnly = true)]
     [AboutDialogInfo(PackageGuidString, "ASP.NET Core Blazor Language Services", "#110", "112")]
     [Guid(BlazorPackage.PackageGuidString)]
+    [ProvideAutoLoad(UIContextGuids80.SolutionExists)]
     public sealed class BlazorPackage : Package
     {
         public const string PackageGuidString = "d9fe04bc-57a7-4107-915e-3a5c2f9e19fb";
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+            RegisterAutoRebuildService();
+        }
+
+        private void RegisterAutoRebuildService()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // Create build watcher. No need to unadvise, as this only happens once anyway.
+            var buildWatcher = new BuildEventsWatcher();
+            var buildManager = (IVsSolutionBuildManager)GetService(typeof(SVsSolutionBuildManager));
+            var hr = buildManager.AdviseUpdateSolutionEvents(buildWatcher, out var cookie);
+            Marshal.ThrowExceptionForHR(hr);
+
+            // Create AutoRebuildService
+            var solution = (IVsSolution)GetGlobalService(typeof(IVsSolution));
+            new AutoRebuildService(solution, buildManager, buildWatcher).Listen();
+        }
     }
 }

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/BlazorPackage.cs
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/BlazorPackage.cs
@@ -28,14 +28,13 @@ namespace Microsoft.VisualStudio.BlazorExtension
             ThreadHelper.ThrowIfNotOnUIThread();
 
             // Create build watcher. No need to unadvise, as this only happens once anyway.
-            var buildWatcher = new BuildEventsWatcher();
+            var solution = (IVsSolution)GetGlobalService(typeof(IVsSolution));
             var buildManager = (IVsSolutionBuildManager)GetService(typeof(SVsSolutionBuildManager));
+            var buildWatcher = new BuildEventsWatcher(solution, buildManager);
             var hr = buildManager.AdviseUpdateSolutionEvents(buildWatcher, out var cookie);
             Marshal.ThrowExceptionForHR(hr);
 
-            // Create AutoRebuildService
-            var solution = (IVsSolution)GetGlobalService(typeof(IVsSolution));
-            new AutoRebuildService(solution, buildManager, buildWatcher).Listen();
+            new AutoRebuildService(buildWatcher).Listen();
         }
     }
 }

--- a/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
+++ b/tooling/Microsoft.VisualStudio.BlazorExtension/Microsoft.VisualStudio.BlazorExtension.csproj
@@ -250,6 +250,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AboutDialogInfoAttribute.cs" />
+    <Compile Include="AutoRebuild\AutoRebuildService.cs" />
+    <Compile Include="AutoRebuild\BuildEventsWatcher.cs" />
+    <Compile Include="AutoRebuild\StreamProtocolExtensions.cs" />
     <Compile Include="BlazorPackage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
New approach to replace the didn't-work-properly live reloading system. The new approach is equivalent to how VS auto-rebuilds ASP.NET when you edit a `.cs` file and then begin a new HTTP request to the site.

Currently this only supports VS for Windows, and in other scenarios doesn't auto-rebuild. But the design allows for additional `IRebuildService` implementations such as VS for Mac (and arguably "command line", though I'm not sure that's a good idea because builds are not fast that way).