### PR TITLE
Fix #745 - allow multiple implements directives

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/ImplementsDirectivePass.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/ImplementsDirectivePass.cs
@@ -30,7 +30,6 @@ namespace Microsoft.AspNetCore.Blazor.Razor
                 if (token != null)
                 {
                     @class.Interfaces.Add(token.Content);
-                    break;
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/DirectiveRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/DirectiveRazorIntegrationTest.cs
@@ -59,6 +59,25 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
         }
 
         [Fact]
+        public void SupportsMultipleImplementsDeclarations()
+        {
+            // Arrange/Act
+            var testInterfaceTypeName = FullTypeName<ITestInterface>();
+            var testInterfaceTypeName2 = FullTypeName<ITestInterface2>();
+            var component = CompileToComponent(
+                $"@implements {testInterfaceTypeName}\n" +
+                $"@implements {testInterfaceTypeName2}\n" +
+                $"Hello");
+            var frames = GetRenderTree(component);
+
+            // Assert
+            Assert.IsAssignableFrom<ITestInterface>(component);
+            Assert.IsAssignableFrom<ITestInterface2>(component);
+            Assert.Collection(frames,
+                frame => AssertFrame.Text(frame, "Hello"));
+        }
+
+        [Fact]
         public void SupportsInheritsDirective()
         {
             // Arrange/Act
@@ -134,6 +153,8 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
         }
 
         public interface ITestInterface { }
+
+        public interface ITestInterface2 { }
 
         public class TestBaseClass : BlazorComponent { }
 


### PR DESCRIPTION
The pass for this was 'break'ing after the first directive for no real
reason. Oops.