### PR TITLE
In Blazor cshtml, auto-reference Microsoft.AspNetCore.Blazor and .Components

### DIFF
--- a/samples/StandaloneApp/_ViewImports.cshtml
+++ b/samples/StandaloneApp/_ViewImports.cshtml
@@ -1,6 +1,4 @@
 ﻿@using System.Net.Http
-@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Components
 @using Microsoft.AspNetCore.Blazor.Layouts
 @using Microsoft.AspNetCore.Blazor.Routing
 @using StandaloneApp

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorImportProjectFeature.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorImportProjectFeature.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.AspNetCore.Blazor.Shared;
 using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.AspNetCore.Blazor.Razor
@@ -17,12 +18,14 @@ namespace Microsoft.AspNetCore.Blazor.Razor
         private static readonly char[] PathSeparators = new char[]{ '/', '\\' };
 
         // Using explicit newlines here to avoid fooling our baseline tests
-        private const string DefaultUsingImportContent =
+        private readonly static string DefaultUsingImportContent =
             "\r\n" +
             "@using System\r\n" +
             "@using System.Collections.Generic\r\n" +
             "@using System.Linq\r\n" +
-            "@using System.Threading.Tasks\r\n";
+            "@using System.Threading.Tasks\r\n" +
+            "@using " + BlazorApi.RenderFragment.Namespace + "\r\n" + // Microsoft.AspNetCore.Blazor
+            "@using " + BlazorApi.BlazorComponent.Namespace + "\r\n"; // Microsoft.AspNetCore.Blazor.Components
 
         public RazorProjectEngine ProjectEngine { get; set; }
 

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/_ViewImports.cshtml
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/_ViewImports.cshtml
@@ -1,6 +1,4 @@
 ﻿@using System.Net.Http
-@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Components
 @using Microsoft.AspNetCore.Blazor.Layouts
 @using Microsoft.AspNetCore.Blazor.Routing
 @using BlazorHosted_CSharp.Client

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/_ViewImports.cshtml
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/_ViewImports.cshtml
@@ -1,6 +1,4 @@
 ﻿@using System.Net.Http
-@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Components
 @using Microsoft.AspNetCore.Blazor.Layouts
 @using Microsoft.AspNetCore.Blazor.Routing
 @using BlazorStandalone_CSharp

--- a/src/shared/BlazorApi.cs
+++ b/src/shared/BlazorApi.cs
@@ -11,7 +11,8 @@ namespace Microsoft.AspNetCore.Blazor.Shared
 
         public static class BlazorComponent
         {
-            public static readonly string FullTypeName = "Microsoft.AspNetCore.Blazor.Components.BlazorComponent";
+            public static readonly string Namespace = "Microsoft.AspNetCore.Blazor.Components";
+            public static readonly string FullTypeName = Namespace + ".BlazorComponent";
 
             public static readonly string BuildRenderTree = nameof(BuildRenderTree);
         }
@@ -40,7 +41,8 @@ namespace Microsoft.AspNetCore.Blazor.Shared
 
         public static class RenderFragment
         {
-            public static readonly string FullTypeName = "Microsoft.AspNetCore.Blazor.RenderFragment";
+            public static readonly string Namespace = "Microsoft.AspNetCore.Blazor";
+            public static readonly string FullTypeName = Namespace + ".RenderFragment";
         }
         
         public static class RenderTreeBuilder

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/ComponentRenderingRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/ComponentRenderingRazorIntegrationTest.cs
@@ -213,7 +213,6 @@ namespace Test
 
             var component = CompileToComponent($@"
 @addTagHelper *, TestAssembly
-@using Microsoft.AspNetCore.Blazor
 <MyComponent OnClick=""{expression}""/>
 
 @functions {{
@@ -261,7 +260,6 @@ namespace Test
 
             var component = CompileToComponent(@"
 @addTagHelper *, TestAssembly
-@using Microsoft.AspNetCore.Blazor
 <MyComponent OnClick=""@Increment""/>
 
 @functions {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/DeclarationRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/DeclarationRazorIntegrationTest.cs
@@ -125,6 +125,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/DesignTimeCodeGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/DesignTimeCodeGenerationTest.cs
@@ -162,7 +162,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @addTagHelper *, TestAssembly
-@using Microsoft.AspNetCore.Blazor
 <MyComponent OnClick=""@Increment""/>
 
 @functions {
@@ -232,7 +231,6 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@(x => { })"" />");
 
             // Assert
@@ -248,7 +246,6 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@OnClick"" />
 @functions {
     void OnClick(UIMouseEventArgs e) {
@@ -269,7 +266,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@OnClick"" />
 @functions {
     Task OnClick() 
@@ -292,7 +288,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@OnClick"" />
 @functions {
     Task OnClick(UIMouseEventArgs e) 
@@ -315,7 +310,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""async (e) => await Task.Delay(10)"" />
 ");
 
@@ -333,7 +327,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""async (e) => await Task.Delay(10)"" />
 ");
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RenderingRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RenderingRazorIntegrationTest.cs
@@ -494,7 +494,6 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
         {
             // Arrange
             var component = CompileToComponent(@"
-@using Microsoft.AspNetCore.Blazor
 <button onclick=""@OnClick"" />
 @functions {
     public void OnClick(UIMouseEventArgs e) { Clicked = true; }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RuntimeCodeGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RuntimeCodeGenerationTest.cs
@@ -187,7 +187,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @addTagHelper *, TestAssembly
-@using Microsoft.AspNetCore.Blazor
 <MyComponent OnClick=""@Increment""/>
 
 @functions {
@@ -285,7 +284,6 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@(() => { })"" />");
 
             // Assert
@@ -301,7 +299,6 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@(x => { })"" />");
 
             // Assert
@@ -317,7 +314,6 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@OnClick"" />
 @functions {
     void OnClick() {
@@ -337,7 +333,6 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@OnClick"" />
 @functions {
     void OnClick(UIMouseEventArgs e) {
@@ -357,7 +352,6 @@ namespace Test
 
             // Act
             var generated = CompileToCSharp(@"
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@OnClick"" />
 @functions {
     void OnClick(UIEventArgs e) {
@@ -378,7 +372,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@OnClick"" />
 @functions {
     Task OnClick() 
@@ -401,7 +394,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""@OnClick"" />
 @functions {
     Task OnClick(UIMouseEventArgs e) 
@@ -424,7 +416,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""async (e) => await Task.Delay(10)"" />
 ");
 
@@ -442,7 +433,6 @@ namespace Test
             // Act
             var generated = CompileToCSharp(@"
 @using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 <input onclick=""async (e) => await Task.Delay(10)"" />
 ");
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
@@ -11,11 +11,8 @@ using System.Threading.Tasks;
 
 #line default
 #line hidden
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-using Microsoft.AspNetCore.Blazor;
-
-#line default
-#line hidden
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
@@ -4,7 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"
@@ -20,13 +21,11 @@ Document -
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlContent - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlElement - (67:2,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (83:2,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (31:1,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (47:1,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
                             IntermediateToken -  - CSharp - "async (e) => await Task.Delay(10)"
                             IntermediateToken -  - CSharp - )
-                HtmlContent - (120:2,53 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (120:2,53 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                HtmlContent - (84:1,53 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (84:1,53 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.mappings.txt
@@ -3,8 +3,3 @@ Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (222:9,0 [28] )
 |using System.Threading.Tasks|
 
-Source Location: (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Blazor|
-Generated Location: (335:14,0 [33] )
-|using Microsoft.AspNetCore.Blazor|
-

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
@@ -11,11 +11,8 @@ using System.Threading.Tasks;
 
 #line default
 #line hidden
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-using Microsoft.AspNetCore.Blazor;
-
-#line default
-#line hidden
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
@@ -32,7 +29,7 @@ using Microsoft.AspNetCore.Blazor;
             __o = Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(OnClick);
         }
         #pragma warning restore 1998
-#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     Task OnClick(UIMouseEventArgs e) 
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
@@ -4,7 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"
@@ -20,15 +21,13 @@ Document -
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlContent - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlElement - (67:2,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (83:2,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (31:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (47:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (84:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                            IntermediateToken - (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-                HtmlContent - (95:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (95:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (109:3,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (109:3,12 [91] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick(UIMouseEventArgs e) \n    {\n        return Task.CompletedTask;\n    }\n
+                HtmlContent - (59:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (59:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick(UIMouseEventArgs e) \n    {\n        return Task.CompletedTask;\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -3,24 +3,19 @@ Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (222:9,0 [28] )
 |using System.Threading.Tasks|
 
-Source Location: (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Blazor|
-Generated Location: (335:14,0 [33] )
-|using Microsoft.AspNetCore.Blazor|
-
-Source Location: (84:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (1110:31,136 [7] )
+Generated Location: (1083:28,136 [7] )
 |OnClick|
 
-Source Location: (109:3,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Task OnClick(UIMouseEventArgs e) 
     {
         return Task.CompletedTask;
     }
 |
-Generated Location: (1233:35,12 [91] )
+Generated Location: (1206:32,12 [91] )
 |
     Task OnClick(UIMouseEventArgs e) 
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
@@ -11,11 +11,8 @@ using System.Threading.Tasks;
 
 #line default
 #line hidden
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-using Microsoft.AspNetCore.Blazor;
-
-#line default
-#line hidden
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
@@ -4,7 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"
@@ -20,13 +21,11 @@ Document -
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlContent - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlElement - (67:2,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (83:2,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (31:1,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (47:1,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
                             IntermediateToken -  - CSharp - "async (e) => await Task.Delay(10)"
                             IntermediateToken -  - CSharp - )
-                HtmlContent - (120:2,53 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (120:2,53 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                HtmlContent - (84:1,53 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (84:1,53 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.mappings.txt
@@ -3,8 +3,3 @@ Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (222:9,0 [28] )
 |using System.Threading.Tasks|
 
-Source Location: (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Blazor|
-Generated Location: (335:14,0 [33] )
-|using Microsoft.AspNetCore.Blazor|
-

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
@@ -11,11 +11,8 @@ using System.Threading.Tasks;
 
 #line default
 #line hidden
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-using Microsoft.AspNetCore.Blazor;
-
-#line default
-#line hidden
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
@@ -32,7 +29,7 @@ using Microsoft.AspNetCore.Blazor;
             __o = Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(OnClick);
         }
         #pragma warning restore 1998
-#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     Task OnClick() 
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
@@ -4,7 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"
@@ -20,15 +21,13 @@ Document -
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlContent - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlElement - (67:2,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (83:2,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (31:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (47:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (84:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                            IntermediateToken - (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-                HtmlContent - (95:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (95:2,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (109:3,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (109:3,12 [73] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick() \n    {\n        return Task.CompletedTask;\n    }\n
+                HtmlContent - (59:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (59:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick() \n    {\n        return Task.CompletedTask;\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -3,24 +3,19 @@ Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (222:9,0 [28] )
 |using System.Threading.Tasks|
 
-Source Location: (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Blazor|
-Generated Location: (335:14,0 [33] )
-|using Microsoft.AspNetCore.Blazor|
-
-Source Location: (84:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (1110:31,136 [7] )
+Generated Location: (1083:28,136 [7] )
 |OnClick|
 
-Source Location: (109:3,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Task OnClick() 
     {
         return Task.CompletedTask;
     }
 |
-Generated Location: (1233:35,12 [73] )
+Generated Location: (1206:32,12 [73] )
 |
     Task OnClick() 
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (66:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1061:28,35 [11] )
+Generated Location: (1152:30,35 [11] )
 |ParentValue|
 
 Source Location: (95:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1480:41,12 [50] )
+Generated Location: (1571:43,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (66:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1061:28,35 [11] )
+Generated Location: (1152:30,35 [11] )
 |ParentValue|
 
 Source Location: (95:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1514:40,12 [50] )
+Generated Location: (1605:42,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (56:1,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1051:28,25 [11] )
+Generated Location: (1142:30,25 [11] )
 |ParentValue|
 
 Source Location: (85:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1470:41,12 [50] )
+Generated Location: (1561:43,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (56:1,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1051:28,25 [11] )
+Generated Location: (1142:30,25 [11] )
 |ParentValue|
 
 Source Location: (85:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1504:40,12 [50] )
+Generated Location: (1595:42,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (72:1,41 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (973:26,78 [11] )
+Generated Location: (1064:28,78 [11] )
 |CurrentDate|
 
 Source Location: (122:2,12 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1252:31,12 [77] )
+Generated Location: (1343:33,12 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (72:1,41 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (973:26,78 [11] )
+Generated Location: (1064:28,78 [11] )
 |ParentValue|
 
 Source Location: (101:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1234:31,12 [50] )
+Generated Location: (1325:33,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (49:1,18 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (973:26,78 [11] )
+Generated Location: (1064:28,78 [11] )
 |ParentValue|
 
 Source Location: (78:2,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1234:31,12 [55] )
+Generated Location: (1325:33,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (43:1,12 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (973:26,78 [11] )
+Generated Location: (1064:28,78 [11] )
 |ParentValue|
 
 Source Location: (72:2,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (1234:31,12 [55] )
+Generated Location: (1325:33,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (61:1,30 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |Enabled|
-Generated Location: (973:26,78 [7] )
+Generated Location: (1064:28,78 [7] )
 |Enabled|
 
 Source Location: (86:2,12 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |
-Generated Location: (1222:31,12 [41] )
+Generated Location: (1313:33,12 [41] )
 |
     public bool Enabled { get; set; }
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (57:1,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (973:26,78 [11] )
+Generated Location: (1064:28,78 [11] )
 |CurrentDate|
 
 Source Location: (85:1,54 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Format|
-Generated Location: (986:26,91 [6] )
+Generated Location: (1077:28,91 [6] )
 |Format|
 
 Source Location: (108:2,12 [135] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +19,7 @@ Source Location: (108:2,12 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1250:31,12 [135] )
+Generated Location: (1341:33,12 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (57:1,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
-Generated Location: (973:26,78 [11] )
+Generated Location: (1064:28,78 [11] )
 |CurrentDate|
 
 Source Location: (111:2,12 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1262:31,12 [77] )
+Generated Location: (1353:33,12 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (57:1,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (973:26,78 [11] )
+Generated Location: (1064:28,78 [11] )
 |ParentValue|
 
 Source Location: (86:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1234:31,12 [50] )
+Generated Location: (1325:33,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (45:1,14 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (973:26,78 [11] )
+Generated Location: (1064:28,78 [11] )
 |ParentValue|
 
 Source Location: (74:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1234:31,12 [50] )
+Generated Location: (1325:33,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
@@ -7,11 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-using Microsoft.AspNetCore.Blazor;
-
-#line default
-#line hidden
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
@@ -30,7 +27,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
         {
             base.BuildRenderTree(builder);
             __o = new System.Action<Microsoft.AspNetCore.Blazor.UIEventArgs>(
-#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                        Increment
 
 #line default
@@ -41,7 +38,7 @@ global::System.Object __typeHelper = "*, TestAssembly";
             ));
         }
         #pragma warning restore 1998
-#line 5 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     private int counter;
     private void Increment(UIEventArgs e) {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.ir.txt
@@ -4,7 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"
@@ -21,13 +22,11 @@ Document -
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 HtmlContent - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (29:0,29 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlContent - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (65:1,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                ComponentExtensionNode - (67:2,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
-                    ComponentAttributeExtensionNode - (89:2,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - OnClick
-                        CSharpExpression - (90:2,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
-                            IntermediateToken - (90:2,23 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Increment
-                HtmlContent - (102:2,35 [4] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (102:2,35 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
-            CSharpCode - (118:4,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (118:4,12 [100] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    private int counter;\n    private void Increment(UIEventArgs e) {\n        counter++;\n    }\n
+                ComponentExtensionNode - (31:1,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
+                    ComponentAttributeExtensionNode - (53:1,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - OnClick
+                        CSharpExpression - (54:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+                            IntermediateToken - (54:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Increment
+                HtmlContent - (66:1,35 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (66:1,35 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
+            CSharpCode - (82:3,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (82:3,12 [100] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    private int counter;\n    private void Increment(UIEventArgs e) {\n        counter++;\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
@@ -1,26 +1,21 @@
-Source Location: (32:1,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Blazor|
-Generated Location: (257:10,0 [33] )
-|using Microsoft.AspNetCore.Blazor|
-
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (586:19,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
-Source Location: (90:2,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (54:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
-Generated Location: (1166:33,23 [9] )
+Generated Location: (1139:30,23 [9] )
 |Increment|
 
-Source Location: (118:4,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (82:3,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment(UIEventArgs e) {
         counter++;
     }
 |
-Generated Location: (1483:44,12 [100] )
+Generated Location: (1456:41,12 [100] )
 |
     private int counter;
     private void Increment(UIEventArgs e) {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (62:1,31 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |42.ToString()|
-Generated Location: (997:28,31 [13] )
+Generated Location: (1088:30,31 [13] )
 |42.ToString()|
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (55:1,24 [23] x:\dir\subdir\Test\TestComponent.cshtml)
 |(e) => { Increment(); }|
-Generated Location: (1049:28,24 [23] )
+Generated Location: (1140:30,24 [23] )
 |(e) => { Increment(); }|
 
 Source Location: (98:3,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -15,7 +15,7 @@ Source Location: (98:3,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (1380:39,12 [87] )
+Generated Location: (1471:41,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (86:1,55 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |43.ToString()|
-Generated Location: (1021:28,55 [13] )
+Generated Location: (1112:30,55 [13] )
 |43.ToString()|
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
@@ -1,20 +1,20 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (63:2,17 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |123|
-Generated Location: (983:28,17 [3] )
+Generated Location: (1074:30,17 [3] )
 |123|
 
 Source Location: (87:3,18 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |true|
-Generated Location: (1123:35,18 [4] )
+Generated Location: (1214:37,18 [4] )
 |true|
 
 Source Location: (146:5,20 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |new SomeType()|
-Generated Location: (1266:42,20 [14] )
+Generated Location: (1357:44,20 [14] )
 |new SomeType()|
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Component_WithRef/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Component_WithRef/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (70:1,39 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (1132:30,39 [10] )
+Generated Location: (1223:32,39 [10] )
 |myInstance|
 
 Source Location: (119:3,12 [133] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -14,7 +14,7 @@ Source Location: (119:3,12 [133] x:\dir\subdir\Test\TestComponent.cshtml)
 
     void DoSomething() { myInstance.GetHashCode(); } // Avoid 'assigned but not used' warning
 |
-Generated Location: (1316:37,12 [133] )
+Generated Location: (1407:39,12 [133] )
 |
     Test.MyComponent myInstance;
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Element_WithRef/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Element_WithRef/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 Source Location: (36:0,36 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |myElem|
-Generated Location: (865:23,36 [6] )
+Generated Location: (956:25,36 [6] )
 |myElem|
 
 Source Location: (95:2,12 [147] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -9,7 +9,7 @@ Source Location: (95:2,12 [147] x:\dir\subdir\Test\TestComponent.cshtml)
 
     void DoSomething() { myElem.GetHashCode(); } // Avoid 'assigned but not used' warning
 |
-Generated Location: (1067:30,12 [147] )
+Generated Location: (1158:32,12 [147] )
 |
     Microsoft.AspNetCore.Blazor.ElementRef myElem;
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.codegen.cs
@@ -7,11 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-using Microsoft.AspNetCore.Blazor;
-
-#line default
-#line hidden
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219
@@ -28,7 +25,7 @@ using Microsoft.AspNetCore.Blazor;
             __o = Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(OnClick);
         }
         #pragma warning restore 1998
-#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     void OnClick(UIMouseEventArgs e) {
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.ir.txt
@@ -4,7 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
-        UsingDirective - (1:0,1 [33] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"
@@ -18,15 +19,13 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlContent - (34:0,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (34:0,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlElement - (36:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (52:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (53:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                            IntermediateToken - (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-                HtmlContent - (64:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (64:1,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-            CSharpCode - (78:2,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (78:2,12 [49] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick(UIMouseEventArgs e) {\n    }\n
+                HtmlContent - (28:0,28 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    IntermediateToken - (28:0,28 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+            CSharpCode - (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick(UIMouseEventArgs e) {\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
@@ -1,19 +1,14 @@
-Source Location: (1:0,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Blazor|
-Generated Location: (257:10,0 [33] )
-|using Microsoft.AspNetCore.Blazor|
-
-Source Location: (53:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (1032:27,136 [7] )
+Generated Location: (1005:24,136 [7] )
 |OnClick|
 
-Source Location: (78:2,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick(UIMouseEventArgs e) {
     }
 |
-Generated Location: (1155:31,12 [49] )
+Generated Location: (1128:28,12 [49] )
 |
     void OnClick(UIMouseEventArgs e) {
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.codegen.cs
@@ -7,11 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-using Microsoft.AspNetCore.Blazor;
-
-#line default
-#line hidden
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.ir.txt
@@ -4,7 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
-        UsingDirective - (1:0,1 [33] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"
@@ -18,11 +19,9 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlContent - (34:0,34 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (34:0,34 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
-                HtmlElement - (36:1,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (52:1,16 [11] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (0:0,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (16:0,16 [11] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (54:1,18 [8] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - x => { }
+                            IntermediateToken - (18:0,18 [8] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - x => { }
                             IntermediateToken -  - CSharp - )

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.mappings.txt
@@ -1,10 +1,5 @@
-Source Location: (1:0,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Blazor|
-Generated Location: (257:10,0 [33] )
-|using Microsoft.AspNetCore.Blazor|
-
-Source Location: (54:1,18 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (18:0,18 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |x => { }|
-Generated Location: (1032:27,136 [8] )
+Generated Location: (1005:24,136 [8] )
 |x => { }|
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 219

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [32] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [17] ) - System.Linq
         UsingDirective - (73:4,1 [28] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [33] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [44] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             DesignTimeDirective - 
                 DirectiveToken - (14:0,14 [32] ) - "*, Microsoft.AspNetCore.Blazor"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/DesignTimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 Source Location: (14:0,14 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |*, TestAssembly|
-Generated Location: (468:14,38 [15] )
+Generated Location: (559:16,38 [15] )
 |*, TestAssembly|
 
 Source Location: (48:1,17 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |y|
-Generated Location: (1043:28,17 [1] )
+Generated Location: (1134:30,17 [1] )
 |y|
 
 Source Location: (67:2,12 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |
-Generated Location: (1466:40,12 [24] )
+Generated Location: (1557:42,12 [24] )
 |
     string y = null;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.ir.txt
@@ -4,13 +4,14 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (67:2,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (83:2,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (31:1,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (47:1,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
                             IntermediateToken -  - CSharp - "async (e) => await Task.Delay(10)"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
@@ -19,7 +20,7 @@ namespace Test
             builder.CloseElement();
         }
         #pragma warning restore 1998
-#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     Task OnClick(UIMouseEventArgs e) 
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.ir.txt
@@ -4,16 +4,17 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (67:2,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (83:2,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (31:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (47:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (84:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                            IntermediateToken - (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-            CSharpCode - (109:3,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (109:3,12 [91] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick(UIMouseEventArgs e) \n    {\n        return Task.CompletedTask;\n    }\n
+            CSharpCode - (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick(UIMouseEventArgs e) \n    {\n        return Task.CompletedTask;\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
-Source Location: (109:3,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (73:2,12 [91] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Task OnClick(UIMouseEventArgs e) 
     {
         return Task.CompletedTask;
     }
 |
-Generated Location: (922:22,12 [91] )
+Generated Location: (973:23,12 [91] )
 |
     Task OnClick(UIMouseEventArgs e) 
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.ir.txt
@@ -4,13 +4,14 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (67:2,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (83:2,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (31:1,0 [53] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (47:1,16 [33] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
                             IntermediateToken -  - CSharp - "async (e) => await Task.Delay(10)"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
@@ -19,7 +20,7 @@ namespace Test
             builder.CloseElement();
         }
         #pragma warning restore 1998
-#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     Task OnClick() 
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.ir.txt
@@ -4,16 +4,17 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (67:2,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (83:2,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (31:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (47:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (84:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                            IntermediateToken - (48:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-            CSharpCode - (109:3,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (109:3,12 [73] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick() \n    {\n        return Task.CompletedTask;\n    }\n
+            CSharpCode - (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    Task OnClick() \n    {\n        return Task.CompletedTask;\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
-Source Location: (109:3,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (73:2,12 [73] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Task OnClick() 
     {
         return Task.CompletedTask;
     }
 |
-Generated Location: (922:22,12 [73] )
+Generated Location: (973:23,12 [73] )
 |
     Task OnClick() 
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (95:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (957:22,12 [50] )
+Generated Location: (1048:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (95:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1005:22,12 [50] )
+Generated Location: (1096:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (85:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (960:22,12 [50] )
+Generated Location: (1051:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (85:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1008:22,12 [50] )
+Generated Location: (1099:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (122:2,12 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1063:23,12 [77] )
+Generated Location: (1154:25,12 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (101:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1045:23,12 [50] )
+Generated Location: (1136:25,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (78:2,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (990:22,12 [55] )
+Generated Location: (1081:24,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (72:2,12 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |
-Generated Location: (990:22,12 [55] )
+Generated Location: (1081:24,12 [55] )
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (86:2,12 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |
-Generated Location: (1039:23,12 [41] )
+Generated Location: (1130:25,12 [41] )
 |
     public bool Enabled { get; set; }
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -4,7 +4,7 @@ Source Location: (108:2,12 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public string Format { get; set; } = "MM/dd/yyyy";
 |
-Generated Location: (1061:23,12 [135] )
+Generated Location: (1152:25,12 [135] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (111:2,12 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |
-Generated Location: (1073:23,12 [77] )
+Generated Location: (1164:25,12 [77] )
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (86:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1045:23,12 [50] )
+Generated Location: (1136:25,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (74:2,12 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (991:22,12 [50] )
+Generated Location: (1082:24,12 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_Simple/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_Simple/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_Simple/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_Simple/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
@@ -19,7 +20,7 @@ namespace Test
             builder.CloseComponent();
         }
         #pragma warning restore 1998
-#line 5 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 4 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     private int counter;
     private void Increment(UIEventArgs e) {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.ir.txt
@@ -4,14 +4,15 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
-        UsingDirective - (32:1,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                ComponentExtensionNode - (67:2,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
-                    ComponentAttributeExtensionNode - (89:2,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - OnClick
-                        CSharpExpression - (90:2,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
-                            IntermediateToken - (90:2,23 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Increment
-            CSharpCode - (118:4,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (118:4,12 [100] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    private int counter;\n    private void Increment(UIEventArgs e) {\n        counter++;\n    }\n
+                ComponentExtensionNode - (31:1,0 [35] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
+                    ComponentAttributeExtensionNode - (53:1,22 [10] x:\dir\subdir\Test\TestComponent.cshtml) - OnClick - OnClick
+                        CSharpExpression - (54:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+                            IntermediateToken - (54:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Increment
+            CSharpCode - (82:3,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (82:3,12 [100] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    private int counter;\n    private void Increment(UIEventArgs e) {\n        counter++;\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
-Source Location: (118:4,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (82:3,12 [100] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment(UIEventArgs e) {
         counter++;
     }
 |
-Generated Location: (878:22,12 [100] )
+Generated Location: (929:23,12 [100] )
 |
     private int counter;
     private void Increment(UIEventArgs e) {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
@@ -5,7 +5,7 @@ Source Location: (96:3,12 [87] x:\dir\subdir\Test\TestComponent.cshtml)
         counter++;
     }
 |
-Generated Location: (850:21,12 [87] )
+Generated Location: (941:23,12 [87] )
 |
     private int counter;
     private void Increment() {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     [Microsoft.AspNetCore.Blazor.Components.RouteAttribute("/MyPage")]
     [Microsoft.AspNetCore.Blazor.Components.RouteAttribute("/AnotherRoute/{id}")]
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         RouteAttributeExtensionNode -  - /MyPage
         RouteAttributeExtensionNode -  - /AnotherRoute/{id}
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (70:1,39 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (849:20,39 [10] )
+Generated Location: (940:22,39 [10] )
 |myInstance|
 
 Source Location: (119:3,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Test.MyComponent myInstance;
 |
-Generated Location: (1103:30,12 [44] )
+Generated Location: (1194:32,12 [44] )
 |
     private Test.MyComponent myInstance;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (49:1,18 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (1160:28,18 [10] )
+Generated Location: (1251:30,18 [10] )
 |myInstance|
 
 Source Location: (143:5,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Test.MyComponent myInstance;
 |
-Generated Location: (1414:38,12 [44] )
+Generated Location: (1505:40,12 [44] )
 |
     private Test.MyComponent myInstance;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Element_WithRef/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Element_WithRef/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Element_WithRef/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Element_WithRef/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (36:0,36 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |myElem|
-Generated Location: (840:20,36 [6] )
+Generated Location: (931:22,36 [6] )
 |myElem|
 
 Source Location: (95:2,12 [62] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Microsoft.AspNetCore.Blazor.ElementRef myElem;
 |
-Generated Location: (1115:31,12 [62] )
+Generated Location: (1206:33,12 [62] )
 |
     private Microsoft.AspNetCore.Blazor.ElementRef myElem;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
@@ -19,7 +20,7 @@ namespace Test
             builder.CloseElement();
         }
         #pragma warning restore 1998
-#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     void OnClick(UIEventArgs e) {
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.ir.txt
@@ -4,16 +4,17 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
-        UsingDirective - (1:0,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (36:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (52:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (53:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                            IntermediateToken - (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-            CSharpCode - (78:2,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (78:2,12 [44] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick(UIEventArgs e) {\n    }\n
+            CSharpCode - (42:1,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (42:1,12 [44] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick(UIEventArgs e) {\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -1,9 +1,9 @@
-Source Location: (78:2,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (42:1,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick(UIEventArgs e) {
     }
 |
-Generated Location: (922:22,12 [44] )
+Generated Location: (973:23,12 [44] )
 |
     void OnClick(UIEventArgs e) {
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.ir.txt
@@ -4,14 +4,15 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
-        UsingDirective - (1:0,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (36:1,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (52:1,16 [11] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (0:0,0 [31] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (16:0,16 [11] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (54:1,18 [8] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - x => { }
+                            IntermediateToken - (18:0,18 [8] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - x => { }
                             IntermediateToken -  - CSharp - )

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
@@ -19,7 +20,7 @@ namespace Test
             builder.CloseElement();
         }
         #pragma warning restore 1998
-#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     void OnClick(UIMouseEventArgs e) {
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.ir.txt
@@ -4,16 +4,17 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
-        UsingDirective - (1:0,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (36:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (52:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (53:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                            IntermediateToken - (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-            CSharpCode - (78:2,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (78:2,12 [49] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick(UIMouseEventArgs e) {\n    }\n
+            CSharpCode - (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick(UIMouseEventArgs e) {\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -1,9 +1,9 @@
-Source Location: (78:2,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (42:1,12 [49] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick(UIMouseEventArgs e) {
     }
 |
-Generated Location: (922:22,12 [49] )
+Generated Location: (973:23,12 [49] )
 |
     void OnClick(UIMouseEventArgs e) {
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998
@@ -19,7 +20,7 @@ namespace Test
             builder.CloseElement();
         }
         #pragma warning restore 1998
-#line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
             
     void OnClick() {
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.ir.txt
@@ -4,16 +4,17 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
-        UsingDirective - (1:0,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (36:1,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (52:1,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (0:0,0 [28] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (16:0,16 [8] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (53:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
+                            IntermediateToken - (17:0,17 [7] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - OnClick
                             IntermediateToken -  - CSharp - )
-            CSharpCode - (78:2,12 [31] x:\dir\subdir\Test\TestComponent.cshtml)
-                IntermediateToken - (78:2,12 [31] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick() {\n    }\n
+            CSharpCode - (42:1,12 [31] x:\dir\subdir\Test\TestComponent.cshtml)
+                IntermediateToken - (42:1,12 [31] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    void OnClick() {\n    }\n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
@@ -1,9 +1,9 @@
-Source Location: (78:2,12 [31] x:\dir\subdir\Test\TestComponent.cshtml)
+Source Location: (42:1,12 [31] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick() {
     }
 |
-Generated Location: (922:22,12 [31] )
+Generated Location: (973:23,12 [31] )
 |
     void OnClick() {
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.codegen.cs
@@ -8,6 +8,7 @@ namespace Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.ir.txt
@@ -4,14 +4,15 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
-        UsingDirective - (1:0,1 [35] x:\dir\subdir\Test\TestComponent.cshtml) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (36:1,0 [32] x:\dir\subdir\Test\TestComponent.cshtml) - input
-                    HtmlAttribute - (52:1,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
+                HtmlElement - (0:0,0 [32] x:\dir\subdir\Test\TestComponent.cshtml) - input
+                    HtmlAttribute - (16:0,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - onclick=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - Microsoft.AspNetCore.Blazor.Components.BindMethods.GetEventHandlerValue<Microsoft.AspNetCore.Blazor.UIMouseEventArgs>(
-                            IntermediateToken - (54:1,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
+                            IntermediateToken - (18:0,18 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
                             IntermediateToken -  - CSharp - )

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_597/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_597/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -2,7 +2,7 @@ Source Location: (67:2,12 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |
-Generated Location: (966:22,12 [24] )
+Generated Location: (1057:24,12 [24] )
 |
     string y = null;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ScriptTag_WithErrorSuppressed/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {
         #pragma warning disable 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -7,6 +7,8 @@ namespace Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Blazor;
+    using Microsoft.AspNetCore.Blazor.Components;
     [Microsoft.AspNetCore.Blazor.Components.RouteAttribute("/my/url")]
     public class TestComponent : Microsoft.AspNetCore.Blazor.Components.BlazorComponent
     {

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -4,6 +4,8 @@ Document -
         UsingDirective - (18:2,1 [34] ) - System.Collections.Generic
         UsingDirective - (53:3,1 [19] ) - System.Linq
         UsingDirective - (73:4,1 [30] ) - System.Threading.Tasks
+        UsingDirective - (104:5,1 [35] ) - Microsoft.AspNetCore.Blazor
+        UsingDirective - (140:6,1 [46] ) - Microsoft.AspNetCore.Blazor.Components
         RouteAttributeExtensionNode -  - /my/url
         ClassDeclaration -  - public - TestComponent - Microsoft.AspNetCore.Blazor.Components.BlazorComponent - 
             MethodDeclaration -  - protected override - void - BuildRenderTree

--- a/test/testapps/BasicTestApp/AfterRenderInteropComponent.cshtml
+++ b/test/testapps/BasicTestApp/AfterRenderInteropComponent.cshtml
@@ -1,5 +1,4 @@
-﻿@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Browser.Interop
+﻿@using Microsoft.AspNetCore.Blazor.Browser.Interop
 
 <input ref="myInput" value="Value set during render" />
 

--- a/test/testapps/BasicTestApp/AsyncEventHandlerComponent.cshtml
+++ b/test/testapps/BasicTestApp/AsyncEventHandlerComponent.cshtml
@@ -1,5 +1,4 @@
 ﻿@using System.Threading.Tasks
-@using Microsoft.AspNetCore.Blazor
 
 <div>
     <span id="state">@state</span>

--- a/test/testapps/BasicTestApp/BindCasesComponent.cshtml
+++ b/test/testapps/BasicTestApp/BindCasesComponent.cshtml
@@ -1,5 +1,4 @@
-﻿@using Microsoft.AspNetCore.Blazor
-<h2>Textbox</h2>
+﻿<h2>Textbox</h2>
 <p>
     Initially blank:
     <input id="textbox-initially-blank" bind="textboxInitiallyBlankValue" />

--- a/test/testapps/BasicTestApp/ComponentRefComponent.cshtml
+++ b/test/testapps/BasicTestApp/ComponentRefComponent.cshtml
@@ -1,6 +1,4 @@
-﻿@using Microsoft.AspNetCore.Blazor
-
-<h1>Component capture</h1>
+﻿<h1>Component capture</h1>
 
 <p>
     This shows how a component reference may be captured as a field value using 'ref' syntax.

--- a/test/testapps/BasicTestApp/ElementRefComponent.cshtml
+++ b/test/testapps/BasicTestApp/ElementRefComponent.cshtml
@@ -1,5 +1,4 @@
-﻿@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Browser.Interop
+﻿@using Microsoft.AspNetCore.Blazor.Browser.Interop
 
 <h1>Element capture</h1>
 

--- a/test/testapps/BasicTestApp/FocusEventComponent.cshtml
+++ b/test/testapps/BasicTestApp/FocusEventComponent.cshtml
@@ -1,5 +1,4 @@
 ﻿@using System.Collections.Generic
-@using Microsoft.AspNetCore.Blazor
 
 <h2>Focus and activation</h2>
 

--- a/test/testapps/BasicTestApp/KeyPressEventComponent.cshtml
+++ b/test/testapps/BasicTestApp/KeyPressEventComponent.cshtml
@@ -1,5 +1,5 @@
 ﻿@using System.Collections.Generic
-@using Microsoft.AspNetCore.Blazor
+
 Type here: <input onkeypress=@OnKeyPressed />
 <ul>
     @foreach (var key in keysPressed)

--- a/test/testapps/BasicTestApp/MessageComponent.cshtml
+++ b/test/testapps/BasicTestApp/MessageComponent.cshtml
@@ -1,5 +1,4 @@
-﻿@using Microsoft.AspNetCore.Blazor.Components
-<span style="color: red" class="message">@Message</span>
+﻿<span style="color: red" class="message">@Message</span>
 @functions {
     [Parameter] string Message { get; set; }
 }

--- a/test/testapps/BasicTestApp/MouseEventComponent.cshtml
+++ b/test/testapps/BasicTestApp/MouseEventComponent.cshtml
@@ -1,7 +1,4 @@
 ﻿@using System.Collections.Generic
-@using Microsoft.AspNetCore.Blazor
-
-
 
 <div>
     <h2>Mouse position</h2>

--- a/test/testapps/BasicTestApp/PassThroughContentComponent.cshtml
+++ b/test/testapps/BasicTestApp/PassThroughContentComponent.cshtml
@@ -1,6 +1,4 @@
-﻿@using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Components
-@ChildContent
+﻿@ChildContent
 @functions {
     // Note: The lack of any whitespace or other output besides @ChildContent is important for
     // what scenarios this component is used for in E2E tests.

--- a/test/testapps/BasicTestApp/PropertiesChangedHandlerChild.cshtml
+++ b/test/testapps/BasicTestApp/PropertiesChangedHandlerChild.cshtml
@@ -1,5 +1,4 @@
-﻿@using Microsoft.AspNetCore.Blazor.Components
-<div class="supplied">You supplied: @SuppliedValue</div>
+﻿<div class="supplied">You supplied: @SuppliedValue</div>
 <div class="computed">I computed: @computedValue</div>
 
 @functions {

--- a/test/testapps/BasicTestApp/RenderFragmentToggler.cshtml
+++ b/test/testapps/BasicTestApp/RenderFragmentToggler.cshtml
@@ -1,5 +1,4 @@
-﻿@using Microsoft.AspNetCore.Blazor
-<div>
+﻿<div>
     <p>Fragment will be toggled below</p>
 
     @if (showFragment)


### PR DESCRIPTION
Fixes #749.

I know that arguably we don't *have* to do this (C# developers already add `using` for things they need), but for a Blazor cshtml file there's basically no scenario where you'd ever not want to import `Microsoft.AspNetCore.Blazor` and `Microsoft.AspNetCore.Blazor.Components`. So this PR adds those namespaces to the ones implicitly referenced both at design time and build time. Can't think of any reason we shouldn't do this.

It looks like a big PR because so many baseline files are affected, but really it's quite a small change. For easier review, you might want to consider each of the commits separately.

I'm not proposing to auto-add other namespaces like `.Routing`, `.Layouts`, `.Browser.Interop`, etc., because there are plenty of cases where you might not want them, and their type names might clash with some other library you're using.