### PR TITLE
Publish wwwroot to dist for Linux-based OSs

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -20,7 +20,7 @@
       <ResolvedAssembliesToPublish Remove="@(ResolvedAssembliesToPublish)" />
 
       <!-- Move wwwroot files to output root -->
-      <ContentWithTargetPath Update="@(ContentWithTargetPath)" Condition="$([System.String]::new(%(TargetPath)).StartsWith('wwwroot\'))">
+      <ContentWithTargetPath Update="@(ContentWithTargetPath)" Condition="$([System.String]::new(%(TargetPath)).StartsWith('wwwroot\')) OR $([System.String]::new(%(TargetPath)).StartsWith('wwwroot/'))">
         <TargetPath>$(BlazorPublishDistDir)$([System.String]::new(%(TargetPath)).Substring(8))</TargetPath>
       </ContentWithTargetPath>
       


### PR DESCRIPTION
`.StartsWith('wwwroot\')` fails on Linux and macOS.