### PR TITLE
For checkboxes, bind to 'checked'. Fix special property handling in BrowserRenderer.ts. Fixes #659 and #703

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
@@ -224,18 +224,14 @@ export class BrowserRenderer {
       case 'INPUT':
       case 'SELECT':
       case 'TEXTAREA':
-        if (isCheckbox(element)) {
-          (element as HTMLInputElement).checked = value === '';
-        } else {
-          (element as any).value = value;
+        (element as any).value = value;
 
-          if (element.tagName === 'SELECT') {
-            // <select> is special, in that anything we write to .value will be lost if there
-            // isn't yet a matching <option>. To maintain the expected behavior no matter the
-            // element insertion/update order, preserve the desired value separately so
-            // we can recover it when inserting any matching <option>.
-            element[selectValuePropname] = value;
-          }
+        if (element.tagName === 'SELECT') {
+          // <select> is special, in that anything we write to .value will be lost if there
+          // isn't yet a matching <option>. To maintain the expected behavior no matter the
+          // element insertion/update order, preserve the desired value separately so
+          // we can recover it when inserting any matching <option>.
+          element[selectValuePropname] = value;
         }
         return true;
       case 'OPTION':
@@ -279,10 +275,6 @@ function countDescendantFrames(frame: RenderTreeFramePointer): number {
     default:
       return 0;
   }
-}
-
-function isCheckbox(element: Element) {
-  return element.tagName === 'INPUT' && element.getAttribute('type') === 'checkbox';
 }
 
 function raiseEvent(event: Event, browserRendererId: number, componentId: number, eventHandlerId: number, eventArgs: EventForDotNet<UIEventArgs>) {

--- a/src/Microsoft.AspNetCore.Blazor/Components/BindAttributes.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BindAttributes.cs
@@ -15,8 +15,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
     // when a specific type attribute is applied.
     [BindInputElement(null, null, "value", "onchange")]
 
-    // For right now, the BrowserRenderer translates the value attribute to the checked attribute.
-    [BindInputElement("checkbox", null, "value", "onchange")]
+    [BindInputElement("checkbox", null, "checked", "onchange")]
     [BindInputElement("text", null, "value", "onchange")]
 
     [BindElement("select", null, "value", "onchange")]

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
             base.BuildRenderTree(builder);
             builder.OpenElement(0, "input");
             builder.AddAttribute(1, "type", "checkbox");
-            builder.AddAttribute(2, "value", Microsoft.AspNetCore.Blazor.Components.BindMethods.GetValue(Enabled));
+            builder.AddAttribute(2, "checked", Microsoft.AspNetCore.Blazor.Components.BindMethods.GetValue(Enabled));
             builder.AddAttribute(3, "onchange", Microsoft.AspNetCore.Blazor.Components.BindMethods.SetValueHandler(__value => Enabled = __value, Enabled));
             builder.CloseElement();
         }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (86:2,12 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |
-Generated Location: (1037:23,12 [41] )
+Generated Location: (1039:23,12 [41] )
 |
     public bool Enabled { get; set; }
 |

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/BindTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/BindTest.cs
@@ -28,14 +28,25 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         {
             var target = Browser.FindElement(By.Id("textbox-initially-blank"));
             var boundValue = Browser.FindElement(By.Id("textbox-initially-blank-value"));
+            var mirrorValue = Browser.FindElement(By.Id("textbox-initially-blank-mirror"));
+            var setNullButton = Browser.FindElement(By.Id("textbox-initially-blank-setnull"));
             Assert.Equal(string.Empty, target.GetAttribute("value"));
             Assert.Equal(string.Empty, boundValue.Text);
+            Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
 
-            // Modify target; verify value is updated
+            // Modify target; verify value is updated and that textboxes linked to the same data are updated
             target.SendKeys("Changed value");
             Assert.Equal(string.Empty, boundValue.Text); // Doesn't update until change event
+            Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
             target.SendKeys("\t");
             Assert.Equal("Changed value", boundValue.Text);
+            Assert.Equal("Changed value", mirrorValue.GetAttribute("value"));
+
+            // Remove the value altogether
+            setNullButton.Click();
+            Assert.Equal(string.Empty, target.GetAttribute("value"));
+            Assert.Equal(string.Empty, boundValue.Text);
+            Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
         }
 
         [Fact]
@@ -43,13 +54,23 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         {
             var target = Browser.FindElement(By.Id("textbox-initially-populated"));
             var boundValue = Browser.FindElement(By.Id("textbox-initially-populated-value"));
+            var mirrorValue = Browser.FindElement(By.Id("textbox-initially-populated-mirror"));
+            var setNullButton = Browser.FindElement(By.Id("textbox-initially-populated-setnull"));
             Assert.Equal("Hello", target.GetAttribute("value"));
             Assert.Equal("Hello", boundValue.Text);
+            Assert.Equal("Hello", mirrorValue.GetAttribute("value"));
 
-            // Modify target; verify value is updated
+            // Modify target; verify value is updated and that textboxes linked to the same data are updated
             target.Clear();
             target.SendKeys("Changed value\t");
             Assert.Equal("Changed value", boundValue.Text);
+            Assert.Equal("Changed value", mirrorValue.GetAttribute("value"));
+
+            // Remove the value altogether
+            setNullButton.Click();
+            Assert.Equal(string.Empty, target.GetAttribute("value"));
+            Assert.Equal(string.Empty, boundValue.Text);
+            Assert.Equal(string.Empty, mirrorValue.GetAttribute("value"));
         }
         
         [Fact]

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/BindTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/BindTest.cs
@@ -86,6 +86,7 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         {
             var target = Browser.FindElement(By.Id("checkbox-initially-unchecked"));
             var boundValue = Browser.FindElement(By.Id("checkbox-initially-unchecked-value"));
+            var invertButton = Browser.FindElement(By.Id("checkbox-initially-unchecked-invert"));
             Assert.False(target.Selected);
             Assert.Equal("False", boundValue.Text);
 
@@ -93,6 +94,11 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             target.Click();
             Assert.True(target.Selected);
             Assert.Equal("True", boundValue.Text);
+
+            // Modify data; verify checkbox is updated
+            invertButton.Click();
+            Assert.False(target.Selected);
+            Assert.Equal("False", boundValue.Text);
         }
 
         [Fact]
@@ -100,6 +106,7 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         {
             var target = Browser.FindElement(By.Id("checkbox-initially-checked"));
             var boundValue = Browser.FindElement(By.Id("checkbox-initially-checked-value"));
+            var invertButton = Browser.FindElement(By.Id("checkbox-initially-checked-invert"));
             Assert.True(target.Selected);
             Assert.Equal("True", boundValue.Text);
 
@@ -107,6 +114,11 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             target.Click();
             Assert.False(target.Selected);
             Assert.Equal("False", boundValue.Text);
+
+            // Modify data; verify checkbox is updated
+            invertButton.Click();
+            Assert.True(target.Selected);
+            Assert.Equal("True", boundValue.Text);
         }
 
         [Fact]

--- a/test/testapps/BasicTestApp/BindCasesComponent.cshtml
+++ b/test/testapps/BasicTestApp/BindCasesComponent.cshtml
@@ -4,11 +4,15 @@
     Initially blank:
     <input id="textbox-initially-blank" bind="textboxInitiallyBlankValue" />
     <span id="textbox-initially-blank-value">@textboxInitiallyBlankValue</span>
+    <input id="textbox-initially-blank-mirror" bind="textboxInitiallyBlankValue" readonly />
+    <button id="textbox-initially-blank-setnull" onclick="@(() => { textboxInitiallyBlankValue = null; })">Set null</button>
 </p>
 <p>
     Initially populated:
     <input id="textbox-initially-populated" bind="textboxInitiallyPopulatedValue" />
     <span id="textbox-initially-populated-value">@textboxInitiallyPopulatedValue</span>
+    <input id="textbox-initially-populated-mirror" bind="textboxInitiallyPopulatedValue" readonly />
+    <button id="textbox-initially-populated-setnull" onclick="@(() => { textboxInitiallyPopulatedValue = null; })">Set null</button>
 </p>
 
 <h2>Text Area</h2>

--- a/test/testapps/BasicTestApp/BindCasesComponent.cshtml
+++ b/test/testapps/BasicTestApp/BindCasesComponent.cshtml
@@ -28,11 +28,13 @@
     Initially unchecked:
     <input id="checkbox-initially-unchecked" bind="checkboxInitiallyUncheckedValue" type="checkbox" />
     <span id="checkbox-initially-unchecked-value">@checkboxInitiallyUncheckedValue</span>
+    <button id="checkbox-initially-unchecked-invert" onclick="@(() => { checkboxInitiallyUncheckedValue = !checkboxInitiallyUncheckedValue; })">Invert</button>
 </p>
 <p>
     Initially checked:
     <input id="checkbox-initially-checked" bind="checkboxInitiallyCheckedValue" type="checkbox" />
     <span id="checkbox-initially-checked-value">@checkboxInitiallyCheckedValue</span>
+    <button id="checkbox-initially-checked-invert" onclick="@(() => { checkboxInitiallyCheckedValue = !checkboxInitiallyCheckedValue; })">Invert</button>
 </p>
 
 <h2>Select</h2>


### PR DESCRIPTION
At first I was going to fix #703 by changing how attributes are applied so we capture all their values up front and can make decisions in an order-independent way. But then I realised that if we treated checkboxes properly then the ordering issue wouldn't exist anyway.

This PR changes `bind` for checkboxes to use the `checked` property instead of `value`. It should always have done that really, but didn't as a historical consequence of the old `@bind(...)` syntax. With the new syntax we can just treat checkboxes properly and the issue goes away.

This PR also fixes #659 since now we have more consistent (and simpler) handling of "special" attributes.

### Breaking change

People who previously used `<input type='checkbox' value=@someBoolValue />` should now instead write `<input type='checkbox' checked=@someBoolValue />`. This makes a lot more sense anyway.

It doesn't affect any code that uses `bind=@someBoolValue`, because we now map that to the new correct property.