### PR TITLE
Fix line endings on OSX

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Force LF for package-lock files - not all version of NPM detect line endings.
 package-lock.json text eol=lf
+
+# Use windows line endings in baselines to minimize churn to baseline files
+TestFiles/** text eol=crlf

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorBaselineIntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorBaselineIntegrationTestBase.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             {
                 var baselineFullPath = Path.Combine(TestProjectRoot, baselineFilePath);
                 Directory.CreateDirectory(Path.GetDirectoryName(baselineFullPath));
-                File.WriteAllText(baselineFullPath, IntermediateNodeSerializer.Serialize(document));
+                WriteBaseline(IntermediateNodeSerializer.Serialize(document), baselineFullPath);
 
                 return;
             }
@@ -86,13 +86,13 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             {
                 var baselineFullPath = Path.Combine(TestProjectRoot, baselineFilePath);
                 Directory.CreateDirectory(Path.GetDirectoryName(baselineFullPath));
-                File.WriteAllText(baselineFullPath, document.GeneratedCode);
+                WriteBaseline(document.GeneratedCode, baselineFullPath);
 
                 var baselineDiagnosticsFullPath = Path.Combine(TestProjectRoot, baselineDiagnosticsFilePath);
                 var lines = document.Diagnostics.Select(RazorDiagnosticSerializer.Serialize).ToArray();
                 if (lines.Any())
                 {
-                    File.WriteAllLines(baselineDiagnosticsFullPath, lines);
+                    WriteBaseline(lines, baselineDiagnosticsFullPath);
                 }
                 else if (File.Exists(baselineDiagnosticsFullPath))
                 {
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
                 var text = SourceMappingsSerializer.Serialize(document, codeDocument.Source);
                 if (!string.IsNullOrEmpty(text))
                 {
-                    File.WriteAllText(baselineMappingsFullPath, text);
+                    WriteBaseline(text, baselineMappingsFullPath);
                 }
                 else if (File.Exists(baselineMappingsFullPath))
                 {
@@ -174,6 +174,28 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             }
 
             return Path.Combine(DirectoryPath, Path.ChangeExtension(fileName, extension));
+        }
+
+
+        private static void WriteBaseline(string text, string filePath)
+        {
+            var lines = text.Split(new char[]{ '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            WriteBaseline(lines, filePath);
+        }
+
+        private static void WriteBaseline(string[] lines, string filePath)
+        {
+            using (var writer = new StreamWriter(File.Open(filePath, FileMode.Create)))
+            {
+                // Force windows-style line endings so that we're consistent. This isn't
+                // required for correctness, but will prevent churcn when developing on OSX.
+                writer.NewLine = "\r\n";
+
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    writer.WriteLine(lines[i]);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This change makes our baseline system use CRLF for line endings end to
end. This isn't needed for correctness, but it helps with quality of
life when developing on OSX.

This will avoid churn to the baseline files related to line endings when
updating.

This might only take effect if you nuke the TestFiles directory and
check it out again.