### PR TITLE
Added binding support on double/float/decimal

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Components/BindMethods.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BindMethods.cs
@@ -77,6 +77,30 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// <summary>
         /// Not intended to be used directly.
         /// </summary>
+        public static UIEventHandler SetValueHandler(Action<double> setter, double existingValue)
+        {
+            return _ => setter(double.Parse((string)((UIChangeEventArgs)_).Value));
+        }
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static UIEventHandler SetValueHandler(Action<float> setter, float existingValue)
+        {
+            return _ => setter(float.Parse((string)((UIChangeEventArgs)_).Value));
+        }
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static UIEventHandler SetValueHandler(Action<decimal> setter, decimal existingValue)
+        {
+            return _ => setter(decimal.Parse((string)((UIChangeEventArgs)_).Value));
+        }
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
         public static UIEventHandler SetValueHandler(Action<DateTime> setter, DateTime existingValue)
         {
             return _ => SetDateTimeValue(setter, (object)((UIChangeEventArgs)_).Value, null);
@@ -125,6 +149,24 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// </summary>
         public static Action<object> SetValue(Action<int> setter, int existingValue)
             => objValue => setter(int.Parse((string)objValue));
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static Action<object> SetValue(Action<double> setter, double existingValue)
+            => objValue => setter(double.Parse((string)objValue));
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static Action<object> SetValue(Action<float> setter, float existingValue)
+            => objValue => setter(float.Parse((string)objValue));
+
+        /// <summary>
+        /// Not intended to be used directly.
+        /// </summary>
+        public static Action<object> SetValue(Action<decimal> setter, decimal existingValue)
+            => objValue => setter(decimal.Parse((string)objValue));
 
         /// <summary>
         /// Not intended to be used directly.

--- a/test/testapps/BasicTestApp/BindCasesComponent.cshtml
+++ b/test/testapps/BasicTestApp/BindCasesComponent.cshtml
@@ -11,6 +11,18 @@
     <span id="textbox-initially-populated-value">@textboxInitiallyPopulatedValue</span>
 </p>
 
+<h2>Numeric Stepper</h2>
+<p>
+    Initially blank:
+    <input id="numericstepper-initially-blank" bind="numericStepperInitiallyBlankValue" type="number" step="any" />
+    <span id="numericstepper-initially-blank-value">@numericStepperInitiallyBlankValue</span>
+</p>
+<p>
+    Initially populated:
+    <input id="numericstepper-initially-populated" bind="numericStepperInitiallyPopulatedValue" type="number" step="any" />
+    <span id="numericstepper-initially-populated-value">@numericStepperInitiallyPopulatedValue</span>
+</p>
+
 <h2>Text Area</h2>
 <p>
     Initially blank:
@@ -59,6 +71,9 @@
 
     bool checkboxInitiallyUncheckedValue = false;
     bool checkboxInitiallyCheckedValue = true;
+
+    decimal numericStepperInitiallyBlankValue = default;
+    decimal numericStepperInitiallyPopulatedValue = 1.23456789M;
 
     bool includeFourthOption = false;
     enum SelectableValue { First, Second, Third, Fourth }


### PR DESCRIPTION
Added binding support on double/float/decimal, by adding corresponding delegates for theses use case.

**NOTE:** Binding parsed and showed value for decimal is correspond to current thread culture format (System.Threading.Thread.CurrentThread.CurrentCulture or System.Threading.Thread.CurrentThread.CurrentUICulture , doesn't have made deep test), so the ouput may be influenced and corresponding to culture requirement.

**Suggestion:** What about  System.OverflowException ? Actually mocking the previous implementation (btw doing nothing specially).

Fix #623 