### PR TITLE
Add more struct readonlyness hints

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Blazor.Performance/RenderTreeDiffBuilderBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Blazor.Performance/RenderTreeDiffBuilderBenchmark.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Blazor.Performance
             {
             }
 
-            protected override void UpdateDisplay(RenderBatch renderBatch)
+            protected override void UpdateDisplay(in RenderBatch renderBatch)
             {
             }
         }

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         }
 
         /// <inheritdoc />
-        protected override void UpdateDisplay(RenderBatch batch)
+        protected override void UpdateDisplay(in RenderBatch batch)
         {
             RegisteredFunction.InvokeUnmarshalled<int, RenderBatch, object>(
                 "renderBatch",

--- a/src/Microsoft.AspNetCore.Blazor/Components/EventHandlerInvoker.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/EventHandlerInvoker.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
     /// <summary>
     /// A bound event handler delegate.
     /// </summary>
-    public struct EventHandlerInvoker
+    public readonly struct EventHandlerInvoker
     {
         private readonly MulticastDelegate _delegate;
 

--- a/src/Microsoft.AspNetCore.Blazor/Components/ParameterCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/ParameterCollectionExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// <param name="parameterCollection">The <see cref="ParameterCollection"/>.</param>
         /// <param name="target">An object that has a public writable property matching each parameter's name and type.</param>
         public static void AssignToProperties(
-            this ParameterCollection parameterCollection,
+            in this ParameterCollection parameterCollection,
             object target)
         {
             if (target == null)

--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeBuilder.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeBuilder.cs
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
         /// </summary>
         /// <param name="sequence">An integer that represents the position of the instruction in the source code.</param>
         /// <param name="frame">A <see cref="RenderTreeFrame"/> holding the name and value of the attribute.</param>
-        public void AddAttribute(int sequence, RenderTreeFrame frame)
+        public void AddAttribute(int sequence, in RenderTreeFrame frame)
         {
             if (frame.FrameType != RenderTreeFrameType.Attribute)
             {

--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeDiffBuilder.cs
@@ -291,7 +291,7 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
             }
         }
 
-        private static int NextSiblingIndex(RenderTreeFrame frame, int frameIndex)
+        private static int NextSiblingIndex(in RenderTreeFrame frame, int frameIndex)
         {
             switch (frame.FrameType)
             {

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// Updates the visible UI.
         /// </summary>
         /// <param name="renderBatch">The changes to the UI since the previous call.</param>
-        protected abstract void UpdateDisplay(RenderBatch renderBatch);
+        protected abstract void UpdateDisplay(in RenderBatch renderBatch);
 
         /// <summary>
         /// Notifies the specified component that an event has occurred.

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorIntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorIntegrationTestBase.cs
@@ -370,7 +370,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             public void AttachComponent(IComponent component)
                 => AssignComponentId(component);
 
-            protected override void UpdateDisplay(RenderBatch renderBatch)
+            protected override void UpdateDisplay(in RenderBatch renderBatch)
             {
                 LatestBatchReferenceFrames = renderBatch.ReferenceFrames.ToArray();
             }

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeBuilderTest.cs
@@ -1005,7 +1005,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
             }
 
-            protected override void UpdateDisplay(RenderBatch renderBatch)
+            protected override void UpdateDisplay(in RenderBatch renderBatch)
                 => throw new NotImplementedException();
         }
     }

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
@@ -1496,7 +1496,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
             }
 
-            protected override void UpdateDisplay(RenderBatch renderBatch)
+            protected override void UpdateDisplay(in RenderBatch renderBatch)
             {
             }
         }

--- a/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
@@ -1080,7 +1080,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             public new int AssignComponentId(IComponent component)
                 => base.AssignComponentId(component);
 
-            protected override void UpdateDisplay(RenderBatch renderBatch)
+            protected override void UpdateDisplay(in RenderBatch renderBatch)
             {
             }
         }

--- a/test/shared/TestRenderer.cs
+++ b/test/shared/TestRenderer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Blazor.Test.Helpers
         public T InstantiateComponent<T>() where T : IComponent
             => (T)InstantiateComponent(typeof(T));
 
-        protected override void UpdateDisplay(RenderBatch renderBatch)
+        protected override void UpdateDisplay(in RenderBatch renderBatch)
         {
             OnUpdateDisplay?.Invoke(renderBatch);
 


### PR DESCRIPTION
These suggestions come from ErrorProne.NET, a set of Roslyn analyzers that warn about suboptimal `struct` usage.