### PR TITLE
Add [Parameter] for component parameters

### DIFF
--- a/samples/StandaloneApp/Shared/MainLayout.cshtml
+++ b/samples/StandaloneApp/Shared/MainLayout.cshtml
@@ -15,5 +15,6 @@
 </div>
 
 @functions {
+    [Parameter]
     public RenderFragment Body { get; set; }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorApi.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorApi.cs
@@ -16,6 +16,11 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             public static readonly string BuildRenderTree = nameof(BuildRenderTree);
         }
 
+        public static class ParameterAttribute
+        {
+            public static readonly string FullTypeName = "Microsoft.AspNetCore.Blazor.Components.ParameterAttribute";
+        }
+
         public static class LayoutAttribute
         {
             public static readonly string FullTypeName = "Microsoft.AspNetCore.Blazor.Layouts.LayoutAttribute";

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/Shared/SurveyPrompt.cshtml
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted.CSharp/BlazorHosted.CSharp.Client/Shared/SurveyPrompt.cshtml
@@ -14,5 +14,6 @@
 @functions
 {
     // This is to demonstrate how a parent component can supply parameters
+    [Parameter]
     public string Title { get; set; }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/Shared/SurveyPrompt.cshtml
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone.CSharp/Shared/SurveyPrompt.cshtml
@@ -14,5 +14,6 @@
 @functions
 {
     // This is to demonstrate how a parent component can supply parameters
+    [Parameter]
     public string Title { get; set; }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Components/ParameterAttribute.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/ParameterAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Blazor.Components
+{
+    /// <summary>
+    /// Denotes the target member as a component parameter.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    public sealed class ParameterAttribute : Attribute
+    {
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor/Components/ParameterCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/ParameterCollectionExtensions.cs
@@ -66,6 +66,13 @@ namespace Microsoft.AspNetCore.Blazor.Components
                     $"matching the name '{propertyName}'.");
             }
 
+            if (!property.IsDefined(typeof(ParameterAttribute)))
+            {
+                throw new InvalidOperationException(
+                    $"Object of type '{targetType.FullName}' has a property matching the name '{propertyName}', " +
+                    $"but it does not have [{nameof(ParameterAttribute)}] applied.");
+            }
+
             return property;
         }
     }

--- a/src/Microsoft.AspNetCore.Blazor/Layouts/LayoutDisplay.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Layouts/LayoutDisplay.cs
@@ -21,11 +21,13 @@ namespace Microsoft.AspNetCore.Blazor.Layouts
         /// Gets or sets the type of the page component to display.
         /// The type must implement <see cref="IComponent"/>.
         /// </summary>
+        [Parameter]
         public Type Page { get; set; }
 
         /// <summary>
         /// Gets or sets the parameters to pass to the page.
         /// </summary>
+        [Parameter]
         public IDictionary<string, object> PageParameters { get; set; }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.Blazor/Routing/NavLink.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/NavLink.cs
@@ -38,11 +38,13 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         /// Gets or sets the CSS class name applied to the NavLink when the 
         /// current route matches the NavLink href.
         /// </summary>
+        [Parameter]
         public string ActiveClass { get; set; }
 
         /// <summary>
         /// Gets or sets a value representing the URL matching behavior.
         /// </summary>
+        [Parameter]
         public NavLinkMatch Match { get; set; }
 
         [Inject] private IUriHelper UriHelper { get; set; }

--- a/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         /// Gets or sets the assembly that should be searched, along with its referenced
         /// assemblies, for components matching the URI.
         /// </summary>
+        [Parameter]
         public Assembly AppAssembly { get; set; }
 
         private RouteTable Routes { get; set; }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/BindRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/BindRazorIntegrationTest.cs
@@ -24,8 +24,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public int Value { get; set; }
 
+        [Parameter]
         public Action<int> ValueChanged { get; set; }
     }
 }"));
@@ -96,8 +98,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public int Value { get; set; }
 
+        [Parameter]
         public Action<int> OnChanged { get; set; }
     }
 }"));

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/ComponentRenderingRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/ComponentRenderingRazorIntegrationTest.cs
@@ -57,10 +57,10 @@ namespace Test
 
     public class MyComponent : BlazorComponent
     {
-        public int IntProperty { get; set; }
-        public bool BoolProperty { get; set; }
-        public string StringProperty { get; set; }
-        public SomeType ObjectProperty { get; set; }
+        [Parameter] public int IntProperty { get; set; }
+        [Parameter] public bool BoolProperty { get; set; }
+        [Parameter] public string StringProperty { get; set; }
+        [Parameter] public SomeType ObjectProperty { get; set; }
     }
 }
 "));
@@ -91,6 +91,36 @@ namespace Test
         }
 
         [Fact]
+        public void Render_ChildComponent_TriesToSetNonParamter()
+        {
+            // Arrange
+            AdditionalSyntaxTrees.Add(Parse(@"
+using Microsoft.AspNetCore.Blazor.Components;
+
+namespace Test
+{
+    public class MyComponent : BlazorComponent
+    {
+        public int IntProperty { get; set; }
+    }
+}
+"));
+
+            var component = CompileToComponent(@"
+@addTagHelper *, TestAssembly
+<MyComponent  IntProperty=""123"" />");
+
+            // Act
+            var ex = Assert.Throws<InvalidOperationException>(() => GetRenderTree(component));
+
+            // Assert
+            Assert.Equal(
+                "Object of type 'Test.MyComponent' has a property matching the name 'IntProperty', " +
+                    "but it does not have [ParameterAttribute] applied.",
+                ex.Message);
+        }
+
+        [Fact]
         public void Render_ChildComponent_WithExplicitStringParameter()
         {
             // Arrange
@@ -101,6 +131,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public string StringProperty { get; set; }
     }
 }
@@ -174,6 +205,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public Action<UIMouseEventArgs> OnClick { get; set; }
     }
 }
@@ -221,6 +253,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public Action<UIEventArgs> OnClick { get; set; }
     }
 }
@@ -267,6 +300,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public bool BoolProperty { get; set; }
     }
 }"));
@@ -296,7 +330,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public string MyAttr { get; set; }
+
+        [Parameter]
         public RenderFragment ChildContent { get; set; }
     }
 }
@@ -338,6 +375,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public RenderFragment ChildContent { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/DesignTimeCodeGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/DesignTimeCodeGenerationTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Blazor.Build.Test
@@ -27,10 +26,10 @@ namespace Test
 
     public class MyComponent : BlazorComponent
     {
-        public int IntProperty { get; set; }
-        public bool BoolProperty { get; set; }
-        public string StringProperty { get; set; }
-        public SomeType ObjectProperty { get; set; }
+        [Parameter] public int IntProperty { get; set; }
+        [Parameter] public bool BoolProperty { get; set; }
+        [Parameter] public string StringProperty { get; set; }
+        [Parameter] public SomeType ObjectProperty { get; set; }
     }
 }
 "));
@@ -61,6 +60,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public string StringProperty { get; set; }
     }
 }
@@ -116,6 +116,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public Action<UIEventArgs> OnClick { get; set; }
     }
 }
@@ -152,6 +153,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public Action<UIEventArgs> OnClick { get; set; }
     }
 }
@@ -188,8 +190,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public string MyAttr { get; set; }
 
+        [Parameter]
         public RenderFragment ChildContent { get; set; }
     }
 }
@@ -382,8 +386,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public int Value { get; set; }
 
+        [Parameter]
         public Action<int> ValueChanged { get; set; }
     }
 }"));
@@ -446,8 +452,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public int Value { get; set; }
 
+        [Parameter]
         public Action<int> OnChanged { get; set; }
     }
 }"));

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/DirectiveRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/DirectiveRazorIntegrationTest.cs
@@ -121,6 +121,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
 
         public class TestLayout : ILayoutComponent
         {
+            [Parameter]
             public RenderFragment Body { get; set; }
 
             public void Init(RenderHandle renderHandle)

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RuntimeCodeGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RuntimeCodeGenerationTest.cs
@@ -51,10 +51,10 @@ namespace Test
 
     public class MyComponent : BlazorComponent
     {
-        public int IntProperty { get; set; }
-        public bool BoolProperty { get; set; }
-        public string StringProperty { get; set; }
-        public SomeType ObjectProperty { get; set; }
+        [Parameter] public int IntProperty { get; set; }
+        [Parameter] public bool BoolProperty { get; set; }
+        [Parameter] public string StringProperty { get; set; }
+        [Parameter] public SomeType ObjectProperty { get; set; }
     }
 }
 "));
@@ -85,6 +85,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public string StringProperty { get; set; }
     }
 }
@@ -141,6 +142,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public Action<UIEventArgs> OnClick { get; set; }
     }
 }
@@ -177,6 +179,7 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public Action<UIEventArgs> OnClick { get; set; }
     }
 }
@@ -213,8 +216,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public string MyAttr { get; set; }
 
+        [Parameter]
         public RenderFragment ChildContent { get; set; }
     }
 }
@@ -635,8 +640,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public int Value { get; set; }
 
+        [Parameter]
         public Action<int> ValueChanged { get; set; }
     }
 }"));
@@ -699,8 +706,10 @@ namespace Test
 {
     public class MyComponent : BlazorComponent
     {
+        [Parameter]
         public int Value { get; set; }
 
+        [Parameter]
         public Action<int> OnChanged { get; set; }
     }
 }"));

--- a/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/BindTagHelperDescriptorProviderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/BindTagHelperDescriptorProviderTest.cs
@@ -27,8 +27,10 @@ namespace Test
 
         public void SetParameters(ParameterCollection parameters) { }
 
+        [Parameter]
         public string MyProperty { get; set; }
 
+        [Parameter]
         public Action<string> MyPropertyChanged { get; set; }
     }
 }

--- a/test/Microsoft.AspNetCore.Blazor.Test/LayoutTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/LayoutTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Blazor.Components;
 using Microsoft.AspNetCore.Blazor.Layouts;
 using Microsoft.AspNetCore.Blazor.RenderTree;
 using Microsoft.AspNetCore.Blazor.Test.Helpers;
@@ -219,6 +220,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
         private class RootLayout : AutoRenderComponent, ILayoutComponent
         {
+            [Parameter]
             public RenderFragment Body { get; set; }
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -232,6 +234,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
         [Layout(typeof(RootLayout))]
         private class NestedLayout : AutoRenderComponent, ILayoutComponent
         {
+            [Parameter]
             public RenderFragment Body { get; set; }
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
@@ -1503,11 +1503,22 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
         private class FakeComponent : IComponent
         {
+            [Parameter]
             public int IntProperty { get; set; }
+
+            [Parameter]
             public string StringProperty { get; set; }
+
+            [Parameter]
             public object ObjectProperty { get; set; }
+
+            [Parameter]
             public string ReadonlyProperty { get; private set; }
+
+            [Parameter]
             private string PrivateProperty { get; set; }
+
+            public string NonParameterProperty { get; set; }
 
             public void Init(RenderHandle renderHandle) { }
             public void SetParameters(ParameterCollection parameters)

--- a/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
@@ -1109,6 +1109,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
         private class MessageComponent : AutoRenderComponent
         {
+            [Parameter]
             public string Message { get; set; }
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -1119,9 +1120,15 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
         private class FakeComponent : IComponent
         {
+            [Parameter]
             public int IntProperty { get; set; }
+
+            [Parameter]
             public string StringProperty { get; set; }
+
+            [Parameter]
             public object ObjectProperty { get; set; }
+
             public RenderHandle RenderHandle { get; private set; }
 
             public void Init(RenderHandle renderHandle)
@@ -1133,8 +1140,13 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
         private class EventComponent : AutoRenderComponent, IComponent, IHandleEvent
         {
+            [Parameter]
             public Action<UIEventArgs> OnTest { get; set; }
+
+            [Parameter]
             public Action<UIMouseEventArgs> OnClick { get; set; }
+
+            [Parameter]
             public Action OnClickAction { get; set; }
 
             public bool SkipElement { get; set; }
@@ -1174,7 +1186,10 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
         private class ConditionalParentComponent<T> : AutoRenderComponent where T : IComponent
         {
+            [Parameter]
             public bool IncludeChild { get; set; }
+
+            [Parameter]
             public IDictionary<string, object> ChildParameters { get; set; }
 
             protected override void BuildRenderTree(RenderTreeBuilder builder)
@@ -1199,6 +1214,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
         
         private class ReRendersParentComponent : AutoRenderComponent
         {
+            [Parameter]
             public TestComponent Parent { get; set; }
             private bool _isFirstTime = true;
 
@@ -1216,6 +1232,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
         private class RendersSelfAfterEventComponent : IComponent, IHandleEvent
         {
+            [Parameter]
             public Action<object> OnClick { get; set; }
 
             private RenderHandle _renderHandle;

--- a/test/testapps/BasicTestApp/MessageComponent.cshtml
+++ b/test/testapps/BasicTestApp/MessageComponent.cshtml
@@ -1,4 +1,5 @@
-﻿<span style="color: red" class="message">@Message</span>
+﻿@using Microsoft.AspNetCore.Blazor.Components
+<span style="color: red" class="message">@Message</span>
 @functions {
-    public string Message { get; set; }
+    [Parameter] public string Message { get; set; }
 }

--- a/test/testapps/BasicTestApp/PassThroughContentComponent.cshtml
+++ b/test/testapps/BasicTestApp/PassThroughContentComponent.cshtml
@@ -1,8 +1,9 @@
 ﻿@using Microsoft.AspNetCore.Blazor
+@using Microsoft.AspNetCore.Blazor.Components
 @ChildContent
 @functions {
     // Note: The lack of any whitespace or other output besides @ChildContent is important for
     // what scenarios this component is used for in E2E tests.
 
-    public RenderFragment ChildContent { get; set; }
+    [Parameter] public RenderFragment ChildContent { get; set; }
 }

--- a/test/testapps/BasicTestApp/PropertiesChangedHandlerChild.cshtml
+++ b/test/testapps/BasicTestApp/PropertiesChangedHandlerChild.cshtml
@@ -1,7 +1,9 @@
-﻿<div class="supplied">You supplied: @SuppliedValue</div>
+﻿@using Microsoft.AspNetCore.Blazor.Components
+<div class="supplied">You supplied: @SuppliedValue</div>
 <div class="computed">I computed: @computedValue</div>
 
 @functions {
+    [Parameter]
     public int SuppliedValue { get; set; }
 
     private int computedValue;

--- a/test/testapps/BasicTestApp/RouterTest/WithParameters.cshtml
+++ b/test/testapps/BasicTestApp/RouterTest/WithParameters.cshtml
@@ -1,11 +1,14 @@
 ﻿@page "/RouterTest/WithParameters/Name/{firstName}/LastName/{lastName}"
 @using BasicTestApp.RouterTest
+@using Microsoft.AspNetCore.Blazor.Components
 <div id="test-info">Your full name is @FirstName @LastName.</div>
 <Links />
 
 @functions
 {
+    [Parameter]
     public string FirstName { get; set; }
 
+    [Parameter]
     public string LastName { get ; set; }
 }


### PR DESCRIPTION
This change introduces ParameterAttribute to specify a bindable
component parameter. As of the 0.3 release of Blazor we plan to make
[Parameter] required to make a property bindable by callers.

This also applies to parameters when their value is set by the
infrastructure, such as `Body` for layouts, and route paramters.

The rationale behind this change is that we think there is a need to
separate the definition of properties from their suitability for a
caller to set them through markup. We plan to introduce more features in
this area in the future such as marking parameters as required. This is
first step, and we think that this approach will scale nicely as we add
more functionaly.

The 0.3 release seems like the right time to change this behavior since
we're also introducing `ref` for captures in this release.