### PR TITLE
Fix #974

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
@@ -14,6 +14,8 @@
     <!-- Deactivates the Razor SDK's build-time compilation. We do our own -->
     <RazorCompileOnBuild>false</RazorCompileOnBuild>
 
+    <RazorLangVersion>Experimental</RazorLangVersion>
+
     <!-- 
       This version is used to build our RazorConfiguration, and is hardcoded into the tools in VS. If you change
       This to a value that doesn't match VS, then the Blazor Razor experience won't work for those documents.

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -38,6 +38,17 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         {
             var appElement = MountTestComponent<TextOnlyComponent>();
             Assert.Equal("Hello from TextOnlyComponent", appElement.Text);
+        }
+
+        // This verifies that we've correctly configured the Razor language version via MSBuild.
+        // See #974
+        [Fact]
+        public void CanRenderComponentWithDataDash()
+        {
+            var appElement = MountTestComponent<DataDashComponent>();
+            var element = appElement.FindElement(By.Id("cool_beans"));
+            Assert.Equal("17", element.GetAttribute("data-tab"));
+            Assert.Equal("17", element.Text);
         }
 
         [Fact]

--- a/test/testapps/BasicTestApp/DataDashComponent.cshtml
+++ b/test/testapps/BasicTestApp/DataDashComponent.cshtml
@@ -1,0 +1,5 @@
+<div id="cool_beans" data-tab="@TabId">@TabId</div>
+
+@functions {
+    string TabId = "17";
+}


### PR DESCRIPTION
The root cause here was that we weren't setting the language version in
MSBuild, which is only for the command line version.