### PR TITLE
When clicking <a> tag with no href, don't attempt navigation to "null". Fixes #943

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Services/UriHelper.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Services/UriHelper.ts
@@ -19,9 +19,11 @@ registerFunction(`${registeredFunctionPrefix}.enableNavigationInterception`, () 
 
   document.addEventListener('click', event => {
     // Intercept clicks on all <a> elements where the href is within the <base href> URI space
-    const anchorTarget = findClosestAncestor(event.target as Element | null, 'A');
-    if (anchorTarget) {
-      const href = anchorTarget.getAttribute('href');
+    // We must explicitly check if it has an 'href' attribute, because if it doesn't, the result might be null or an empty string depending on the browser
+    const anchorTarget = findClosestAncestor(event.target as Element | null, 'A') as HTMLAnchorElement;
+    const hrefAttributeName = 'href';
+    if (anchorTarget && anchorTarget.hasAttribute(hrefAttributeName)) {
+      const href = anchorTarget.getAttribute(hrefAttributeName)!;
       const absoluteHref = toAbsoluteUri(href);
 
       // Don't stop ctrl/meta-click (etc) from opening links in new tabs/windows

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/RoutingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/RoutingTest.cs
@@ -231,6 +231,19 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             AssertHighlightedLinks("Other", "Other with base-relative URL (matches all)");
         }
 
+        [Fact]
+        public void ClickingAnchorWithNoHrefShouldNotNavigate()
+        {
+            SetUrlViaPushState($"{ServerPathBase}/");
+            var initialUrl = Browser.Url;
+
+            var app = MountTestComponent<TestRouter>();
+            app.FindElement(By.Id("anchor-with-no-href")).Click();
+
+            Assert.Equal(initialUrl, Browser.Url);
+            AssertHighlightedLinks("Default (matches all)", "Default with base-relative URL (matches all)");
+        }
+
         public void Dispose()
         {
             // Clear any existing state

--- a/test/testapps/BasicTestApp/RouterTest/Links.cshtml
+++ b/test/testapps/BasicTestApp/RouterTest/Links.cshtml
@@ -16,3 +16,7 @@
 <button onclick=@(x => uriHelper.NavigateTo("Other"))>
     Programmatic navigation
 </button>
+
+<a id="anchor-with-no-href">
+    Anchor tag with no href attribute
+</a>


### PR DESCRIPTION
This PR will merge into `release/0.4.0` (and afterwards, I'll cherry-pick to `dev`).

The recent change to stop calling `preventDefault` on all events has caused a regression if you click on an `<a>` element that has no `href`. Our "internal link navigation" logic will try to read the `href`, gets the value `null`, and then because that's not anticipated it ends up being treated as string string `"null"` and we attempt to navigate to that as if it's a URL.

The fix is simply to do nothing if there's no `href` attribute. There is nothing we want to do in that situation.

**Broader note**: This is an example of how the removal of `preventDefault` might be breaking in a bunch of unanticipated ways. However I still think it's the right thing to do (both by default, and for the great majority of cases). When we hear of scenarios where it's necessary to preventDefault, we'll have to consider each of them separately, as well as consider adding a general mechanism for controlling whether events are preventDefaulted.