### PR TITLE
Make Razor.Design a transitive dependency

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.csproj
@@ -19,7 +19,10 @@
   <Target Name="PublishAll" BeforeTargets="_IntermediatePack">
     <PropertyGroup>
       <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
-      <NuspecProperties>version=$(PackageVersion);publishDir=$([MSBuild]::NormalizeDirectory($(IntermediatePackDir)))</NuspecProperties>
+      <NuspecProperties>
+      version=$(PackageVersion);
+      publishDir=$([MSBuild]::NormalizeDirectory($(IntermediatePackDir)));
+      razorversion=$(RazorPackageVersion);</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
@@ -64,6 +67,10 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor.Browser.JS\Microsoft.AspNetCore.Blazor.Browser.JS.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor.Razor.Extensions\Microsoft.AspNetCore.Blazor.Razor.Extensions.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
+
+    <!-- Intentionally include Razor.Design's MSBuild assets for everyone who reference Blazor.Build -->
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(RazorPackageVersion)" PrivateAssets="None" />
+
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0" />

--- a/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.nuspec
+++ b/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.nuspec
@@ -5,6 +5,9 @@
     <version>$version$</version>
     <authors>Microsoft</authors>
     <description>Build mechanism for Blazor applications.</description>
+    <dependencies>
+      <dependency id="Microsoft.AspNetCore.Razor.Design" version="$razorversion$" include="all" />
+    </dependencies>
   </metadata>
   <files>
     <file src="_._" target="lib/netstandard1.0/" />

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/BlazorHosted.CSharp.Client.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/BlazorHosted.CSharp.Client.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.0-preview2-final" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="$(TemplateBlazorPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="$(TemplateBlazorPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary.CSharp/BlazorLibrary.CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary.CSharp/BlazorLibrary.CSharp.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.0-preview2-final" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="$(TemplateBlazorPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="$(TemplateBlazorPackageVersion)" />
   </ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/BlazorStandalone.CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/BlazorStandalone.CSharp.csproj
@@ -12,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.0-preview2-final" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="$(TemplateBlazorPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="$(TemplateBlazorPackageVersion)" />
     <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="$(TemplateBlazorPackageVersion)" />


### PR DESCRIPTION
By making Razor.Design a transitive dependency of Blazor.Build we can
avoid the need for users to care which version of Razor we depend upon,
and take it out of the templates.