### PR TITLE
Add support for pointer events, change oncontextmenu event type

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
@@ -40,6 +40,7 @@
       case 'keypress':
         return new EventForDotNet<UIKeyboardEventArgs>('keyboard', { Type: event.type, Key: (event as any).key });
 
+      case 'contextmenu':
       case 'click':
       case 'mouseover':
       case 'mouseout':
@@ -49,9 +50,6 @@
       case 'dblclick':
         return new EventForDotNet<UIMouseEventArgs>('mouse', { Type: event.type });
 
-      case 'contextmenu':
-        return new EventForDotNet<UIPointerEventArgs>('pointer', { Type: event.type });
-
       case 'progress':
         return new EventForDotNet<UIProgressEventArgs>('progress', { Type: event.type });
 
@@ -60,6 +58,18 @@
       case 'touchmove':
       case 'touchstart':
         return new EventForDotNet<UITouchEventArgs>('touch', { Type: event.type });
+
+      case 'gotpointercapture':
+      case 'lostpointercapture':
+      case 'pointercancel':
+      case 'pointerdown':
+      case 'pointerenter':
+      case 'pointerleave':
+      case 'pointermove':
+      case 'pointerout':
+      case 'pointerover':
+      case 'pointerup':
+        return new EventForDotNet<UIPointerEventArgs>('pointer', { Type: event.type });
 
       case 'mousewheel':
         return new EventForDotNet<UIWheelEventArgs>('wheel', { Type: event.type });

--- a/src/Microsoft.AspNetCore.Blazor/Components/EventHandlers.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/EventHandlers.cs
@@ -25,6 +25,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
     [EventHandler("onclick", typeof(UIMouseEventArgs))]
     [EventHandler("ondblclick", typeof(UIMouseEventArgs))]
     [EventHandler("onmousewheel", typeof(UIWheelEventArgs))]
+    [EventHandler("oncontextmenu", typeof(UIMouseEventArgs))]
 
     // Drag events
     [EventHandler("ondrag", typeof(UIDragEventArgs))]
@@ -39,9 +40,6 @@ namespace Microsoft.AspNetCore.Blazor.Components
     [EventHandler("onkeydown", typeof(UIKeyboardEventArgs))]
     [EventHandler("onkeyup", typeof(UIKeyboardEventArgs))]
     [EventHandler("onkeypress", typeof(UIKeyboardEventArgs))]
-
-    // Pointer events
-    [EventHandler("oncontextmenu", typeof(UIPointerEventArgs))]
 
     // Input events
     [EventHandler("onchange", typeof(UIChangeEventArgs))]
@@ -66,6 +64,18 @@ namespace Microsoft.AspNetCore.Blazor.Components
     [EventHandler("ontouchend", typeof(UITouchEventArgs))]
     [EventHandler("ontouchmove", typeof(UITouchEventArgs))]
     [EventHandler("ontouchstart", typeof(UITouchEventArgs))]
+
+    // Pointer events
+    [EventHandler("gotpointercapture", typeof(UIPointerEventArgs))]
+    [EventHandler("lostpointercapture", typeof(UIPointerEventArgs))]
+    [EventHandler("pointercancel", typeof(UIPointerEventArgs))]
+    [EventHandler("pointerdown", typeof(UIPointerEventArgs))]
+    [EventHandler("pointerenter", typeof(UIPointerEventArgs))]
+    [EventHandler("pointerleave", typeof(UIPointerEventArgs))]
+    [EventHandler("pointermove", typeof(UIPointerEventArgs))]
+    [EventHandler("pointerout", typeof(UIPointerEventArgs))]
+    [EventHandler("pointerover", typeof(UIPointerEventArgs))]
+    [EventHandler("pointerup", typeof(UIPointerEventArgs))]
 
     // Media events
     [EventHandler("oncanplay", typeof(UIEventArgs))]


### PR DESCRIPTION
- Add support for pointer events
- Change oncontextmenu event from pointerevent to mouseevent (based on MDN docs)

Fixes: https://github.com/aspnet/Blazor/issues/763