### PR TITLE
Don't preventDefault on events. Fixes #803

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
@@ -1,4 +1,4 @@
-﻿import { System_Array, MethodHandle } from '../Platform/Platform';
+import { System_Array, MethodHandle } from '../Platform/Platform';
 import { getRenderTreeEditPtr, renderTreeEdit, RenderTreeEditPointer, EditType } from './RenderTreeEdit';
 import { getTreeFramePtr, renderTreeFrame, FrameType, RenderTreeFramePointer } from './RenderTreeFrame';
 import { platform } from '../Environment';
@@ -309,8 +309,6 @@ function countDescendantFrames(frame: RenderTreeFramePointer): number {
 }
 
 function raiseEvent(event: Event, browserRendererId: number, componentId: number, eventHandlerId: number, eventArgs: EventForDotNet<UIEventArgs>) {
-  event.preventDefault();
-
   if (!raiseEventMethod) {
     raiseEventMethod = platform.findMethod(
       'Microsoft.AspNetCore.Blazor.Browser', 'Microsoft.AspNetCore.Blazor.Browser.Rendering', 'BrowserRendererEventDispatcher', 'DispatchEvent'

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
@@ -100,6 +100,9 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             Assert.Collection(liElements(),
                 li => Assert.Equal("a", li.Text),
                 li => Assert.Equal("b", li.Text));
+
+            // Textbox contains typed text
+            Assert.Equal("ab", inputElement.GetAttribute("value"));
         }
 
         [Fact]


### PR DESCRIPTION
It seems that we started calling `event.preventDefault` on all .NET-handled events in this commit: https://github.com/aspnet/Blazor/commit/36f5c5898820899831447b3dbde5e8658cc0baaa

It's not explicitly stated why I added that line in that commit, but my guess now is that it was needed because we didn't yet have the "internal link click" handling logic that we now do (which does call `preventDefault` when it recognizes clicks on internal links).

So it looks like we can fix #803 and all related issues trivially just be removing the `event.preventDefault` call. It doesn't appear to affect anything else negatively, and conceptually should be the right thing to do because saying you want to handle an event is not the same as saying you want to prevent its default actions.