### PR TITLE
Add support for sending and receiving arbitrary HttpContent, refs #479 

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Platform/Mono/MonoPlatform.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Platform/Mono/MonoPlatform.ts
@@ -91,6 +91,12 @@ export const monoPlatform: Platform = {
     return mono_string(jsString);
   },
 
+  toUint8Array: function toUint8Array(array: System_Array<any>): Uint8Array {
+    const dataPtr = getArrayDataPointer(array);
+    const length = Module.getValue(dataPtr, 'i32');
+    return new Uint8Array(Module.HEAPU8.buffer, dataPtr + 4, length);
+  },
+
   getArrayLength: function getArrayLength(array: System_Array<any>): number {
     return Module.getValue(getArrayDataPointer(array), 'i32');
   },

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Platform/Platform.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Platform/Platform.ts
@@ -8,6 +8,8 @@
   toJavaScriptString(dotNetString: System_String): string;
   toDotNetString(javaScriptString: string): System_String;
 
+  toUint8Array(array: System_Array<any>): Uint8Array;
+
   getArrayLength(array: System_Array<any>): number;
   getArrayEntryPtr<TPtr extends Pointer>(array: System_Array<TPtr>, index: number, itemSize: number): TPtr;
 

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpMessageHandler.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpMessageHandler.cs
@@ -49,33 +49,34 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
                 _pendingRequests.Add(id, tcs);
             }
 
-            request.Properties.TryGetValue(FetchArgs, out var fetchArgs);
+            var options = new FetchOptions();
+            if (request.Properties.TryGetValue(FetchArgs, out var fetchArgs))
+            {
+                options.RequestInitOverrides = fetchArgs;
+            }
 
-            RegisteredFunction.Invoke<object>(
+            options.RequestInit = new RequestInit
+            {
+                Credentials = GetDefaultCredentialsString(),
+                Headers = GetHeadersAsStringArray(request),
+                Method = request.Method.Method
+            };
+
+            options.RequestUri = request.RequestUri.ToString();
+
+            RegisteredFunction.InvokeUnmarshalled<int, byte[], string, object>(
                 $"{typeof(BrowserHttpMessageHandler).FullName}.Send",
                 id,
-                request.Method.Method,
-                request.RequestUri,
-                request.Content == null ? null : await GetContentAsString(request.Content),
-                SerializeHeadersAsJson(request),
-                fetchArgs ?? CreateDefaultFetchArgs());
+                request.Content == null ? null : await request.Content.ReadAsByteArrayAsync(),
+                JsonUtil.Serialize(options));
 
             return await tcs.Task;
         }
 
-        private string SerializeHeadersAsJson(HttpRequestMessage request)
-            => JsonUtil.Serialize(
-                (from header in request.Headers.Concat(request.Content?.Headers ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
-                 from headerValue in header.Value // There can be more than one value for each name
-                 select new[] { header.Key, headerValue }).ToList()
-            );
-
-        private static async Task<string> GetContentAsString(HttpContent content)
-            => content is StringContent stringContent
-                ? await stringContent.ReadAsStringAsync()
-                : throw new InvalidOperationException($"Currently, {typeof(HttpClient).FullName} " +
-                    $"only supports contents of type {nameof(StringContent)}, but you supplied " +
-                    $"{content.GetType().FullName}.");
+        private string[][] GetHeadersAsStringArray(HttpRequestMessage request)
+            => (from header in request.Headers.Concat(request.Content?.Headers ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
+                from headerValue in header.Value // There can be more than one value for each name
+                select new[] { header.Key, headerValue }).ToArray();
 
         private static void ReceiveResponse(
             string id,
@@ -104,10 +105,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
             }
         }
 
-        private static object CreateDefaultFetchArgs()
-            => new { credentials = GetDefaultCredentialsString() };
-
-        private static object GetDefaultCredentialsString()
+        private static string GetDefaultCredentialsString()
         {
             // See https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials for
             // standard values and meanings
@@ -124,17 +122,33 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
             }
         }
 
-        // Keep in sync with TypeScript class in Http.ts
+        // Keep these in sync with TypeScript class in Http.ts
+        private class FetchOptions
+        {
+            public string RequestUri { get; set; }
+            public RequestInit RequestInit { get; set; }
+            public object RequestInitOverrides { get; set; }
+        }
+
+        private class RequestInit
+        {
+            public string Credentials { get; set; }
+            public string[][] Headers { get; set; }
+            public string Method { get; set; }
+        }
+
         private class ResponseDescriptor
         {
             #pragma warning disable 0649
             public int StatusCode { get; set; }
+            public string StatusText { get; set; }
             public string[][] Headers { get; set; }
             #pragma warning restore 0649
 
             public HttpResponseMessage ToResponseMessage(HttpContent content)
             {
                 var result = new HttpResponseMessage((HttpStatusCode)StatusCode);
+                result.ReasonPhrase = StatusText;
                 result.Content = content;
                 var headers = result.Headers;
                 var contentHeaders = result.Content?.Headers;

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpMessageHandler.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpMessageHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
         private static void ReceiveResponse(
             string id,
             string responseDescriptorJson,
-            string responseBodyText,
+            byte[] responseBodyData,
             string errorText)
         {
             TaskCompletionSource<HttpResponseMessage> tcs;
@@ -99,10 +99,15 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
             else
             {
                 var responseDescriptor = JsonUtil.Deserialize<ResponseDescriptor>(responseDescriptorJson);
-                var responseContent = responseBodyText == null ? null : new StringContent(responseBodyText);
+                var responseContent = responseBodyData == null ? null : new ByteArrayContent(responseBodyData);
                 var responseMessage = responseDescriptor.ToResponseMessage(responseContent);
                 tcs.SetResult(responseMessage);
             }
+        }
+
+        private static byte[] AllocateArray(string length)
+        {
+            return new byte[int.Parse(length)];
         }
 
         private static string GetDefaultCredentialsString()

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/BinaryHttpClientTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/BinaryHttpClientTest.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BasicTestApp.HttpClientTest;
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
+{
+    public class BinaryHttpClientTest : BasicTestAppTestBase, IClassFixture<AspNetSiteServerFixture>
+    {
+        readonly ServerFixture _apiServerFixture;
+        readonly IWebElement _appElement;
+        IWebElement _responseStatus;
+        IWebElement _responseStatusText;
+        IWebElement _testOutcome;
+
+        public BinaryHttpClientTest(
+            BrowserFixture browserFixture,
+            DevHostServerFixture<BasicTestApp.Program> devHostServerFixture,
+            AspNetSiteServerFixture apiServerFixture,
+            ITestOutputHelper output)
+            : base(browserFixture, devHostServerFixture, output)
+        {
+            apiServerFixture.BuildWebHostMethod = TestServer.Program.BuildWebHost;
+            _apiServerFixture = apiServerFixture;
+
+            Navigate(ServerPathBase, noReload: true);
+            _appElement = MountTestComponent<BinaryHttpRequestsComponent>();
+        }
+        
+        [Fact]
+        public void CanSendAndReceiveBytes()
+        {
+            IssueRequest("/api/data");
+            Assert.Equal("OK", _responseStatus.Text);
+            Assert.Equal("OK", _responseStatusText.Text);
+            Assert.Equal("", _testOutcome.Text);
+        }
+
+        private void IssueRequest(string relativeUri)
+        {
+            var targetUri = new Uri(_apiServerFixture.RootUri, relativeUri);
+            SetValue("request-uri", targetUri.AbsoluteUri);
+
+            _appElement.FindElement(By.Id("send-request")).Click();
+
+            new WebDriverWait(Browser, TimeSpan.FromSeconds(30)).Until(
+                driver => driver.FindElement(By.Id("response-status")) != null);
+            _responseStatus = _appElement.FindElement(By.Id("response-status"));
+            _responseStatusText = _appElement.FindElement(By.Id("response-status-text"));
+            _testOutcome = _appElement.FindElement(By.Id("test-outcome"));
+        }
+
+        private void SetValue(string elementId, string value)
+        {
+            var element = Browser.FindElement(By.Id(elementId));
+            element.Clear();
+            element.SendKeys(value);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/HttpClientTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/HttpClientTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             AddRequestHeader("Content-Type", "application/json");
             IssueRequest("PUT", "/api/person", "{\"Name\": \"Bert\", \"Id\": 123}");
             Assert.Equal("OK", _responseStatus.Text);
-            Assert.Contains("Content-Type: application/json", _responseHeaders.Text);
+            Assert.Contains("Content-Type: application/json", _responseHeaders.Text, StringComparison.OrdinalIgnoreCase);
             Assert.Equal("{\"id\":123,\"name\":\"Bert\"}", _responseBody.Text);
         }
 

--- a/test/testapps/BasicTestApp/HttpClientTest/BinaryHttpRequestsComponent.cshtml
+++ b/test/testapps/BasicTestApp/HttpClientTest/BinaryHttpRequestsComponent.cshtml
@@ -1,0 +1,71 @@
+﻿@using System.Net
+@using System.Net.Http
+@inject HttpClient Http
+
+<h1>Binary HTTP request tester</h1>
+
+<p>
+    <div>URI:</div>
+    <input id="request-uri" bind="@uri" size="60"/>
+</p>
+
+<button id="send-request" onclick="@DoRequest">Request</button>
+
+@if (responseStatusCode.HasValue)
+{
+    <h2>Response</h2>
+    <p><div>Status:</div><span id="response-status">@responseStatusCode</span></p>
+    <p><div>StatusText:</div><span id="response-status-text">@responseStatusText</span></p>
+}
+
+<span id="test-outcome">@testOutcome</span>
+
+@functions {
+    string uri = "";
+    HttpStatusCode? responseStatusCode;
+    string responseStatusText;
+    string testOutcome = "";
+
+    async Task DoRequest()
+    {
+        responseStatusCode = null;
+        responseStatusText = null;
+        testOutcome = null;
+
+        try
+        {
+            var bytes = await Http.GetByteArrayAsync(uri);
+            if (bytes.Length != 256)
+            {
+                testOutcome = "Expected 256 bytes but got " + bytes.Length.ToString();
+                return;
+            }
+
+            var reversedBytes = bytes.ToArray();
+            Array.Reverse(reversedBytes);
+
+            var response = await Http.PostAsync(uri, new ByteArrayContent(reversedBytes));
+            responseStatusCode = response.StatusCode;
+            responseStatusText = response.ReasonPhrase;
+            var doubleReversed = await response.Content.ReadAsByteArrayAsync();
+
+            for (int i = 0; i <= byte.MaxValue; i++)
+            {
+                if (doubleReversed[i] != (byte)i)
+                {
+                    testOutcome = $"Expected byte at index {i} to have value {i} but actually was {doubleReversed[i]}";
+                    return;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            if (ex is AggregateException)
+            {
+                ex = ex.InnerException;
+            }
+            responseStatusCode = HttpStatusCode.SeeOther;
+            testOutcome = ex.Message + Environment.NewLine + ex.StackTrace;
+        }
+    }
+}

--- a/test/testapps/BasicTestApp/HttpClientTest/HttpRequestsComponent.cshtml
+++ b/test/testapps/BasicTestApp/HttpClientTest/HttpRequestsComponent.cshtml
@@ -88,6 +88,15 @@
 
             foreach (var header in requestHeaders)
             {
+                // StringContent automatically adds its own Content-Type header with default value "text/plain"
+                // If the developer is trying to specify a content type explicitly, we need to replace the default value,
+                // rather than adding a second Content-Type header.
+                if (header.Name.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) && requestMessage.Content != null)
+                {
+                    requestMessage.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(header.Value);
+                    continue;
+                }
+
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Name, header.Value))
                 {
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Name, header.Value);

--- a/test/testapps/BasicTestApp/wwwroot/index.html
+++ b/test/testapps/BasicTestApp/wwwroot/index.html
@@ -26,6 +26,7 @@
       <option value="BasicTestApp.TextOnlyComponent">Plain text</option>
       <option value="BasicTestApp.HierarchicalImportsTest.Subdir.ComponentUsingImports">Imports statement</option>
       <option value="BasicTestApp.HttpClientTest.HttpRequestsComponent">HttpClient tester</option>
+      <option value="BasicTestApp.HttpClientTest.BinaryHttpRequestsComponent">Binary HttpClient tester</option>
       <option value="BasicTestApp.HttpClientTest.CookieCounterComponent">HttpClient cookies</option>
       <option value="BasicTestApp.BindCasesComponent">@bind cases</option>
       <option value="BasicTestApp.ExternalContentPackage">External content package</option>

--- a/test/testapps/TestServer/Controllers/DataController.cs
+++ b/test/testapps/TestServer/Controllers/DataController.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Cors;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TestServer.Controllers
+{
+    [EnableCors("AllowAll")]
+    [Route("api/[controller]")]
+    public class DataController : Controller
+    {
+        // GET api/data
+        [HttpGet]
+        public FileContentResult Get()
+        {
+            var bytes = new byte[byte.MaxValue + 1];
+            for (int i = 0; i <= byte.MaxValue; i++)
+            {
+                bytes[i] = (byte)i;
+            }
+
+            return File(bytes, "application/octet-stream");
+        }
+
+        // POST api/data
+        [HttpPost]
+        public async Task<IActionResult> PostAsync()
+        {
+            var ms = new MemoryStream();
+            await Request.Body.CopyToAsync(ms);
+            var bytes = ms.ToArray();
+            Array.Reverse(bytes);
+
+            for (int i = 0; i <= byte.MaxValue; i++)
+            {
+                if (bytes[i] != (byte)i)
+                {
+                    return BadRequest();
+                }
+            }
+
+            return File(bytes, "application/octet-stream");
+        }
+    }
+}


### PR DESCRIPTION
This adds support for sending arbitrary `HttpContent` by writing it to a `byte[]` first and then zero copy marshalling that as `Uint8Array` which is supported as request body.
It also supports receiving binary data by getting an `ArrayBuffer` from fetch, allocating a managed array of that size and then copying the response over.