### PR TITLE
[WIP] Routing cleanup and feedback

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Routing/RouteTable.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/RouteTable.cs
@@ -16,14 +16,14 @@ namespace Microsoft.AspNetCore.Blazor.Routing
             Routes = routes;
         }
 
-        public RouteEntry[] Routes { get; set; }
+        public RouteEntry[] Routes { get; }
 
         public static RouteTable Create(IEnumerable<Type> types)
         {
             var routes = new List<RouteEntry>();
             foreach (var type in types)
             {
-                var routeAttributes = type.GetCustomAttributes<RouteAttribute>(); // Inherit: true?
+                var routeAttributes = type.GetCustomAttributes<RouteAttribute>(inherit: true);
                 foreach (var routeAttribute in routeAttributes)
                 {
                     var template = TemplateParser.ParseTemplate(routeAttribute.Template);

--- a/test/testapps/BasicTestApp/RouterTest/Links.cshtml
+++ b/test/testapps/BasicTestApp/RouterTest/Links.cshtml
@@ -1,4 +1,3 @@
-@page "/Links"
 @using Microsoft.AspNetCore.Blazor.Routing
 @inject Microsoft.AspNetCore.Blazor.Services.IUriHelper uriHelper
 <style type="text/css">a.active { background-color: yellow; font-weight: bold; }</style>


### PR DESCRIPTION
Addresses feedback from https://github.com/aspnet/Blazor/pull/266:
* Consider assemblies as candidates when any of their dependencies references the blazor assembly.
* Provides an extensibility endpoint for implementing your own custom logic when subclassing the router component.
* Makes RouteTable.Routes get only.
* Removes the unnecessary page directive from the links component in the basic test app.
* Caches route tables per entry assembly
* Discovers routes with [Route] applied to a base class