### PR TITLE
SimpleJson: more informative exception when attempting to deserialize object with non-empty constructor

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Json/SimpleJson/SimpleJson.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Json/SimpleJson/SimpleJson.cs
@@ -1430,7 +1430,13 @@ namespace SimpleJson
                             obj = value;
                         else
                         {
-                            obj = ConstructorCache[type]();
+                            try{
+                                obj = ConstructorCache[type](); 
+                            }
+                            catch(NullReferenceException)
+                            {
+                                throw new InvalidOperationException($"Objects must have a constructorless parameter to deserialize. Offending type '{type}'");
+                            }
                             foreach (KeyValuePair<string, KeyValuePair<Type, ReflectionUtils.SetDelegate>> setter in SetCache[type])
                             {
                                 object jsonValue;

--- a/src/Microsoft.AspNetCore.Blazor/Json/SimpleJson/SimpleJson.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Json/SimpleJson/SimpleJson.cs
@@ -1430,12 +1430,13 @@ namespace SimpleJson
                             obj = value;
                         else
                         {
-                            try{
+                            try
+                            {
                                 obj = ConstructorCache[type](); 
                             }
-                            catch(NullReferenceException)
+                            catch (NullReferenceException)
                             {
-                                throw new InvalidOperationException($"Objects must have a constructorless parameter to deserialize. Offending type '{type}'");
+                                throw new InvalidOperationException($"Cannot deserialize JSON into type '{type.FullName}' because it does not have a public parameterless constructor.");
                             }
                             foreach (KeyValuePair<string, KeyValuePair<Type, ReflectionUtils.SetDelegate>> setter in SetCache[type])
                             {

--- a/test/Microsoft.AspNetCore.Blazor.Test/JsonUtilTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/JsonUtilTest.cs
@@ -113,6 +113,33 @@ namespace Microsoft.AspNetCore.Blazor.Test
             Assert.Equal(1, simpleError.NullableIntProperty);
         }
 
+        [Fact]
+        public void NonEmptyConstructorThrowsUsefulException()
+        {
+            // Arrange
+            var json = "{\"Property\":1}";
+            var type = typeof(NonEmptyConstructorPoco);
+
+            // Act
+            var exception = Record.Exception(() => 
+            {
+                JsonUtil.Deserialize<NonEmptyConstructorPoco>(json); 
+            });
+
+            // Assert
+            Assert.IsType<InvalidOperationException>(exception);
+            Assert.Equal(
+                $"Cannot deserialize JSON into type '{type.FullName}' because it does not have a public parameterless constructor.", 
+                exception.Message);
+        }
+
+        class NonEmptyConstructorPoco
+        {
+            public NonEmptyConstructorPoco(int parameter) {}
+
+            public int Property { get; set; }
+        }
+
         struct SimpleStruct
         {
             public string StringProperty { get; set; }


### PR DESCRIPTION
This is in response to #578.  Although Simple JSON will possibly be replaced in the future, I figured for now this more informative exception message may prevent future issues from being created.