### PR TITLE
Change ElementRef IDs to be strings, not ints

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
@@ -153,7 +153,7 @@ export class BrowserRenderer {
         return this.insertFrameRange(batch, componentId, parent, childIndex, frames, frameIndex + 1, frameIndex + frameReader.subtreeLength(frame));
       case FrameType.elementReferenceCapture:
         if (parent instanceof Element) {
-          applyCaptureIdToElement(parent, frameReader.elementReferenceCaptureId(frame));
+          applyCaptureIdToElement(parent, frameReader.elementReferenceCaptureId(frame)!);
           return 0; // A "capture" is a child in the diff, but has no node in the DOM
         } else {
           throw new Error('Reference capture frames can only be children of element frames.');

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/ElementReferenceCapture.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/ElementReferenceCapture.ts
@@ -1,20 +1,20 @@
-export function applyCaptureIdToElement(element: Element, referenceCaptureId: number) {
+export function applyCaptureIdToElement(element: Element, referenceCaptureId: string) {
   element.setAttribute(getCaptureIdAttributeName(referenceCaptureId), '');
 }
 
-function getElementByCaptureId(referenceCaptureId: number) {
+function getElementByCaptureId(referenceCaptureId: string) {
   const selector = `[${getCaptureIdAttributeName(referenceCaptureId)}]`;
   return document.querySelector(selector);
 }
 
-function getCaptureIdAttributeName(referenceCaptureId: number) {
+function getCaptureIdAttributeName(referenceCaptureId: string) {
   return `_bl_${referenceCaptureId}`;
 }
 
 // Support receiving ElementRef instances as args in interop calls
 const elementRefKey = '_blazorElementRef'; // Keep in sync with ElementRef.cs
 DotNet.attachReviver((key, value) => {
-  if (value && typeof value === 'object' && value.hasOwnProperty(elementRefKey) && typeof value[elementRefKey] === 'number') {
+  if (value && typeof value === 'object' && value.hasOwnProperty(elementRefKey) && typeof value[elementRefKey] === 'string') {
     return getElementByCaptureId(value[elementRefKey]);
   } else {
     return value;

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/RenderBatch/RenderBatch.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/RenderBatch/RenderBatch.ts
@@ -43,7 +43,7 @@ export interface RenderTreeEditReader {
 export interface RenderTreeFrameReader {
   frameType(frame: RenderTreeFrame): FrameType;
   subtreeLength(frame: RenderTreeFrame): number;
-  elementReferenceCaptureId(frame: RenderTreeFrame): number;
+  elementReferenceCaptureId(frame: RenderTreeFrame): string | null;
   componentId(frame: RenderTreeFrame): number;
   elementName(frame: RenderTreeFrame): string | null;
   textContent(frame: RenderTreeFrame): string | null;

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/RenderBatch/SharedMemoryRenderBatch.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/RenderBatch/SharedMemoryRenderBatch.ts
@@ -77,7 +77,7 @@ const frameReader = {
   structLength: 28,
   frameType: (frame: RenderTreeFrame) => platform.readInt32Field(frame as any, 4) as FrameType,
   subtreeLength: (frame: RenderTreeFrame) => platform.readInt32Field(frame as any, 8),
-  elementReferenceCaptureId: (frame: RenderTreeFrame) => platform.readInt32Field(frame as any, 8),
+  elementReferenceCaptureId: (frame: RenderTreeFrame) => platform.readStringField(frame as any, 16),
   componentId: (frame: RenderTreeFrame) => platform.readInt32Field(frame as any, 12),
   elementName: (frame: RenderTreeFrame) => platform.readStringField(frame as any, 16),
   textContent: (frame: RenderTreeFrame) => platform.readStringField(frame as any, 16),

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RenderBatchWriter.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RenderBatchWriter.cs
@@ -158,7 +158,7 @@ namespace Microsoft.AspNetCore.Blazor.Server.Circuits
                     WritePadding(_binaryWriter, 4);
                     break;
                 case RenderTreeFrameType.ElementReferenceCapture:
-                    _binaryWriter.Write(frame.ElementReferenceCaptureId);
+                    WriteString(frame.ElementReferenceCaptureId);
                     WritePadding(_binaryWriter, 8);
                     break;
                 case RenderTreeFrameType.Region:

--- a/src/Microsoft.AspNetCore.Blazor/Components/ComponentResolver.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/ComponentResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
     /// <summary>
     /// Resolves components for an application.
     /// </summary>
-    internal class ComponentResolver
+    internal static class ComponentResolver
     {
         /// <summary>
         /// Lists all the types 

--- a/src/Microsoft.AspNetCore.Blazor/PlatformInfo.cs
+++ b/src/Microsoft.AspNetCore.Blazor/PlatformInfo.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Blazor
+{
+    internal static class PlatformInfo
+    {
+        public static bool IsWebAssembly { get; }
+
+        static PlatformInfo()
+        {
+            IsWebAssembly = RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeFrame.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeFrame.cs
@@ -137,13 +137,13 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
         /// If the <see cref="FrameType"/> property equals <see cref="RenderTreeFrameType.ElementReferenceCapture"/>,
         /// gets the ID of the reference capture. Otherwise, the value is undefined.
         /// </summary>
-        [FieldOffset(8)] public readonly int ElementReferenceCaptureId;
+        [FieldOffset(16)] public readonly string ElementReferenceCaptureId;
 
         /// <summary>
         /// If the <see cref="FrameType"/> property equals <see cref="RenderTreeFrameType.ElementReferenceCapture"/>,
         /// gets the action that writes the reference to its target. Otherwise, the value is undefined.
         /// </summary>
-        [FieldOffset(16)] public readonly Action<ElementRef> ElementReferenceCaptureAction;
+        [FieldOffset(24)] public readonly Action<ElementRef> ElementReferenceCaptureAction;
 
         // --------------------------------------------------------------------------------
         // RenderTreeFrameType.ComponentReferenceCapture
@@ -227,7 +227,7 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
             RegionSubtreeLength = regionSubtreeLength;
         }
 
-        private RenderTreeFrame(int sequence, Action<ElementRef> elementReferenceCaptureAction, int elementReferenceCaptureId)
+        private RenderTreeFrame(int sequence, Action<ElementRef> elementReferenceCaptureAction, string elementReferenceCaptureId)
             : this()
         {
             FrameType = RenderTreeFrameType.ElementReferenceCapture;
@@ -264,7 +264,7 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
             => new RenderTreeFrame(sequence, regionSubtreeLength: 0);
 
         internal static RenderTreeFrame ElementReferenceCapture(int sequence, Action<ElementRef> elementReferenceCaptureAction)
-            => new RenderTreeFrame(sequence, elementReferenceCaptureAction: elementReferenceCaptureAction, elementReferenceCaptureId: 0);
+            => new RenderTreeFrame(sequence, elementReferenceCaptureAction: elementReferenceCaptureAction, elementReferenceCaptureId: null);
 
         internal static RenderTreeFrame ComponentReferenceCapture(int sequence, Action<object> componentReferenceCaptureAction, int parentFrameIndex)
             => new RenderTreeFrame(sequence, componentReferenceCaptureAction: componentReferenceCaptureAction, parentFrameIndex: parentFrameIndex);
@@ -287,7 +287,7 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
         internal RenderTreeFrame WithRegionSubtreeLength(int regionSubtreeLength)
             => new RenderTreeFrame(Sequence, regionSubtreeLength: regionSubtreeLength);
 
-        internal RenderTreeFrame WithElementReferenceCaptureId(int elementReferenceCaptureId)
+        internal RenderTreeFrame WithElementReferenceCaptureId(string elementReferenceCaptureId)
             => new RenderTreeFrame(Sequence, ElementReferenceCaptureAction, elementReferenceCaptureId);
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/RenderQueueEntry.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/RenderQueueEntry.cs
@@ -1,7 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Blazor.RenderTree;
 using System;
 
 namespace Microsoft.AspNetCore.Blazor.Rendering

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
@@ -1,11 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Blazor.Components;
 using Microsoft.AspNetCore.Blazor.RenderTree;
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Blazor.Rendering
 {

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Blazor.Components;
@@ -1342,9 +1342,9 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act
             var (diff, referenceFrames) = GetSingleUpdatedComponent();
 
-            // Assert: Distinct nonzero IDs
-            Assert.NotEqual(0, ref1.Id);
-            Assert.NotEqual(0, ref2.Id);
+            // Assert: Distinct nonnull IDs
+            Assert.NotNull(ref1.Id);
+            Assert.NotNull(ref2.Id);
             Assert.NotEqual(ref1.Id, ref2.Id);
 
             // Assert: Also specified in diff
@@ -1388,7 +1388,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Note: We're not preserving the ReferenceCaptureId on the actual RenderTreeFrames in the same
             //       way we do for event handler IDs, simply because there's no need to do so. We only do
             //       anything with ReferenceCaptureId when frames are first inserted into the document.
-            Assert.NotEqual(0, ref1.Id);
+            Assert.NotNull(ref1.Id);
             Assert.Equal(1, refWriteCount);
             Assert.Empty(diff.Edits);
             Assert.Empty(referenceFrames);

--- a/test/Microsoft.AspnetCore.Blazor.Server.Test/Circuits/RenderBatchWriterTest.cs
+++ b/test/Microsoft.AspnetCore.Blazor.Server.Test/Circuits/RenderBatchWriterTest.cs
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Blazor.Server
                     RenderTreeFrame.Element(128, "Some element")
                         .WithElementSubtreeLength(1234),
                     RenderTreeFrame.ElementReferenceCapture(129, value => { })
-                        .WithElementReferenceCaptureId(12121),
+                        .WithElementReferenceCaptureId("my unique ID"),
                     RenderTreeFrame.Region(130)
                         .WithRegionSubtreeLength(1234),
                     RenderTreeFrame.Text(131, "Some text"),
@@ -212,7 +212,7 @@ namespace Microsoft.AspNetCore.Blazor.Server
                 RenderTreeFrameType.Component, 5678, 2000, 0,
                 RenderTreeFrameType.ComponentReferenceCapture, 0, 0, 0,
                 RenderTreeFrameType.Element, 1234, "Some element", 0,
-                RenderTreeFrameType.ElementReferenceCapture, 12121, 0, 0,
+                RenderTreeFrameType.ElementReferenceCapture, "my unique ID", 0, 0,
                 RenderTreeFrameType.Region, 1234, 0, 0,
                 RenderTreeFrameType.Text, "Some text", 0, 0
             );


### PR DESCRIPTION
We don't want to use ints for elementref IDs for remote rendering, because:

1. Eventually we could run out of them. A few billion isn't enough.
2. Having a global static incrementing sequence discloses cross-user state (number of IDs assigned)

This PR changes the IDs to be strings.

Then for non-WebAssembly scenarios we use GUIDs. For WebAssembly we use an incrementing sequence of long values (with `.ToString()`), just because there's no need to go through all the GUID code paths. That's just an internal implementation detail though. Consumers just treat the IDs as opaque strings.