### PR TITLE
Added VSIISExeLauncher autorebuild support.

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
             try
             {
                 var vsProcess = Process.GetProcessById(owningPid);
-                if (vsProcess != null && !vsProcess.HasExited)
+                if (vsProcess != null && vsProcess.ProcessName.Equals("devenv", StringComparison.OrdinalIgnoreCase) && !vsProcess.HasExited)
                     return vsProcess;
             }
             catch (Exception)

--- a/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/AutoRebuild/VSForWindowsRebuildService.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.IO.Pipes;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
@@ -68,6 +71,46 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
             _vsProcess = vsProcess ?? throw new ArgumentNullException(nameof(vsProcess));
         }
 
+        private static Process FindIISHostedVSProcess(Process VSIISExeLauncher)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return null;
+            }
+
+            var launcherDirectory = Path.GetDirectoryName(VSIISExeLauncher.MainModule.FileName);
+
+            //Assuming default IISLauncherArgs.txt filename
+            var IISExeLauncherArgs = Path.Combine(launcherDirectory, "IISExeLauncherArgs.txt");
+            if (!File.Exists(IISExeLauncherArgs))
+                return null;
+
+            string args = File.ReadAllText(IISExeLauncherArgs);
+            Match m = Regex.Match(args, @"-owningPid (?<Pid>[0-9]+)");
+
+            int owningPid = 0;
+            if (!int.TryParse(m.Groups["Pid"]?.Value, out owningPid))
+            {
+                return null;
+            }
+
+            try
+            {
+                var vsProcess = Process.GetProcessById(owningPid);
+                if (vsProcess != null && !vsProcess.HasExited)
+                    return vsProcess;
+            }
+            catch (Exception)
+            {
+                // There's probably some permissions issue that prevents us from seeing
+                // more information about devenv process. The used service account in IIS
+                // may not be in the administrator group, and lack of privilege.
+            }
+
+            //If no process were found or if the devenv process exited, then there is no eligible PID
+            return null;
+        }
+
         private static Process FindAncestorVSProcess()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -89,6 +132,18 @@ namespace Microsoft.AspNetCore.Blazor.Server.AutoRebuild
                     if (candidateProcess.ProcessName.Equals("devenv", StringComparison.OrdinalIgnoreCase))
                     {
                         return candidateProcess;
+                    }
+
+                    // The currently debuggable process may be launched from the VSIISExeLauncher program
+                    // if hosted in IIS with Visual Studio IIS continuous integration. In this scenario we
+                    // retrieve VS PID (devenv) from IISExeLauncherArgs.txt file, in owningPid option.
+                    if (candidateProcess.ProcessName.Equals("VSIISExeLauncher", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var hostedVSProcess = FindIISHostedVSProcess(candidateProcess);
+                        if (hostedVSProcess != null)
+                        {
+                            return hostedVSProcess;
+                        }
                     }
 
                     candidateProcess = ProcessUtils.GetParent(candidateProcess);

--- a/src/Microsoft.AspNetCore.Blazor/Components/BindMethods.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BindMethods.cs
@@ -77,6 +77,30 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// <summary>
         /// Not intended to be used directly.
         /// </summary>
+        public static UIEventHandler SetValueHandler(Action<double> setter, double existingValue)
+        {
+            return _ => setter(double.Parse((string)((UIChangeEventArgs)_).Value));
+        }
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static UIEventHandler SetValueHandler(Action<float> setter, float existingValue)
+        {
+            return _ => setter(float.Parse((string)((UIChangeEventArgs)_).Value));
+        }
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static UIEventHandler SetValueHandler(Action<decimal> setter, decimal existingValue)
+        {
+            return _ => setter(decimal.Parse((string)((UIChangeEventArgs)_).Value));
+        }
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
         public static UIEventHandler SetValueHandler(Action<DateTime> setter, DateTime existingValue)
         {
             return _ => SetDateTimeValue(setter, (object)((UIChangeEventArgs)_).Value, null);
@@ -125,6 +149,24 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// </summary>
         public static Action<object> SetValue(Action<int> setter, int existingValue)
             => objValue => setter(int.Parse((string)objValue));
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static Action<object> SetValue(Action<double> setter, double existingValue)
+            => objValue => setter(double.Parse((string)objValue));
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static Action<object> SetValue(Action<float> setter, float existingValue)
+            => objValue => setter(float.Parse((string)objValue));
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static Action<object> SetValue(Action<decimal> setter, decimal existingValue)
+            => objValue => setter(decimal.Parse((string)objValue));
 
         /// <summary>
         /// Not intended to be used directly.

--- a/src/Microsoft.AspNetCore.Blazor/Components/BindMethods.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BindMethods.cs
@@ -77,30 +77,6 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// <summary>
         /// Not intended to be used directly.
         /// </summary>
-        public static UIEventHandler SetValueHandler(Action<double> setter, double existingValue)
-        {
-            return _ => setter(double.Parse((string)((UIChangeEventArgs)_).Value));
-        }
-
-        /// <summary>
-        /// Not intended to be used directly.
-        /// </summary>
-        public static UIEventHandler SetValueHandler(Action<float> setter, float existingValue)
-        {
-            return _ => setter(float.Parse((string)((UIChangeEventArgs)_).Value));
-        }
-
-        /// <summary>
-        /// Not intended to be used directly.
-        /// </summary>
-        public static UIEventHandler SetValueHandler(Action<decimal> setter, decimal existingValue)
-        {
-            return _ => setter(decimal.Parse((string)((UIChangeEventArgs)_).Value));
-        }
-
-        /// <summary>
-        /// Not intended to be used directly.
-        /// </summary>
         public static UIEventHandler SetValueHandler(Action<DateTime> setter, DateTime existingValue)
         {
             return _ => SetDateTimeValue(setter, (object)((UIChangeEventArgs)_).Value, null);
@@ -149,24 +125,6 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// </summary>
         public static Action<object> SetValue(Action<int> setter, int existingValue)
             => objValue => setter(int.Parse((string)objValue));
-
-        /// <summary>
-        /// Not intended to be used directly.
-        /// </summary>
-        public static Action<object> SetValue(Action<double> setter, double existingValue)
-            => objValue => setter(double.Parse((string)objValue));
-
-        /// <summary>
-        /// Not intended to be used directly.
-        /// </summary>
-        public static Action<object> SetValue(Action<float> setter, float existingValue)
-            => objValue => setter(float.Parse((string)objValue));
-
-        /// <summary>
-        /// Not intended to be used directly.
-        /// </summary>
-        public static Action<object> SetValue(Action<decimal> setter, decimal existingValue)
-            => objValue => setter(decimal.Parse((string)objValue));
 
         /// <summary>
         /// Not intended to be used directly.


### PR DESCRIPTION
(Re-opened pull, as i branched correctly my code)

Added **VSIISExeLauncher** autorebuild support.

When searching for devenv process in FindAncestorVSProcess method, if "VSIISExeLauncher" is found in the process tree, then we are likely in a debugable IIS hosted app.

Retrieving the initial launcher to find the owningPid number, actually the current devenv instance.

Returning devenv process if found and valid.

This behavior will fail of course if the current executing process lack of permissions, like not being in the administrator group.

In my case, added my current ApplicationPool in the Administrators group, then restarted IIS, was sufficient to allow to read devenv process.

Correct me if i'm wrong, but as the VSIISExeLauncher will be called only if launched from Visual Studio, this behavior should never happen in production.

**NOTE**: FindIISHostedVSProcess is called within FindAncestorVSProcess **while** loop if its relevant, however if you prefer by design that this method is called after FindAncestorVSProcess in TryCreate (if relevant), i will change this.