### PR TITLE
convert marshalled members to camelCase

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
@@ -318,10 +318,10 @@ function raiseEvent(event: Event, browserRendererId: number, componentId: number
   }
 
   const eventDescriptor = {
-    BrowserRendererId: browserRendererId,
-    ComponentId: componentId,
-    EventHandlerId: eventHandlerId,
-    EventArgsType: eventArgs.type
+    browserRendererId,
+    componentId,
+    eventHandlerId,
+    eventArgsType: eventArgs.type
   };
 
   platform.callMethod(raiseEventMethod, null, [

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
@@ -9,13 +9,13 @@
       case 'change': {
         const targetIsCheckbox = isCheckbox(element);
         const newValue = targetIsCheckbox ? !!element['checked'] : element['value'];
-        return new EventForDotNet<UIChangeEventArgs>('change', { Type: event.type, Value: newValue });
+        return new EventForDotNet<UIChangeEventArgs>('change', { type: event.type, value: newValue });
       }
 
       case 'copy':
       case 'cut':
       case 'paste':
-        return new EventForDotNet<UIClipboardEventArgs>('clipboard', { Type: event.type });
+        return new EventForDotNet<UIClipboardEventArgs>('clipboard', { type: event.type });
 
       case 'drag':
       case 'dragend':
@@ -24,21 +24,21 @@
       case 'dragover':
       case 'dragstart':
       case 'drop':
-        return new EventForDotNet<UIDragEventArgs>('drag', { Type: event.type });
+        return new EventForDotNet<UIDragEventArgs>('drag', { type: event.type });
 
       case 'error':
-        return new EventForDotNet<UIProgressEventArgs>('error', { Type: event.type });
+        return new EventForDotNet<UIProgressEventArgs>('error', { type: event.type });
 
       case 'focus':
       case 'blur':
       case 'focusin':
       case 'focusout':
-        return new EventForDotNet<UIFocusEventArgs>('focus', { Type: event.type });
+        return new EventForDotNet<UIFocusEventArgs>('focus', { type: event.type });
 
       case 'keydown':
       case 'keyup':
       case 'keypress':
-        return new EventForDotNet<UIKeyboardEventArgs>('keyboard', { Type: event.type, Key: (event as any).key });
+        return new EventForDotNet<UIKeyboardEventArgs>('keyboard', { type: event.type, key: (event as any).key });
 
       case 'contextmenu':
       case 'click':
@@ -48,16 +48,16 @@
       case 'mousedown':
       case 'mouseup':
       case 'dblclick':
-        return new EventForDotNet<UIMouseEventArgs>('mouse', { Type: event.type });
+        return new EventForDotNet<UIMouseEventArgs>('mouse', { type: event.type });
 
       case 'progress':
-        return new EventForDotNet<UIProgressEventArgs>('progress', { Type: event.type });
+        return new EventForDotNet<UIProgressEventArgs>('progress', { type: event.type });
 
       case 'touchcancel':
       case 'touchend':
       case 'touchmove':
       case 'touchstart':
-        return new EventForDotNet<UITouchEventArgs>('touch', { Type: event.type });
+        return new EventForDotNet<UITouchEventArgs>('touch', { type: event.type });
 
       case 'gotpointercapture':
       case 'lostpointercapture':
@@ -69,14 +69,14 @@
       case 'pointerout':
       case 'pointerover':
       case 'pointerup':
-        return new EventForDotNet<UIPointerEventArgs>('pointer', { Type: event.type });
+        return new EventForDotNet<UIPointerEventArgs>('pointer', { type: event.type });
 
       case 'mousewheel':
-        return new EventForDotNet<UIWheelEventArgs>('wheel', { Type: event.type });
+        return new EventForDotNet<UIWheelEventArgs>('wheel', { type: event.type });
 
 
       default:
-        return new EventForDotNet<UIEventArgs>('unknown', { Type: event.type });
+        return new EventForDotNet<UIEventArgs>('unknown', { type: event.type });
     }
   }
 }
@@ -90,11 +90,11 @@ function isCheckbox(element: Element | null) {
 type EventArgsType = 'change' | 'clipboard' | 'drag' | 'error' | 'focus' | 'keyboard' | 'mouse' | 'pointer' | 'progress' | 'touch' | 'unknown' | 'wheel';
 
 export interface UIEventArgs {
-  Type: string;
+  type: string;
 }
 
 interface UIChangeEventArgs extends UIEventArgs {
-  Value: string | boolean;
+  value: string | boolean;
 }
 
 interface UIClipboardEventArgs extends UIEventArgs {
@@ -110,7 +110,7 @@ interface UIFocusEventArgs extends UIEventArgs {
 }
 
 interface UIKeyboardEventArgs extends UIEventArgs {
-  Key: string;
+  key: string;
 }
 
 interface UIMouseEventArgs extends UIEventArgs {

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Services/Http.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Services/Http.ts
@@ -34,11 +34,11 @@ async function sendAsync(id: number, method: string, requestUri: string, body: s
 
 function dispatchSuccessResponse(id: number, response: Response, responseText: string) {
   const responseDescriptor: ResponseDescriptor = {
-    StatusCode: response.status,
-    Headers: []
+    statusCode: response.status,
+    headers: []
   };
   response.headers.forEach((value, name) => {
-    responseDescriptor.Headers.push([name, value]);
+    responseDescriptor.headers.push([name, value]);
   });
 
   dispatchResponse(
@@ -81,6 +81,6 @@ interface ResponseDescriptor {
   // We don't have BodyText in here because if we did, then in the JSON-response case (which
   // is the most common case), we'd be double-encoding it, since the entire ResponseDescriptor
   // also gets JSON encoded. It would work but is twice the amount of string processing.
-  StatusCode: number;
-  Headers: string[][];
+  statusCode: number;
+  headers: string[][];
 }


### PR DESCRIPTION
Convert the member names to camelCase for interfaces/class/types getting marshalled to C# side.


As @SteveSandersonMS asked in https://github.com/aspnet/Blazor/issues/774


I've  coordinated with @galvesribiero and he is updating his PR: https://github.com/aspnet/Blazor/pull/771