### PR TITLE
Show templates in VS for ASP.NET 2.0 and 2.1

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/.template.config/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/.template.config/template.json
@@ -73,10 +73,14 @@
         {
           "choice": "netcoreapp2.0",
           "description": "Target netcoreapp2.0"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
-      "replaces": "netcoreapp2.0",
-      "defaultValue": "netcoreapp2.0"
+      "replaces": "netcoreapp2.1",
+      "defaultValue": "netcoreapp2.1"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/BlazorHosted.CSharp.Client.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/BlazorHosted.CSharp.Client.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.0-preview2-final" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.2.0-preview1-10189" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.2.0-preview1-10189" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.2.0-preview1-10195" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.2.0-preview1-10195" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Server/BlazorHosted.CSharp.Server.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Server/BlazorHosted.CSharp.Server.csproj
@@ -9,11 +9,11 @@
 
   <ItemGroup Condition="'$(Framework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-preview2-final" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.2.0-preview1-10189" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.2.0-preview1-10195" />
   </ItemGroup>
   <ItemGroup Condition="'$(Framework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.2.0-preview1-10189" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.2.0-preview1-10195" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Server/BlazorHosted.CSharp.Server.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Server/BlazorHosted.CSharp.Server.csproj
@@ -1,13 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <!-- This custom package feed is required only when using nightly builds of Blazor -->
     <RestoreSources>$(RestoreSources);https://dotnet.myget.org/f/blazor-dev/api/v3/index.json</RestoreSources>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(Framework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.2.0-preview1-10189" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Framework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.2.0-preview1-10189" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Server/BlazorHosted.CSharp.Server.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Server/BlazorHosted.CSharp.Server.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(Framework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-preview2-final" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.2.0-preview1-10189" />
   </ItemGroup>
   <ItemGroup Condition="'$(Framework)' == 'netcoreapp2.0'">

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/global.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.1.300-preview1-008174"
+    "version": "2.1.300-preview2-008530"
   }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary.CSharp/.template.config/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary.CSharp/.template.config/template.json
@@ -34,10 +34,14 @@
         {
           "choice": "netcoreapp2.0",
           "description": "Target netcoreapp2.0"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
-      "replaces": "netcoreapp2.0",
-      "defaultValue": "netcoreapp2.0"
+      "replaces": "netcoreapp2.1",
+      "defaultValue": "netcoreapp2.1"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary.CSharp/BlazorLibrary.CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary.CSharp/BlazorLibrary.CSharp.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.0-preview2-final" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.2.0-preview1-10189" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.2.0-preview1-10189" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.2.0-preview1-10195" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.2.0-preview1-10195" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/.template.config/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/.template.config/template.json
@@ -34,10 +34,14 @@
         {
           "choice": "netcoreapp2.0",
           "description": "Target netcoreapp2.0"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
-      "replaces": "netcoreapp2.0",
-      "defaultValue": "netcoreapp2.0"
+      "replaces": "netcoreapp2.1",
+      "defaultValue": "netcoreapp2.1"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/BlazorStandalone.CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/BlazorStandalone.CSharp.csproj
@@ -11,9 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.0-preview2-final" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.2.0-preview1-10189" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.2.0-preview1-10189" />
-    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.2.0-preview1-10189" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.2.0-preview1-10195" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.2.0-preview1-10195" />
+    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.2.0-preview1-10195" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/global.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.1.300-preview1-008174"
+    "version": "2.1.300-preview2-008530"
   }
 }


### PR DESCRIPTION
Supersedes #465 

Note that whichever of ASP.NET Core 2.0 or 2.1 the developer picks, they still get a `global.json` that locks them to SDK `2.1.300-preview1-008174` (i.e., the released build of preview 1). When I checked, it works fine for both, but @rynowak, do you have any reason to believe this is wrong?