### PR TITLE
Fix base type of UIErrorEventArgs

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
@@ -248,7 +248,7 @@ interface UIDataTransferItem {
   type: string;
 }
 
-interface UIErrorEventArgs extends UIProgressEventArgs {
+interface UIErrorEventArgs extends UIEventArgs {
 }
 
 interface UIFocusEventArgs extends UIEventArgs {

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventForDotNet.ts
@@ -47,12 +47,14 @@ export class EventForDotNet<TData extends UIEventArgs> {
       case 'dblclick':
         return new EventForDotNet<UIMouseEventArgs>('mouse', parseMouseEvent(<MouseEvent>event));
 
+      case 'error':
+        return new EventForDotNet<UIErrorEventArgs>('error', parseErrorEvent(<ErrorEvent>event));
+
       case 'loadstart':
       case 'timeout':
       case 'abort':
       case 'load':
       case 'loadend':
-      case 'error':
       case 'progress':
         return new EventForDotNet<UIProgressEventArgs>('progress', parseProgressEvent(<ProgressEvent>event));
 
@@ -112,6 +114,16 @@ function parseWheelEvent(event: WheelEvent) {
     deltaZ: event.deltaZ,
     deltaMode: event.deltaMode
   };
+}
+
+function parseErrorEvent(event: ErrorEvent) {
+  return {
+    type: event.type,
+    message: event.message,
+    filename: event.filename,
+    lineno: event.lineno,
+    colno: event.colno
+  }
 }
 
 function parseProgressEvent(event: ProgressEvent) {
@@ -249,6 +261,13 @@ interface UIDataTransferItem {
 }
 
 interface UIErrorEventArgs extends UIEventArgs {
+  message: string;
+  filename: string;
+  lineno: number;
+  colno: number;
+
+  // omitting 'error' here since we'd have to serialize it, and it's not clear we will want to
+  // do that. https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent
 }
 
 interface UIFocusEventArgs extends UIEventArgs {

--- a/src/Microsoft.AspNetCore.Blazor/UIEventArgs.cs
+++ b/src/Microsoft.AspNetCore.Blazor/UIEventArgs.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Blazor
     /// <summary>
     /// Supplies information about an error event that is being raised.
     /// </summary>
-    public class UIErrorEventArgs : UIProgressEventArgs
+    public class UIErrorEventArgs : UIEventArgs
     {
     }
 

--- a/src/Microsoft.AspNetCore.Blazor/UIEventArgs.cs
+++ b/src/Microsoft.AspNetCore.Blazor/UIEventArgs.cs
@@ -170,6 +170,25 @@ namespace Microsoft.AspNetCore.Blazor
     /// </summary>
     public class UIErrorEventArgs : UIEventArgs
     {
+        /// <summary>
+        /// Gets a a human-readable error message describing the problem.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Gets the name of the script file in which the error occurred.
+        /// </summary>
+        public string Filename { get; set; }
+
+        /// <summary>
+        /// Gets the line number of the script file on which the error occurred.
+        /// </summary>
+        public int Lineno { get; set; }
+
+        /// <summary>
+        /// Gets the column number of the script file on which the error occurred.
+        /// </summary>
+        public int Colno { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
I don't believe `UIErrorEventArgs` should derive from `UIProgressEventArgs`. Switching base type to `UIEventArgs` instead.