### PR TITLE
Simple autorebuild mechanism for hosted apps

### DIFF
--- a/samples/HostedInAspNet.Client/HostedInAspNet.Client.csproj
+++ b/samples/HostedInAspNet.Client/HostedInAspNet.Client.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Exe</OutputType>
-
-    <!-- Temporary workaround for a VS build issue -->
-    <BlazorRebuildOnFileChange>false</BlazorRebuildOnFileChange>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorAppBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Net.Http.Headers;
 using System.Net.Mime;
+using System;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -16,6 +17,8 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public static class BlazorAppBuilderExtensions
     {
+        const string DevServerApplicationName = "dotnet-blazor";
+
         /// <summary>
         /// Configures the middleware pipeline to work with Blazor.
         /// </summary>
@@ -54,7 +57,14 @@ namespace Microsoft.AspNetCore.Builder
 
             if (env.IsDevelopment() && config.EnableAutoRebuilding)
             {
-                applicationBuilder.UseAutoRebuild(config);
+                if (env.ApplicationName.Equals(DevServerApplicationName, StringComparison.OrdinalIgnoreCase))
+                {
+                    applicationBuilder.UseDevServerAutoRebuild(config);
+                }
+                else
+                {
+                    applicationBuilder.UseHostedAutoRebuild(config, env.ContentRootPath);
+                }
             }
 
             // First, match the request against files in the client app dist directory

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
@@ -9,9 +9,6 @@
       https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
     </RestoreSources>
     <LangVersion>7.3</LangVersion>
-
-    <!-- Temporary workaround for a VS build issue -->
-    <BlazorRebuildOnFileChange>false</BlazorRebuildOnFileChange>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In the 0.3.0 release we had to disable autorebuild for hosted apps due to a bug. This PR re-enables it, replacing the implementation with a much simpler alternative.

This implementation should be understood as a stopgap measure until some future version of ASP.NET Core and VS can hopefully extend the native autorebuild support to rebuild when there are changes in referenced projects. Once (and if) that is implemented, both the standalone and hosted variants of Blazor's autorebuild feature could be removed because both would inherit it from ASP.NET Core.