### PR TITLE
Use RestoreAdditionalProjectSources instead of RestoreSources

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,10 @@ To use a nightly or developer CI build of the Blazor package, ensure that you ha
 
 Update your projects to include the Blazor developer feed (`https://dotnet.myget.org/f/blazor-dev/api/v3/index.json`) and ASP.NET Core developer feed (`https://dotnet.myget.org/F/dotnet-core/api/v3/index.json`). You can do this in a project file with MSBuild:
 ```xml
-<RestoreSources>
-    $(RestoreSources);
-    https://api.nuget.org/v3/index.json;
+<RestoreAdditionalProjectSources>
     https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
     https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
-</RestoreSources>
+</RestoreAdditionalProjectSources>
 ```
 
 Or in a NuGet.config in the same directory as the solution file:

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
@@ -3,11 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RestoreSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
-      $(RestoreSources);
-      https://api.nuget.org/v3/index.json;
+    <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
       https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
-    </RestoreSources>
+    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RestoreSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
-      $(RestoreSources);
-      https://api.nuget.org/v3/index.json;
+    <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
       https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
-    </RestoreSources>
+    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary-CSharp/BlazorLibrary-CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary-CSharp/BlazorLibrary-CSharp.csproj
@@ -5,11 +5,9 @@
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
     <BlazorLinkOnBuild>false</BlazorLinkOnBuild>
-    <RestoreSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
-      $(RestoreSources);
-      https://api.nuget.org/v3/index.json;
+    <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
       https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
-    </RestoreSources>
+    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/BlazorStandalone-CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/BlazorStandalone-CSharp.csproj
@@ -4,11 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RunCommand>dotnet</RunCommand>
     <RunArguments>blazor serve</RunArguments>
-    <RestoreSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
-      $(RestoreSources);
-      https://api.nuget.org/v3/index.json;
+    <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
       https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
-    </RestoreSources>
+    </RestoreAdditionalProjectSources>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
`RestoreAdditionalProjectSources` is additive while `RestoreSources` replaces the existing sources, see https://github.com/NuGet/Home/wiki/%5BSpec%5D-NuGet-settings-in-MSBuild#project-properties