### PR TITLE
Added OnRemove and OnRemoveAsync method on BlazorComponent

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Blazor.Rendering;
 using Microsoft.AspNetCore.Blazor.RenderTree;
 using System;
 using System.Threading.Tasks;
@@ -91,6 +92,33 @@ namespace Microsoft.AspNetCore.Blazor.Components
             => null;
 
         /// <summary>
+        /// Method invoked when the component is ready to be removed from the DOM
+        /// </summary>
+        protected virtual void OnRemove()
+        {
+        }
+
+        /// <summary>
+        /// Method invoked when the component is ready to be removed from the DOM
+        /// 
+        /// Override this method if you will perform an asynchronous operation. The
+        /// component will not be refreshed when that operation is completed, as it's
+        /// actually disposing.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing any asynchronous operation, or <see langword="null"/>.</returns>
+        protected virtual Task OnRemoveAsync()
+            => null;
+
+        /// <summary>
+        /// This method should be called from <see cref="ComponentState"/> DisposeInBatch method, in order to fire the OnRemove event to the component
+        /// </summary>
+        internal void NotifyOnRemove()
+        {
+            OnRemove();
+            OnRemoveAsync();
+        }
+
+        /// <summary>
         /// Notifies the component that its state has changed. When applicable, this will
         /// cause the component to be re-rendered.
         /// </summary>
@@ -127,7 +155,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
 
             _renderHandle = renderHandle;
         }
-        
+
         /// <summary>
         /// Method invoked to apply initial or updated parameters to the component.
         /// </summary>

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/ComponentState.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/ComponentState.cs
@@ -63,7 +63,14 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         public void DisposeInBatch(RenderBatchBuilder batchBuilder)
         {
             _componentWasDisposed = true;
- 
+
+            //BlazorComponent is abstract, so we are only checking that this instance is a subclass
+            if (_component.GetType().IsSubclassOf(typeof(BlazorComponent)))
+            {
+                var blazorComponent = _component as BlazorComponent;
+                blazorComponent.NotifyOnRemove();
+            }
+
             // TODO: Handle components throwing during dispose. Shouldn't break the whole render batch.
             if (_component is IDisposable disposable)
             {


### PR DESCRIPTION
Added **OnRemove** and **OnRemoveAsync** method on **BlazorComponent**.

Like the opposite of OnInit and OnInitAsync, theses methods are overridable, and will be called once when disposing in ComponentState.DisposeInBatch method.

This way we can leverage some specific event based on type or data or whatever.

My actual needs were more for caching some component somewhere, like some "singleton" component, but being able to track them if any dispose occur, in order to free their reference/existence somewhere in my app for consistency and security.

I searched for an existing unit test for this case, something like OnInit, but i didn't find it.

Tested on the template project, with a nested component in a foreach loop, then leaving the page, checking that OnRemove was called.