### PR TITLE
Avoid globally unique BrowserRenderer IDs

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         /// <param name="serviceProvider">The <see cref="IServiceProvider"/> to use when initializing components.</param>
         public BrowserRenderer(IServiceProvider serviceProvider): base(serviceProvider)
         {
-            _browserRendererId = BrowserRendererRegistry.Add(this);
+            _browserRendererId = BrowserRendererRegistry.CurrentUserInstance.Add(this);
         }
 
         internal void DispatchBrowserEvent(int componentId, int eventHandlerId, UIEventArgs eventArgs)
@@ -79,7 +79,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         /// </summary>
         public void Dispose()
         {
-            BrowserRendererRegistry.TryRemove(_browserRendererId);
+            BrowserRendererRegistry.CurrentUserInstance.TryRemove(_browserRendererId);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRendererEventDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRendererEventDispatcher.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
             BrowserEventDescriptor eventDescriptor, string eventArgsJson)
         {
             var eventArgs = ParseEventArgsJson(eventDescriptor.EventArgsType, eventArgsJson);
-            var browserRenderer = BrowserRendererRegistry.Find(eventDescriptor.BrowserRendererId);
+            var browserRenderer = BrowserRendererRegistry.CurrentUserInstance.Find(eventDescriptor.BrowserRendererId);
             browserRenderer.DispatchBrowserEvent(
                 eventDescriptor.ComponentId,
                 eventDescriptor.EventHandlerId,

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRendererRegistry.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRendererRegistry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -12,18 +12,26 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
     /// their associated component instances aren't GCed when events may still
     /// be received for them.
     /// </summary>
-    internal static class BrowserRendererRegistry
+    internal class BrowserRendererRegistry
     {
-        private static int _nextId;
-        private static IDictionary<int, BrowserRenderer> _browserRenderers
+        private int _nextId;
+        private IDictionary<int, BrowserRenderer> _browserRenderers
             = new Dictionary<int, BrowserRenderer>();
+
+        /// TODO: Don't have just one global static instance.
+        /// For multi-user scenarios, we need the current instance to be distinct for each user,
+        /// and ensure it's always set to that user's value whenever there are incoming JS interop
+        /// calls. We could store the value in the IServiceProvider but then we still need some way
+        /// of reaching the current user's IServiceProvider inside calls to .NET from JS interop.
+        internal static BrowserRendererRegistry CurrentUserInstance { get; }
+            = new BrowserRendererRegistry();
 
         /// <summary>
         /// Adds the <paramref name="browserRenderer"/> and gets a unique identifier for it.
         /// </summary>
         /// <param name="browserRenderer"></param>
         /// <returns>A unique identifier for the <paramref name="browserRenderer"/>.</returns>
-        public static int Add(BrowserRenderer browserRenderer)
+        public int Add(BrowserRenderer browserRenderer)
         {
             lock (_browserRenderers)
             {
@@ -39,7 +47,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         /// </summary>
         /// <param name="browserRendererId">The identifier of the instance to be returned.</param>
         /// <returns>The corresponding <see cref="BrowserRenderer"/> instance.</returns>
-        public static BrowserRenderer Find(int browserRendererId)
+        public BrowserRenderer Find(int browserRendererId)
         {
             lock (_browserRenderers)
             {
@@ -52,7 +60,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         /// </summary>
         /// <param name="browserRendererId">The identifier of the <see cref="BrowserRenderer"/> to remove.</param>
         /// <returns><see langword="true"/> if the <see cref="BrowserRenderer"/> was present; otherwise <see langword="false" />.</returns>
-        public static bool TryRemove(int browserRendererId)
+        public bool TryRemove(int browserRendererId)
         {
             lock (_browserRenderers)
             {


### PR DESCRIPTION
I'm going through all teh codez to check for places where we're falsely assuming there's only a single user. For example, anywhere we use `static` to store per-user state. Any such code needs to be changed so it's safe for remote rendering. Fortunately there only appears to be two places where this applied, addressed by this PR and by #1103.

This PR is a partial step towards not letting users interfere with each other by dispatching events with somebody else's browserRendererId. The fix is not to have globally-unique IDs at all, but rather store the `BrowserRenderer` instances in user-scoped state. We still have browser renderer IDs, but they are per-circuit, which also has the benefit that we won't overflow the int value in the long run.

I can't yet really put in the user-scoped state because that depends on the work in #1092. Somehow when there are incoming JS interop calls, we need to set the correct `IJSRuntime` for that user, plus maybe we need an equivalent context to have the correct `IServiceProvider` for that user. Will discuss with @rynowak.

In the meantime this PR just simplifies and clarifies where the per-user storage needs to be plugged in.