### PR TITLE
[WIP] Prerendering

### DIFF
--- a/Blazor.sln
+++ b/Blazor.sln
@@ -77,7 +77,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHosted-CSharp.Client"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHosted-CSharp.Server", "src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted-CSharp\BlazorHosted-CSharp.Server\BlazorHosted-CSharp.Server.csproj", "{78ED9932-0912-4F36-8F82-33DE850E7A33}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorHosted-CSharp.Shared", "src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted-CSharp\BlazorHosted-CSharp.Shared\BlazorHosted-CSharp.Shared.csproj", "{F3E02B21-1127-431A-B832-0E53CB72097B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHosted-CSharp.Shared", "src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted-CSharp\BlazorHosted-CSharp.Shared\BlazorHosted-CSharp.Shared.csproj", "{F3E02B21-1127-431A-B832-0E53CB72097B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Prerendering", "Prerendering", "{0A6A1E7D-2236-4695-A5B1-0A82EEED0B6C}"
 EndProject
@@ -299,19 +299,31 @@ Global
 		{F3E02B21-1127-431A-B832-0E53CB72097B}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
 		{F3E02B21-1127-431A-B832-0E53CB72097B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3E02B21-1127-431A-B832-0E53CB72097B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3E02B21-1127-431A-B832-0E53CB72097B}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{9C424433-8AA6-452B-BA9E-01ACD2852176}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9C424433-8AA6-452B-BA9E-01ACD2852176}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C424433-8AA6-452B-BA9E-01ACD2852176}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C424433-8AA6-452B-BA9E-01ACD2852176}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
 		{9C424433-8AA6-452B-BA9E-01ACD2852176}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C424433-8AA6-452B-BA9E-01ACD2852176}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C424433-8AA6-452B-BA9E-01ACD2852176}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{9C424433-8AA6-452B-BA9E-01ACD2852176}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
 		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
 		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F3E02B21-1127-431A-B832-0E53CB72097B}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
 		{FF25111E-5A3E-48A3-96D8-08A2C5A2A91C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FF25111E-5A3E-48A3-96D8-08A2C5A2A91C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF25111E-5A3E-48A3-96D8-08A2C5A2A91C}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU

--- a/Blazor.sln
+++ b/Blazor.sln
@@ -77,7 +77,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHosted-CSharp.Client"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHosted-CSharp.Server", "src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted-CSharp\BlazorHosted-CSharp.Server\BlazorHosted-CSharp.Server.csproj", "{78ED9932-0912-4F36-8F82-33DE850E7A33}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorHosted-CSharp.Shared", "src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted-CSharp\BlazorHosted-CSharp.Shared\BlazorHosted-CSharp.Shared.csproj", "{F3E02B21-1127-431A-B832-0E53CB72097B}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorHosted-CSharp.Shared", "src\Microsoft.AspNetCore.Blazor.Templates\content\BlazorHosted-CSharp\BlazorHosted-CSharp.Shared\BlazorHosted-CSharp.Shared.csproj", "{F3E02B21-1127-431A-B832-0E53CB72097B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Prerendering", "Prerendering", "{0A6A1E7D-2236-4695-A5B1-0A82EEED0B6C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Blazor.Server.Rendering", "src\Microsoft.AspNetCore.Blazor.Server.Rendering\Microsoft.AspNetCore.Blazor.Server.Rendering.csproj", "{9C424433-8AA6-452B-BA9E-01ACD2852176}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrerenderingApp.Client", "samples\PrerenderingApp.Client\PrerenderingApp.Client.csproj", "{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PrerenderingApp.Server", "samples\PrerenderingApp.Server\PrerenderingApp.Server.csproj", "{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Blazor.Razor.Extensions.Test", "test\Microsoft.AspNetCore.Blazor.Razor.Extensions.Test\Microsoft.AspNetCore.Blazor.Razor.Extensions.Test.csproj", "{FF25111E-5A3E-48A3-96D8-08A2C5A2A91C}"
 EndProject
@@ -291,6 +299,18 @@ Global
 		{F3E02B21-1127-431A-B832-0E53CB72097B}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
 		{F3E02B21-1127-431A-B832-0E53CB72097B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3E02B21-1127-431A-B832-0E53CB72097B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C424433-8AA6-452B-BA9E-01ACD2852176}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C424433-8AA6-452B-BA9E-01ACD2852176}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C424433-8AA6-452B-BA9E-01ACD2852176}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C424433-8AA6-452B-BA9E-01ACD2852176}.Release|Any CPU.Build.0 = Release|Any CPU
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F3E02B21-1127-431A-B832-0E53CB72097B}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{FF25111E-5A3E-48A3-96D8-08A2C5A2A91C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FF25111E-5A3E-48A3-96D8-08A2C5A2A91C}.Debug|Any CPU.Build.0 = Debug|Any CPU
@@ -386,6 +406,10 @@ Global
 		{7549444A-9C81-44DE-AD0D-2C55501EAAC7} = {73DA1DFD-79F0-4BA2-B0B6-4F3A21D2C3F8}
 		{78ED9932-0912-4F36-8F82-33DE850E7A33} = {73DA1DFD-79F0-4BA2-B0B6-4F3A21D2C3F8}
 		{F3E02B21-1127-431A-B832-0E53CB72097B} = {73DA1DFD-79F0-4BA2-B0B6-4F3A21D2C3F8}
+		{0A6A1E7D-2236-4695-A5B1-0A82EEED0B6C} = {F5FDD4E5-6A52-4A86-BE5E-5E42CB1DC8DA}
+		{9C424433-8AA6-452B-BA9E-01ACD2852176} = {B867E038-B3CE-43E3-9292-61568C46CDEB}
+		{034F0B11-DBA2-44A9-932E-BFCD94DB5F7D} = {0A6A1E7D-2236-4695-A5B1-0A82EEED0B6C}
+		{A61788D9-3764-4BC5-A5BB-118D4A10BBEB} = {0A6A1E7D-2236-4695-A5B1-0A82EEED0B6C}
 		{FF25111E-5A3E-48A3-96D8-08A2C5A2A91C} = {ADA3AE29-F6DE-49F6-8C7C-B321508CAE8E}
 		{43E39257-7DC1-46BD-9BD9-2319A1313D07} = {F563ABB6-85FB-4CFC-B0D2-1D5130E8246D}
 		{9088E4E4-B855-457F-AE9E-D86709A5E1F4} = {F563ABB6-85FB-4CFC-B0D2-1D5130E8246D}

--- a/samples/PrerenderingApp.Client/ClientWeatherService.cs
+++ b/samples/PrerenderingApp.Client/ClientWeatherService.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Blazor;
+
+namespace PrerenderingApp.Client
+{
+    public class ClientWeatherService : IWeatherService
+    {
+        private readonly HttpClient _httpClient;
+
+        public ClientWeatherService(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<IEnumerable<WeatherForecast>> GetForecast()
+        {
+            return await _httpClient.GetJsonAsync<WeatherForecast[]>("/api/SampleData/WeatherForecasts");
+        }
+    }
+}

--- a/samples/PrerenderingApp.Client/ConsumeService.cshtml
+++ b/samples/PrerenderingApp.Client/ConsumeService.cshtml
@@ -1,0 +1,14 @@
+﻿@inject Greeter Greeter
+
+<div>
+    <h2>@Greeter.Greet(name)</h2>
+    <div>
+        <input type="text" @bind(name) placeholder="enter name"/>
+    </div>
+</div>
+
+@functions {
+
+    string name = null;
+
+}

--- a/samples/PrerenderingApp.Client/ConsumeService.cshtml
+++ b/samples/PrerenderingApp.Client/ConsumeService.cshtml
@@ -3,7 +3,7 @@
 <div>
     <h2>@Greeter.Greet(name)</h2>
     <div>
-        <input type="text" @bind(name) placeholder="enter name"/>
+        <input type="text" bind=@name placeholder="enter name"/>
     </div>
 </div>
 

--- a/samples/PrerenderingApp.Client/FetchData.cshtml
+++ b/samples/PrerenderingApp.Client/FetchData.cshtml
@@ -1,0 +1,43 @@
+﻿@inject IWeatherService WeatherService
+
+<h1>Weather forecast</h1>
+
+<p>This component demonstrates fetching data from the server.</p>
+
+@if (forecasts == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class='table'>
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Temp. (C)</th>
+                <th>Temp. (F)</th>
+                <th>Summary</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var forecast in forecasts)
+            {
+                <tr>
+                    <td>@forecast.Date.ToShortDateString()</td>
+                    <td>@forecast.TemperatureC</td>
+                    <td>@forecast.TemperatureF</td>
+                    <td>@forecast.Summary</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@functions {
+    WeatherForecast[] forecasts;
+
+    protected override async Task OnInitAsync()
+    {
+        forecasts = (await WeatherService.GetForecast()).ToArray();
+    }
+}

--- a/samples/PrerenderingApp.Client/Greeter.cs
+++ b/samples/PrerenderingApp.Client/Greeter.cs
@@ -1,0 +1,10 @@
+﻿namespace PrerenderingApp.Client
+{
+    public class Greeter
+    {
+        public string Greet(string name)
+        {
+            return $"Hello {name}";
+        }
+    }
+}

--- a/samples/PrerenderingApp.Client/Home.cshtml
+++ b/samples/PrerenderingApp.Client/Home.cshtml
@@ -1,12 +1,22 @@
-﻿<h1>Hello, world!</h1>
+﻿<h1>Prerendering Sample</h1>
 
-<c:MyInput />
-<c:MyInput />
-<c:MyInput />
+<h3>Input component</h3>
 <c:MyInput />
 
-<br>
-
+<h3>List component</h3>
 <c:MyList />
 
+<h3>Input element</h3>
 <input type="text" />
+
+<div>
+    <h3>Bound inputs</h3>
+    <input type="text" @bind(test)/>
+    <input type="text" @bind(test)/>
+</div>
+
+@functions {
+
+string test = "hello";
+
+}

--- a/samples/PrerenderingApp.Client/Home.cshtml
+++ b/samples/PrerenderingApp.Client/Home.cshtml
@@ -1,6 +1,6 @@
 ﻿<h1>Prerendering Sample</h1>
 
-<h3>Input component</h3>
+@*<h3>Input component</h3>
 <c:MyInput />
 
 <h3>List component</h3>
@@ -16,13 +16,13 @@
 </div>
 
 <h3>Consume same service on client and server</h3>
-<c:ConsumeService />
+<c:ConsumeService />*@
 
 <h3>Consume different service on client and server</h3>
 <c:FetchData />
 
 @functions {
 
-string test = "hello";
+    //string test = "hello";
 
 }

--- a/samples/PrerenderingApp.Client/Home.cshtml
+++ b/samples/PrerenderingApp.Client/Home.cshtml
@@ -11,12 +11,15 @@
 
 <div>
     <h3>Bound inputs</h3>
-    <input type="text" @bind(test)/>
-    <input type="text" @bind(test)/>
+    <input type="text" @bind(test) />
+    <input type="text" @bind(test) />
 </div>
 
-<h3>Consume Service</h3>
+<h3>Consume same service on client and server</h3>
 <c:ConsumeService />
+
+<h3>Consume different service on client and server</h3>
+<c:FetchData />
 
 @functions {
 

--- a/samples/PrerenderingApp.Client/Home.cshtml
+++ b/samples/PrerenderingApp.Client/Home.cshtml
@@ -1,28 +1,28 @@
 ﻿<h1>Prerendering Sample</h1>
 
-@*<h3>Input component</h3>
-<c:MyInput />
+<h3>Input component</h3>
+<MyInput />
 
 <h3>List component</h3>
-<c:MyList />
+<MyList />
 
 <h3>Input element</h3>
 <input type="text" />
 
 <div>
     <h3>Bound inputs</h3>
-    <input type="text" @bind(test) />
-    <input type="text" @bind(test) />
+    <input type="text" bind=@test />
+    <input type="text" bind=@test />
 </div>
 
 <h3>Consume same service on client and server</h3>
-<c:ConsumeService />*@
+<ConsumeService />
 
 <h3>Consume different service on client and server</h3>
 <FetchData />
 
 @functions {
 
-    //string test = "hello";
+    string test = "hello";
 
 }

--- a/samples/PrerenderingApp.Client/Home.cshtml
+++ b/samples/PrerenderingApp.Client/Home.cshtml
@@ -1,0 +1,12 @@
+﻿<h1>Hello, world!</h1>
+
+<c:MyInput />
+<c:MyInput />
+<c:MyInput />
+<c:MyInput />
+
+<br>
+
+<c:MyList />
+
+<input type="text" />

--- a/samples/PrerenderingApp.Client/Home.cshtml
+++ b/samples/PrerenderingApp.Client/Home.cshtml
@@ -19,7 +19,7 @@
 <c:ConsumeService />*@
 
 <h3>Consume different service on client and server</h3>
-<c:FetchData />
+<FetchData />
 
 @functions {
 

--- a/samples/PrerenderingApp.Client/Home.cshtml
+++ b/samples/PrerenderingApp.Client/Home.cshtml
@@ -15,6 +15,9 @@
     <input type="text" @bind(test)/>
 </div>
 
+<h3>Consume Service</h3>
+<c:ConsumeService />
+
 @functions {
 
 string test = "hello";

--- a/samples/PrerenderingApp.Client/IWeatherService.cs
+++ b/samples/PrerenderingApp.Client/IWeatherService.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PrerenderingApp.Client
+{
+    public interface IWeatherService
+    {
+        Task<IEnumerable<WeatherForecast>> GetForecast();
+    }
+}

--- a/samples/PrerenderingApp.Client/MyInput.cshtml
+++ b/samples/PrerenderingApp.Client/MyInput.cshtml
@@ -1,10 +1,1 @@
-﻿@using System.Diagnostics
-
-<input type="text" value="stuff" />
-
-
-@functions{ 
-
-    
-
-}
+﻿<input type="text" value="component" />

--- a/samples/PrerenderingApp.Client/MyInput.cshtml
+++ b/samples/PrerenderingApp.Client/MyInput.cshtml
@@ -1,0 +1,10 @@
+﻿@using System.Diagnostics
+
+<input type="text" value="stuff" />
+
+
+@functions{ 
+
+    
+
+}

--- a/samples/PrerenderingApp.Client/MyList.cshtml
+++ b/samples/PrerenderingApp.Client/MyList.cshtml
@@ -1,0 +1,17 @@
+﻿@foreach (var item in items)
+{
+    <div>@item</div>
+}
+
+@functions {
+
+    int[] items = new[] {1, 2, 3, 4};
+
+
+    protected override void OnInit()
+    {
+        base.OnInit();
+
+        items = new[] {6, 7, 8, 9};
+    }
+}

--- a/samples/PrerenderingApp.Client/MyList.cshtml
+++ b/samples/PrerenderingApp.Client/MyList.cshtml
@@ -7,7 +7,6 @@
 
     int[] items = new[] {1, 2, 3, 4};
 
-
     protected override void OnInit()
     {
         base.OnInit();

--- a/samples/PrerenderingApp.Client/PrerenderingApp.Client.csproj
+++ b/samples/PrerenderingApp.Client/PrerenderingApp.Client.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Local alternative to <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" /> -->
+  <Import Project="..\..\src\Microsoft.AspNetCore.Blazor.Build\ReferenceFromSource.props" />
+  <ItemGroup>
+    <!-- TODO: Remove the "PrivateAssets=all" once we no longer have RazorToolingWorkaround.cs -->
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Browser\Microsoft.AspNetCore.Blazor.Browser.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/PrerenderingApp.Client/PrerenderingApp.Client.csproj
+++ b/samples/PrerenderingApp.Client/PrerenderingApp.Client.csproj
@@ -1,15 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+
+    <!-- Temporary workaround for a VS build issue -->
+    <BlazorRebuildOnFileChange>false</BlazorRebuildOnFileChange>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Browser\Microsoft.AspNetCore.Blazor.Browser.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
+  </ItemGroup>
 
   <!-- Local alternative to <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" /> -->
   <Import Project="..\..\src\Microsoft.AspNetCore.Blazor.Build\ReferenceFromSource.props" />
-  <ItemGroup>
-    <!-- TODO: Remove the "PrivateAssets=all" once we no longer have RazorToolingWorkaround.cs -->
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Browser\Microsoft.AspNetCore.Blazor.Browser.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
-  </ItemGroup>
 
 </Project>

--- a/samples/PrerenderingApp.Client/Program.cs
+++ b/samples/PrerenderingApp.Client/Program.cs
@@ -23,11 +23,5 @@ namespace PrerenderingApp.Client
         {
             new BrowserRenderer().AddComponent<Home>("app");
         }
-
-        /*static void Server(string[] args)
-        {
-            var renderer = new PreRenderer();//.AddComponent<Home>("app");
-            renderer.DoStuff<Home>();
-        }*/
     }
 }

--- a/samples/PrerenderingApp.Client/Program.cs
+++ b/samples/PrerenderingApp.Client/Program.cs
@@ -1,18 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
-using Microsoft.AspNetCore.Blazor.Browser.Http;
 using Microsoft.AspNetCore.Blazor.Browser.Rendering;
 using Microsoft.AspNetCore.Blazor.Browser.Services;
-using Microsoft.AspNetCore.Blazor.Components;
-using Microsoft.AspNetCore.Blazor.Rendering;
-using Microsoft.AspNetCore.Blazor.RenderTree;
-using Microsoft.AspNetCore.Blazor.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace PrerenderingApp.Client
 {
@@ -23,6 +14,7 @@ namespace PrerenderingApp.Client
             var serviceProvider = new BrowserServiceProvider(configure =>
             {
                 configure.AddSharedServices();
+                configure.AddSingleton<IWeatherService, ClientWeatherService>();
             });
 
             new BrowserRenderer(serviceProvider).AddComponent<Home>("app");

--- a/samples/PrerenderingApp.Client/Program.cs
+++ b/samples/PrerenderingApp.Client/Program.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Blazor.Components;
 using Microsoft.AspNetCore.Blazor.Rendering;
 using Microsoft.AspNetCore.Blazor.RenderTree;
 using Microsoft.AspNetCore.Blazor.Services;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace PrerenderingApp.Client
 {
@@ -21,7 +20,12 @@ namespace PrerenderingApp.Client
     {
         static void Main(string[] args)
         {
-            new BrowserRenderer().AddComponent<Home>("app");
+            var serviceProvider = new BrowserServiceProvider(configure =>
+            {
+                configure.AddSharedServices();
+            });
+
+            new BrowserRenderer(serviceProvider).AddComponent<Home>("app");
         }
     }
 }

--- a/samples/PrerenderingApp.Client/Program.cs
+++ b/samples/PrerenderingApp.Client/Program.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using Microsoft.AspNetCore.Blazor.Browser.Http;
+using Microsoft.AspNetCore.Blazor.Browser.Rendering;
+using Microsoft.AspNetCore.Blazor.Browser.Services;
+using Microsoft.AspNetCore.Blazor.Components;
+using Microsoft.AspNetCore.Blazor.Rendering;
+using Microsoft.AspNetCore.Blazor.RenderTree;
+using Microsoft.AspNetCore.Blazor.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace PrerenderingApp.Client
+{
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            new BrowserRenderer().AddComponent<Home>("app");
+        }
+
+        /*static void Server(string[] args)
+        {
+            var renderer = new PreRenderer();//.AddComponent<Home>("app");
+            renderer.DoStuff<Home>();
+        }*/
+    }
+}

--- a/samples/PrerenderingApp.Client/ServiceCollectionExtensions.cs
+++ b/samples/PrerenderingApp.Client/ServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace PrerenderingApp.Client
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddSharedServices(this IServiceCollection configure)
+        {
+            configure.AddSingleton<Greeter>();
+        }
+    }
+}

--- a/samples/PrerenderingApp.Client/WeatherForecast.cs
+++ b/samples/PrerenderingApp.Client/WeatherForecast.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace PrerenderingApp.Client
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+        public int TemperatureC { get; set; }
+        public string Summary { get; set; }
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    }
+}

--- a/samples/PrerenderingApp.Client/wwwroot/customJsFileForTests.js
+++ b/samples/PrerenderingApp.Client/wwwroot/customJsFileForTests.js
@@ -1,0 +1,3 @@
+﻿// This is only used for E2E tests to verify that we're correctly serving static content.
+// Later this will be replaced with something more useful.
+window.customJsWasLoaded = true;

--- a/samples/PrerenderingApp.Client/wwwroot/index.html
+++ b/samples/PrerenderingApp.Client/wwwroot/index.html
@@ -1,0 +1,12 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Sample Blazor app</title>
+</head>
+<body>
+    <app>Loading...</app>
+    <script src="customJsFileForTests.js"></script>
+    <script type="blazor-boot"></script>
+</body>
+</html>

--- a/samples/PrerenderingApp.Server/Controller/SampleDataController.cs
+++ b/samples/PrerenderingApp.Server/Controller/SampleDataController.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using PrerenderingApp.Client;
+
+namespace PrerenderingApp.Server.Controller
+{
+    [Route("api/[controller]")]
+    public class SampleDataController : Microsoft.AspNetCore.Mvc.Controller
+    {
+        private readonly IWeatherService _weatherService;
+
+        public SampleDataController(IWeatherService weatherService)
+        {
+            _weatherService = weatherService;
+        }
+
+        [HttpGet("[action]")]
+        public async Task<IEnumerable<WeatherForecast>> WeatherForecasts()
+        {
+            return await _weatherService.GetForecast();
+        }
+    }
+}

--- a/samples/PrerenderingApp.Server/PrerenderingApp.Server.csproj
+++ b/samples/PrerenderingApp.Server/PrerenderingApp.Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Server.Rendering\Microsoft.AspNetCore.Blazor.Server.Rendering.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Server\Microsoft.AspNetCore.Blazor.Server.csproj" />
+    <ProjectReference Include="..\PrerenderingApp.Client\PrerenderingApp.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/PrerenderingApp.Server/PrerenderingApp.Server.csproj
+++ b/samples/PrerenderingApp.Server/PrerenderingApp.Server.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/PrerenderingApp.Server/Program.cs
+++ b/samples/PrerenderingApp.Server/Program.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Blazor.Server.Rendering;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 
@@ -16,28 +15,16 @@ namespace PrerenderingApp.Server
     {
         public static void Main(string[] args)
         {
-            var directory = Directory.GetCurrentDirectory();
-            var currentDirectory = Environment.CurrentDirectory;
-            var codeBase = Assembly.GetEntryAssembly().CodeBase;
-            var location = Assembly.GetEntryAssembly().Location;
             AssemblyLoadContext.Default.Resolving += Default_Resolving;
-
-            /*var prog = typeof(Client.Program);
-            var method = prog.GetMethod("Server", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            method.Invoke(null, new object[] { null });*/
-
-            var renderer = new PreRenderer();//.AddComponent<Home>("app");
-            renderer.DoStuff<Client.Home>();
-
             BuildWebHost(args).Run();
         }
 
-        private static System.Reflection.Assembly Default_Resolving(AssemblyLoadContext arg1, System.Reflection.AssemblyName arg2)
+        private static Assembly Default_Resolving(AssemblyLoadContext context, AssemblyName assemblyName)
         {
             var location = Assembly.GetEntryAssembly().Location;
             var directoryName = Path.GetDirectoryName(location);
-            var assemblyPath = Path.Combine(directoryName, arg2.Name + ".dll");
-            return arg1.LoadFromAssemblyPath(assemblyPath);
+            var assemblyPath = Path.Combine(directoryName, assemblyName.Name + ".dll");
+            return context.LoadFromAssemblyPath(assemblyPath);
         }
 
         public static IWebHost BuildWebHost(string[] args) =>

--- a/samples/PrerenderingApp.Server/Program.cs
+++ b/samples/PrerenderingApp.Server/Program.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Blazor.Server.Rendering;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace PrerenderingApp.Server
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var directory = Directory.GetCurrentDirectory();
+            var currentDirectory = Environment.CurrentDirectory;
+            var codeBase = Assembly.GetEntryAssembly().CodeBase;
+            var location = Assembly.GetEntryAssembly().Location;
+            //AssemblyLoadContext.Default.Resolving += Default_Resolving;
+
+            /*var prog = typeof(Client.Program);
+            var method = prog.GetMethod("Server", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            method.Invoke(null, new object[] { null });*/
+
+            var renderer = new PreRenderer();//.AddComponent<Home>("app");
+            renderer.DoStuff<Client.Home>();
+
+            BuildWebHost(args).Run();
+        }
+
+        private static System.Reflection.Assembly Default_Resolving(AssemblyLoadContext arg1, System.Reflection.AssemblyName arg2)
+        {
+            var location = Assembly.GetEntryAssembly().Location;
+            var directoryName = Path.GetDirectoryName(location);
+            var assemblyPath = Path.Combine(directoryName, arg2.Name + ".dll");
+            return arg1.LoadFromAssemblyPath(assemblyPath);
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseConfiguration(new ConfigurationBuilder()
+                    .AddCommandLine(args)
+                    .Build())
+                .UseStartup<Startup>()
+                .Build();
+    }
+}

--- a/samples/PrerenderingApp.Server/Program.cs
+++ b/samples/PrerenderingApp.Server/Program.cs
@@ -20,7 +20,7 @@ namespace PrerenderingApp.Server
             var currentDirectory = Environment.CurrentDirectory;
             var codeBase = Assembly.GetEntryAssembly().CodeBase;
             var location = Assembly.GetEntryAssembly().Location;
-            //AssemblyLoadContext.Default.Resolving += Default_Resolving;
+            AssemblyLoadContext.Default.Resolving += Default_Resolving;
 
             /*var prog = typeof(Client.Program);
             var method = prog.GetMethod("Server", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);

--- a/samples/PrerenderingApp.Server/ServerWeatherService.cs
+++ b/samples/PrerenderingApp.Server/ServerWeatherService.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using PrerenderingApp.Client;
+
+namespace PrerenderingApp.Server
+{
+    public class ServerWeatherService : IWeatherService
+    {
+        private static string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+
+        public Task<IEnumerable<WeatherForecast>> GetForecast()
+        {
+            var rng = new Random();
+            return Task.FromResult(Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = rng.Next(-20, 55),
+                Summary = Summaries[rng.Next(Summaries.Length)]
+            }));
+        }
+    }
+}

--- a/samples/PrerenderingApp.Server/Startup.cs
+++ b/samples/PrerenderingApp.Server/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Blazor.Server.Rendering;
+using PrerenderingApp.Client;
 
 namespace PrerenderingApp.Server
 {
@@ -26,9 +27,10 @@ namespace PrerenderingApp.Server
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseBlazorPrerendering<Client.Home>("app", configure =>
+            app.UseBlazorPrerendering<Home>("app", configure =>
             {
                 // add services
+                configure.AddSharedServices();
             });
         }
     }

--- a/samples/PrerenderingApp.Server/Startup.cs
+++ b/samples/PrerenderingApp.Server/Startup.cs
@@ -26,7 +26,10 @@ namespace PrerenderingApp.Server
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseBlazorPrerendering<Client.Home>();
+            app.UseBlazorPrerendering<Client.Home>("app", configure =>
+            {
+                // add services
+            });
         }
     }
 }

--- a/samples/PrerenderingApp.Server/Startup.cs
+++ b/samples/PrerenderingApp.Server/Startup.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+using System.Net.Mime;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Blazor.Server.Rendering;
+using Microsoft.AspNetCore.ResponseCompression;
+using Newtonsoft.Json.Serialization;
 using PrerenderingApp.Client;
 
 namespace PrerenderingApp.Server
@@ -17,20 +19,40 @@ namespace PrerenderingApp.Server
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddMvc().AddJsonOptions(options =>
+            {
+                options.SerializerSettings.ContractResolver = new DefaultContractResolver();
+            });
+
+            services.AddResponseCompression(options =>
+            {
+                options.MimeTypes = ResponseCompressionDefaults.MimeTypes
+                    .Concat(new[] { MediaTypeNames.Application.Octet });
+            });
+
+            services.AddSingleton<IWeatherService, ServerWeatherService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
+            app.UseResponseCompression();
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
 
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute(name: "default", template: "{controller}/{action}/{id?}");
+            });
+
             app.UseBlazorPrerendering<Home>("app", configure =>
             {
                 // add services
                 configure.AddSharedServices();
+                configure.AddSingleton<IWeatherService, ServerWeatherService>();
             });
         }
     }

--- a/samples/PrerenderingApp.Server/Startup.cs
+++ b/samples/PrerenderingApp.Server/Startup.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace PrerenderingApp.Server
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseBlazor<Client.Program>();
+        }
+    }
+}

--- a/samples/PrerenderingApp.Server/Startup.cs
+++ b/samples/PrerenderingApp.Server/Startup.cs
@@ -3,7 +3,10 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Blazor.Server.Rendering;
 
 namespace PrerenderingApp.Server
 {
@@ -23,7 +26,7 @@ namespace PrerenderingApp.Server
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseBlazor<Client.Program>();
+            app.UseBlazorPrerendering<Client.Program>();
         }
     }
 }

--- a/samples/PrerenderingApp.Server/Startup.cs
+++ b/samples/PrerenderingApp.Server/Startup.cs
@@ -26,7 +26,7 @@ namespace PrerenderingApp.Server
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseBlazorPrerendering<Client.Program>();
+            app.UseBlazorPrerendering<Client.Home>();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingAppBuilderExtensions.cs
@@ -4,8 +4,18 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public static class BlazorPrerenderingAppBuilderExtensions
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TEntryComponent"></typeparam>
+        /// <param name="app"></param>
+        /// <param name="entryTagName"></param>
+        /// <param name="configure"></param>
         public static void UseBlazorPrerendering<TEntryComponent>(this IApplicationBuilder app, string entryTagName, Action<IServiceCollection> configure)
         {
             app.UseBlazor<TEntryComponent>(c => c.UseBlazorPrerendering<TEntryComponent>(entryTagName, configure));

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingAppBuilderExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace Microsoft.AspNetCore.Blazor.Server.Rendering
+{
+    public static class BlazorPrerenderingAppBuilderExtensions
+    {
+        public static void UseBlazorPrerendering<T>(this IApplicationBuilder app)
+        {
+            app.UseBlazor<T>(c => c.UseBlazorPrerendering());
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingAppBuilderExtensions.cs
@@ -1,12 +1,14 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
     public static class BlazorPrerenderingAppBuilderExtensions
     {
-        public static void UseBlazorPrerendering<T>(this IApplicationBuilder app)
+        public static void UseBlazorPrerendering<TEntryComponent>(this IApplicationBuilder app, string entryTagName, Action<IServiceCollection> configure)
         {
-            app.UseBlazor<T>(c => c.UseBlazorPrerendering<T>());
+            app.UseBlazor<TEntryComponent>(c => c.UseBlazorPrerendering<TEntryComponent>(entryTagName, configure));
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingAppBuilderExtensions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.Blazor.Server.Rendering
     {
         public static void UseBlazorPrerendering<T>(this IApplicationBuilder app)
         {
-            app.UseBlazor<T>(c => c.UseBlazorPrerendering());
+            app.UseBlazor<T>(c => c.UseBlazorPrerendering<T>());
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingMiddleware.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using AngleSharp;
@@ -61,28 +63,76 @@ namespace Microsoft.AspNetCore.Blazor.Server.Rendering
             });
         }
 
-        private static string Prerender(string html)
+        private static string Prerender(string htmlTemplate)
         {
-            var tokenizer = new HtmlTokenizer(new TextSource(html), HtmlEntityService.Resolver);
+            // copied from IndexHtmlFileProvider.cs
+            var resultBuilder = new StringBuilder();
 
+            // Search for a tag of the form <app></app>, and replace
+            // it with the prerendered content
+            var tokenizer = new HtmlTokenizer(
+                new TextSource(htmlTemplate), 
+                HtmlEntityService.Resolver);
+            var currentRangeStartPos = 0;
+            var isInBlazorBootTag = false;
+            var resumeOnNextToken = false;
             while (true)
             {
                 var token = tokenizer.Get();
+                if (resumeOnNextToken)
+                {
+                    resumeOnNextToken = false;
+                    currentRangeStartPos = token.Position.Position;
+                }
+
                 switch (token.Type)
                 {
+                    case HtmlTokenType.StartTag:
+                        {
+                            // Only do anything special if this is a Blazor boot tag
+                            var tag = token.AsTag();
+                            if (IsBlazorBootTag(tag))
+                            {
+                                // First, emit the original source text prior to this special tag, since
+                                // we want that to be unchanged
+                                resultBuilder.Append(htmlTemplate, currentRangeStartPos, token.Position.Position - currentRangeStartPos - 1);
+
+                                // Instead of emitting the source text for this special tag, emit a fully-
+                                // configured Blazor boot script tag
+                                AppendScriptTagWithBootConfig(resultBuilder);
+
+                                // Set a flag so we know not to emit anything else until the special
+                                // tag is closed
+                                isInBlazorBootTag = true;
+                            }
+                            break;
+                        }
+
+                    case HtmlTokenType.EndTag:
+                        // If this is an end tag corresponding to the Blazor boot script tag, we
+                        // can switch back into the mode of emitting the original source text
+                        if (isInBlazorBootTag)
+                        {
+                            isInBlazorBootTag = false;
+                            resumeOnNextToken = true;
+                        }
+                        break;
+
                     case HtmlTokenType.EndOfFile:
-                        return @"<!DOCTYPE html>
-<html>
-<head>
-    <meta charset=""utf-8"" />
-    <title>Sample Blazor app</title>
-</head>
-<body>
-    <h1>Hello prerendering</h1>
-</body>
-</html>";
+                        // Finally, emit any remaining text from the original source file
+                        resultBuilder.Append(htmlTemplate, currentRangeStartPos, htmlTemplate.Length - currentRangeStartPos);
+                        return resultBuilder.ToString();
                 }
             }
+        }
+
+        private static bool IsBlazorBootTag(HtmlTagToken tag)
+            => string.Equals(tag.Name, "app", StringComparison.Ordinal);
+
+        private static void AppendScriptTagWithBootConfig(
+            StringBuilder resultBuilder)
+        {
+            resultBuilder.AppendLine("<h1>Hello Prerendering</h1>");
         }
     }
 

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingMiddleware.cs
@@ -11,8 +11,18 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class BlazorPrerenderingMiddleware
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="spaBuilder"></param>
+        /// <param name="entryTagName"></param>
+        /// <param name="configure"></param>
         public static void Attach<T>(ISpaBuilder spaBuilder, string entryTagName, Action<IServiceCollection> configure)
         {
             if (spaBuilder == null)

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingMiddleware.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using AngleSharp;
+using AngleSharp.Html;
+using AngleSharp.Parser.Html;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SpaServices;
+using Microsoft.AspNetCore.SpaServices.StaticFiles;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Blazor.Server.Rendering
+{
+    public class BlazorPrerenderingMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public BlazorPrerenderingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+
+
+            return _next(context);
+        }
+
+        public static void Attach(ISpaBuilder spaBuilder)
+        {
+            if (spaBuilder == null)
+                throw new ArgumentNullException(nameof(spaBuilder));
+            IApplicationBuilder applicationBuilder = spaBuilder.ApplicationBuilder;
+
+            SpaOptions options = spaBuilder.Options;
+            var fileOptions = options.DefaultPageStaticFileOptions;
+            applicationBuilder.Use((context, next) =>
+            {
+                context.Request.Path = options.DefaultPage;
+                return next();
+            });
+
+            applicationBuilder.Use((context, next) =>
+            {
+                var subpath = context.Request.Path;
+                var fileInfo = fileOptions.FileProvider.GetFileInfo(subpath);
+                if (fileInfo.Exists)
+                {
+                    fileOptions.ContentTypeProvider.TryGetContentType(subpath, out var contentType);
+
+                    using (var stream = fileInfo.CreateReadStream())
+                    using (var reader = new StreamReader(stream))
+                    {
+                        var html = reader.ReadToEnd();
+
+                        var tokenizer = new HtmlTokenizer(new TextSource(html), HtmlEntityService.Resolver);
+
+
+                    }
+
+                    context.Response.StatusCode = 200;
+                    context.Response.ContentType = contentType;
+                    context.Response.ContentLength = fileInfo.Length;
+                    //stream.CopyTo(context.Response.Body);
+
+                    return Task.FromResult(0);
+                }
+
+                return next();
+            });
+        }
+    }
+
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingSpaBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingSpaBuilderExtensions.cs
@@ -4,8 +4,18 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public static class BlazorPrerenderingSpaBuilderExtensions
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="spa"></param>
+        /// <param name="entryTagName"></param>
+        /// <param name="configure"></param>
         public static void UseBlazorPrerendering<T>(this ISpaBuilder spa, string entryTagName, Action<IServiceCollection> configure)
         {
             BlazorPrerenderingMiddleware.Attach<T>(spa, entryTagName, configure);

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingSpaBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingSpaBuilderExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.SpaServices;
+
+namespace Microsoft.AspNetCore.Blazor.Server.Rendering
+{
+    public static class BlazorPrerenderingSpaBuilderExtensions
+    {
+        public static void UseBlazorPrerendering(this ISpaBuilder spa)
+        {
+            BlazorPrerenderingMiddleware.Attach(spa);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingSpaBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingSpaBuilderExtensions.cs
@@ -1,12 +1,14 @@
-﻿using Microsoft.AspNetCore.SpaServices;
+﻿using System;
+using Microsoft.AspNetCore.SpaServices;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
     public static class BlazorPrerenderingSpaBuilderExtensions
     {
-        public static void UseBlazorPrerendering<T>(this ISpaBuilder spa)
+        public static void UseBlazorPrerendering<T>(this ISpaBuilder spa, string entryTagName, Action<IServiceCollection> configure)
         {
-            BlazorPrerenderingMiddleware.Attach<T>(spa);
+            BlazorPrerenderingMiddleware.Attach<T>(spa, entryTagName, configure);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingSpaBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/BlazorPrerenderingSpaBuilderExtensions.cs
@@ -4,9 +4,9 @@ namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
     public static class BlazorPrerenderingSpaBuilderExtensions
     {
-        public static void UseBlazorPrerendering(this ISpaBuilder spa)
+        public static void UseBlazorPrerendering<T>(this ISpaBuilder spa)
         {
-            BlazorPrerenderingMiddleware.Attach(spa);
+            BlazorPrerenderingMiddleware.Attach<T>(spa);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/Microsoft.AspNetCore.Blazor.Server.Rendering.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/Microsoft.AspNetCore.Blazor.Server.Rendering.csproj
@@ -1,15 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.AspNetCore.Blazor.Server\Microsoft.AspNetCore.Blazor.Server.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj">
+      <Name>AngleSharpBuilder</Name>
+      <Private>False</Private>
+      <SetTargetFramework>TargetFramework=netcoreapp2.0</SetTargetFramework>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <Reference Include="..\anglesharp\AngleSharpBuilder\dist\Microsoft.AspNetCore.Blazor.AngleSharp.dll" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/Microsoft.AspNetCore.Blazor.Server.Rendering.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/Microsoft.AspNetCore.Blazor.Server.Rendering.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/Microsoft.AspNetCore.Blazor.Server.Rendering.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/Microsoft.AspNetCore.Blazor.Server.Rendering.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -14,13 +14,17 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor\Microsoft.AspNetCore.Blazor.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <!--<ItemGroup>
     <ProjectReference Include="..\anglesharp\AngleSharpBuilder\AngleSharpBuilder.csproj">
       <Name>AngleSharpBuilder</Name>
       <Private>False</Private>
       <SetTargetFramework>TargetFramework=netcoreapp2.0</SetTargetFramework>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
+    <Reference Include="..\anglesharp\AngleSharpBuilder\dist\Microsoft.AspNetCore.Blazor.AngleSharp.dll" />
+  </ItemGroup>-->
+
+  <ItemGroup>
     <Reference Include="..\anglesharp\AngleSharpBuilder\dist\Microsoft.AspNetCore.Blazor.AngleSharp.dll" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreRenderer.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.AspNetCore.Blazor.Components;
+using Microsoft.AspNetCore.Blazor.Rendering;
+using Microsoft.AspNetCore.Blazor.RenderTree;
+
+namespace Microsoft.AspNetCore.Blazor.Server.Rendering
+{
+    public class PreRenderer : Renderer
+    {
+        public PreRenderer() : this(new PreServiceProvider())
+        {
+
+        }
+
+        public PreRenderer(IServiceProvider serviceProvider) : base(serviceProvider)
+        {
+        }
+
+        public void DoStuff<TComponent>()
+        {
+            var component = InstantiateComponent(typeof(TComponent));
+            var componentId = AssignComponentId(component);
+            component.SetParameters(ParameterCollection.Empty);
+        }
+
+        protected override void UpdateDisplay(RenderBatch renderBatch)
+        {
+            var sb = new StringBuilder();
+
+            foreach (var u in renderBatch.UpdatedComponents)
+            {
+                UpdateComponent(sb, renderBatch, u.ComponentId, u.Edits, renderBatch.ReferenceFrames);
+
+            }
+
+            foreach (var componentID in renderBatch.DisposedComponentIDs)
+            {
+                DisposeComponent(componentID);
+            }
+
+            var s = sb.ToString();
+        }
+
+        private void DisposeComponent(int componentId)
+        {
+
+        }
+
+        private IList<int> handledComponents = new List<int>();
+
+        private void UpdateComponent(
+            StringBuilder sb,
+            RenderBatch renderBatch,
+            int componentId,
+            ArraySegment<RenderTreeEdit> edits,
+            ArrayRange<RenderTreeFrame> referenceFrames)
+        {
+            if (handledComponents.Contains(componentId)) return;
+            handledComponents.Add(componentId);
+            ApplyEdit(sb, renderBatch, componentId, 0, edits, referenceFrames);
+        }
+
+        private void ApplyEdit(
+            StringBuilder sb,
+            RenderBatch renderBatch,
+            int componentId,
+            int childIndex,
+            ArraySegment<RenderTreeEdit> edits,
+            ArrayRange<RenderTreeFrame> referenceFrames)
+        {
+            //var currentDepth = 0;
+            var childIndexAtCurrentDepth = childIndex;
+            var maxEditIndexExcl = edits.Offset + edits.Count;
+
+            foreach (var edit in edits)
+            {
+                switch (edit.Type)
+                {
+                    case RenderTreeEditType.PrependFrame:
+                        var frame = referenceFrames.Array[edit.ReferenceFrameIndex];
+                        InsertFrame(
+                            sb,
+                            renderBatch,
+                            componentId,
+                            childIndexAtCurrentDepth + edit.SiblingIndex,
+                            referenceFrames,
+                            frame,
+                            edit.ReferenceFrameIndex);
+                        break;
+                    case RenderTreeEditType.RemoveFrame:
+                        break;
+                    case RenderTreeEditType.SetAttribute:
+                        break;
+                    case RenderTreeEditType.RemoveAttribute:
+                        break;
+                    case RenderTreeEditType.UpdateText:
+                        break;
+                    case RenderTreeEditType.StepIn:
+                        break;
+                    case RenderTreeEditType.StepOut:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        private int InsertFrame(
+            StringBuilder sb,
+            RenderBatch renderBatch,
+            int componentId,
+            int childIndex,
+            ArrayRange<RenderTreeFrame> frames,
+            RenderTreeFrame frame, int frameIndex
+            )
+        {
+            switch (frame.FrameType)
+            {
+                case RenderTreeFrameType.Element:
+                    InsertElement(sb, renderBatch, componentId, childIndex, frames, frame, frameIndex);
+                    return 1;
+                case RenderTreeFrameType.Text:
+                    InsertText(sb, childIndex, frame);
+                    return 1;
+                case RenderTreeFrameType.Component:
+                    InsertComponent(sb, renderBatch, childIndex, frame, frames);
+                    return 1;
+                case RenderTreeFrameType.Region:
+                    return InsertFrameRange(
+                        sb,
+                        renderBatch,
+                        componentId,
+                        childIndex,
+                        frames,
+                        frameIndex + 1,
+                        frameIndex + frame.ElementSubtreeLength);
+                case RenderTreeFrameType.Attribute:
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private void InsertComponent(
+            StringBuilder sb,
+            RenderBatch renderBatch,
+            int childIndex,
+            RenderTreeFrame frame,
+            ArrayRange<RenderTreeFrame> frames)
+        {
+            sb.Append("<blazor-component>");
+            var u = renderBatch.UpdatedComponents.Single(c => c.ComponentId == frame.ComponentId);
+            UpdateComponent(sb, renderBatch, u.ComponentId, u.Edits, frames);
+            sb.Append("</blazor-component>");
+        }
+
+        private void InsertText(
+            StringBuilder sb,
+            int childIndex,
+            RenderTreeFrame frame)
+        {
+            var textContent = frame.TextContent;
+            sb.Append(textContent);
+        }
+
+        private void InsertElement(
+            StringBuilder sb,
+            RenderBatch renderBatch,
+            int componentId,
+            int childIndex,
+            ArrayRange<RenderTreeFrame> frames,
+            RenderTreeFrame frame,
+            int frameIndex)
+        {
+            var tagName = frame.ElementName;
+            sb.Append("<");
+            sb.Append(tagName);
+
+            var x = frameIndex + frame.ElementSubtreeLength;
+
+            for (var di = frameIndex + 1; di < x; di++)
+            {
+                var dframe = frames.Array[di];
+                if (dframe.FrameType == RenderTreeFrameType.Attribute)
+                {
+                    ApplyAttribute(sb, componentId, dframe);
+                }
+                else
+                {
+                    sb.Append(">");
+                    InsertFrameRange(sb, renderBatch, componentId, 0, frames, di, x);
+                    sb.Append("</");
+                    sb.Append(tagName);
+                }
+            }
+
+            sb.Append(">");
+        }
+
+        private int InsertFrameRange(
+            StringBuilder sb,
+            RenderBatch renderBatch,
+            int componentId,
+            int childIndex,
+            ArrayRange<RenderTreeFrame> frames,
+            int di,
+            int i1)
+        {
+            var org = childIndex;
+            for (var i = di; i < i1; i++)
+            {
+                var frame = frames.Array[i];
+                var numAdded = InsertFrame(sb, renderBatch, componentId, childIndex, frames, frame, i);
+                childIndex += numAdded;
+
+                var subTreeLength = frame.ElementSubtreeLength;
+                if (subTreeLength > 1)
+                {
+                    i += subTreeLength - 1;
+                }
+            }
+
+            return (childIndex - org);
+        }
+
+        private void ApplyAttribute(StringBuilder sb, int componentId, RenderTreeFrame dframe)
+        {
+            var attributeName = dframe.AttributeName;
+            var value = dframe.AttributeValue;
+            sb.Append(" ");
+            sb.Append(attributeName);
+            sb.Append("=\"");
+            sb.Append(value);
+            sb.Append("\"");
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreRenderer.cs
@@ -8,19 +8,34 @@ using Microsoft.AspNetCore.Blazor.RenderTree;
 
 namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class PreRenderer : Renderer
     {
+        /// <summary>
+        /// 
+        /// </summary>
         public PreRenderer() : this(new PreServiceProvider())
         {
 
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="serviceProvider"></param>
         public PreRenderer(IServiceProvider serviceProvider) : base(serviceProvider)
         {
         }
 
         private StringBuilder _sb;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="TComponent"></typeparam>
+        /// <returns></returns>
         public string Render<TComponent>()
         {
             _sb = new StringBuilder();
@@ -30,6 +45,10 @@ namespace Microsoft.AspNetCore.Blazor.Server.Rendering
             return _sb.ToString();
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="renderBatch"></param>
         protected override void UpdateDisplay(RenderBatch renderBatch)
         {
             foreach (var u in renderBatch.UpdatedComponents)

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreServiceProvider.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreServiceProvider.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class PreServiceProvider : IServiceProvider
     {
         private readonly IServiceProvider _underlyingProvider;

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreServiceProvider.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreServiceProvider.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.AspNetCore.Blazor.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Blazor.Server.Rendering
+{
+    public class PreServiceProvider : IServiceProvider
+    {
+        private readonly IServiceProvider _underlyingProvider;
+
+        /// <summary>
+        /// Constructs an instance of <see cref="PreServiceProvider"/>.
+        /// </summary>
+        public PreServiceProvider() : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Constructs an instance of <see cref="PreServiceProvider"/>.
+        /// </summary>
+        /// <param name="configure">A callback that can be used to configure the <see cref="IServiceCollection"/>.</param>
+        public PreServiceProvider(Action<IServiceCollection> configure)
+        {
+            var serviceCollection = new ServiceCollection();
+            AddDefaultServices(serviceCollection);
+            configure?.Invoke(serviceCollection);
+            _underlyingProvider = serviceCollection.BuildServiceProvider();
+        }
+
+        /// <inheritdoc />
+        public object GetService(Type serviceType)
+            => _underlyingProvider.GetService(serviceType);
+
+        private void AddDefaultServices(ServiceCollection serviceCollection)
+        {
+            var uriHelper = new PreUriHelper();
+            serviceCollection.AddSingleton<IUriHelper>(uriHelper);
+            serviceCollection.AddSingleton(new HttpClient(/*new BrowserHttpMessageHandler()*/)
+            {
+                BaseAddress = new Uri(uriHelper.GetBaseUriPrefix())
+            });
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreUriHelper.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreUriHelper.cs
@@ -3,32 +3,71 @@ using Microsoft.AspNetCore.Blazor.Services;
 
 namespace Microsoft.AspNetCore.Blazor.Server.Rendering
 {
+    /// <summary>
+    /// 
+    /// </summary>
     public class PreUriHelper : IUriHelper
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         public string GetAbsoluteUri()
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
         public event EventHandler<string> OnLocationChanged;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="href"></param>
+        /// <returns></returns>
         public Uri ToAbsoluteUri(string href)
         {
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
         public string GetBaseUriPrefix()
         {
             return "http://localhost:56484/";
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="baseUriPrefix"></param>
+        /// <param name="locationAbsolute"></param>
+        /// <returns></returns>
         public string ToBaseRelativePath(string baseUriPrefix, string locationAbsolute)
         {
             throw new NotImplementedException();
         }
-
+    
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="e"></param>
         protected virtual void OnOnLocationChanged(string e)
         {
             OnLocationChanged?.Invoke(this, e);
+        }
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="uri"></param>
+        public void NavigateTo(string uri)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreUriHelper.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/PreUriHelper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.AspNetCore.Blazor.Services;
+
+namespace Microsoft.AspNetCore.Blazor.Server.Rendering
+{
+    public class PreUriHelper : IUriHelper
+    {
+        public string GetAbsoluteUri()
+        {
+            throw new NotImplementedException();
+        }
+
+        public event EventHandler<string> OnLocationChanged;
+        public Uri ToAbsoluteUri(string href)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetBaseUriPrefix()
+        {
+            return "http://localhost:56484/";
+        }
+
+        public string ToBaseRelativePath(string baseUriPrefix, string locationAbsolute)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected virtual void OnOnLocationChanged(string e)
+        {
+            OnLocationChanged?.Invoke(this, e);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server.Rendering/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server.Rendering/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.AspNetCore.Blazor.Cli")]

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Blazor.Server;
 using Microsoft.AspNetCore.StaticFiles;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Net.Http.Headers;
 using System.Net.Mime;
+using Microsoft.AspNetCore.SpaServices;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -21,14 +23,16 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         /// <typeparam name="TProgram">Any type from the client app project. This is used to identify the client app assembly.</typeparam>
         /// <param name="applicationBuilder"></param>
+        /// <param name="configuration"></param>
         public static void UseBlazor<TProgram>(
-            this IApplicationBuilder applicationBuilder)
+            this IApplicationBuilder applicationBuilder,
+            Action<ISpaBuilder> configuration = null)
         {
             var clientAssemblyInServerBinDir = typeof(TProgram).Assembly;
             applicationBuilder.UseBlazor(new BlazorOptions
             {
                 ClientAssemblyPath = clientAssemblyInServerBinDir.Location,
-            });
+            }, configuration);
         }
 
         /// <summary>
@@ -36,9 +40,11 @@ namespace Microsoft.AspNetCore.Builder
         /// </summary>
         /// <param name="applicationBuilder"></param>
         /// <param name="options"></param>
+        /// <param name="configuration"></param>
         public static void UseBlazor(
             this IApplicationBuilder applicationBuilder,
-            BlazorOptions options)
+            BlazorOptions options,
+            Action<ISpaBuilder> configuration = null)
         {
             // TODO: Make the .blazor.config file contents sane
             // Currently the items in it are bizarre and don't relate to their purpose,
@@ -81,6 +87,7 @@ namespace Microsoft.AspNetCore.Builder
                 childAppBuilder.UseSpa(spa =>
                 {
                     spa.Options.DefaultPageStaticFileOptions = distDirStaticFiles;
+                    configuration?.Invoke(spa);
                 });
             });
         }

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorOptions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorOptions.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.AspNetCore.Builder
 {
     /// <summary>
-    /// Provides configuration options to the <see cref="BlazorAppBuilderExtensions.UseBlazor(IApplicationBuilder, BlazorOptions)"/>
+    /// Provides configuration options to the <see cref="BlazorAppBuilderExtensions.UseBlazor(IApplicationBuilder, BlazorOptions, System.Action{SpaServices.ISpaBuilder})"/>
     /// middleware.
     /// </summary>
     public class BlazorOptions

--- a/src/anglesharp/AngleSharpBuilder/Program.cs
+++ b/src/anglesharp/AngleSharpBuilder/Program.cs
@@ -65,6 +65,7 @@ namespace AngleSharpBuilder
 
             AddInternalsVisibleTo(moduleDefinition, "Microsoft.AspNetCore.Blazor.Build");
             AddInternalsVisibleTo(moduleDefinition, "Microsoft.AspNetCore.Blazor.Razor.Extensions");
+            AddInternalsVisibleTo(moduleDefinition, "Microsoft.AspNetCore.Blazor.Server.Rendering");
             RemoveStrongName(moduleDefinition);
             SetAssemblyName(moduleDefinition, "Microsoft.AspNetCore.Blazor.AngleSharp");
 


### PR DESCRIPTION
Just for the sake of it, its still working and relevant. (Original #238)
* Rebased on latest dev branch

# [WIP] Prerendering (#24)

## How does it work
When ever a request comes in that would result in returning the content of `index.html`, the prerendering kicks in and replaces the `app` tag with the prerendered content.

### In detail
1. Call `app.UseBlazorPrerendering<TEntryComponent>("app", configure => {});` in the server project. `TEntryComponent` will be the component to get prerendered and inserted into the `app` tag.
2. `UseBlazorPrerendering` attaches the `BlazorPrerenderingMiddleware` to the `ISpaBuilder`, to intercept requests to `index.html`.
3. If a request is satisfied by `index.html`. The `index.html` is parsed with `AngleSharp`, and modified to contain the prerendered content. This implementation is almost 100% the same as the one in `IndexHtmlFileProvider`.
4. To Prerender the content there is a new implementation of `Renderer`. This implementation for the most part is identical to the one in `BrowserRenderer.ts`. But it only supports the initial creation, since update on the serverside does not make sense. Also when encountering a `Component` it goes into recursion, which is different from the Browser version.

## What is in this PR
### Microsoft.AspNetCore.Blazor.Server.Rendering project
Contains all things related to prerendering
* `PreRenderer` implementation of `Renderer` (needs cleanup)

### PrerenderingApp sample
* input component
* list component (foreach)
* input element
* 2 bound input elements
* FetchDataComponent using a service making a HttpRequest on the client while using the data directly when prerendering.

## Current Limitations
* After the page is returned to the browser, it is static until the browser catches up with bootstrapping and rerendering the page. It would be nice to actually have some kind of way to map the elements to components. Maybe a custom data tag containing the component id.
* Services used for controllers and prerendering must be specified two times for DI.
* Routing not yet tested. It probably doesn't work.
* `IUriHelper` implementation `PreUriHelper` of method `GetBaseUriPrefix` harcoded to match server url.
* **Missing Tests** If this is the way to go, i will write them.
* ~~It only works with the `app` tag. There should be some way to define the entry component. Also it would be nice to have different services (which also means different references) on server vs client side.~~
~~As of now i can only imaging 3 projects.~~
  * ~~One containing the Components~~
  * ~~One for bootstrapping in Browser~~
  * ~~One for bootstrapping in Server~~
* ~~No way to supply services to prerendering. It would be nice to be able to supply different services while prerendering. This would allow to reuse server services to prerender the content without issuing http calls on the server side.~~

## What now?
I know the issue #24 is not yet assigned to any version. And maybe this implementation is going completely haywire. I just did what i thought might be the general idea. Either way, this was major fun. 
Let me know what you think!