### PR TITLE
Fix diffing when "bind" is combined with conditional attribute. Fixes #624

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeDiffBuilder.cs
@@ -179,8 +179,8 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
                     // These two attributes have the same sequence and name. Keep merging.
                     AppendDiffEntriesForAttributeFrame(ref diffContext, oldStartIndex, newStartIndex);
 
-                    oldStartIndex = NextSiblingIndex(oldTree[oldStartIndex], oldStartIndex);
-                    newStartIndex = NextSiblingIndex(newTree[newStartIndex], newStartIndex);
+                    oldStartIndex++;
+                    newStartIndex++;
                     hasMoreOld = oldEndIndexExcl > oldStartIndex;
                     hasMoreNew = newEndIndexExcl > newStartIndex;
                 }


### PR DESCRIPTION
The issue was that we were using incorrect logic to update the indices during the attribute diffing. The problem only manifests given a very specific diffing scenario because of a fluke in how the memory for a `RenderTreeFrame` is laid out.

Fortunately the fixed code is much simpler. And we get a minor perf boost for free.