### PR TITLE
Overload UriHelper to forceLoad the page even if it's not a Blazor defined Route.

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Services/UriHelper.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Services/UriHelper.ts
@@ -40,11 +40,11 @@ function enableNavigationInterception(assemblyName: string, functionName: string
 }
 
 export function navigateTo(uri: string, forceLoad: boolean) {
+  const absoluteUri = toAbsoluteUri(uri);
+
   if (forceLoad) {
     location.href = uri;
-  }
-  const absoluteUri = toAbsoluteUri(uri);
-  if (isWithinBaseUriSpace(absoluteUri)) {
+  } else if (isWithinBaseUriSpace(absoluteUri)) {
     performInternalNavigation(absoluteUri);
   } else {
     location.href = uri;

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Services/UriHelper.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Services/UriHelper.ts
@@ -39,7 +39,10 @@ function enableNavigationInterception(assemblyName: string, functionName: string
   window.addEventListener('popstate', handleInternalNavigation);
 }
 
-export function navigateTo(uri: string) {
+export function navigateTo(uri: string, forceLoad: boolean) {
+  if (forceLoad) {
+    location.href = uri;
+  }
   const absoluteUri = toAbsoluteUri(uri);
   if (isWithinBaseUriSpace(absoluteUri)) {
     performInternalNavigation(absoluteUri);

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Services/BrowserUriHelper.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Services/BrowserUriHelper.cs
@@ -47,14 +47,14 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Services
         }
 
         /// <inheritdoc />
-        protected override void NavigateToCore(string uri)
+        protected override void NavigateToCore(string uri, bool forceLoad)
         {
             if (uri == null)
             {
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>(Interop.NavigateTo, uri);
+            ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>(Interop.NavigateTo, uri, forceLoad);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteUriHelper.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteUriHelper.cs
@@ -61,14 +61,10 @@ namespace Microsoft.AspNetCore.Blazor.Server.Circuits
             uriHelper.TriggerOnLocationChanged();
         }
 
-        /// <summary>
-        /// Navigates to the specified URI.
-        /// </summary>
-        /// <param name="uri">The destination URI. This can be absolute, or relative to the base URI
-        /// (as returned by <see cref="IUriHelper.GetBaseUri"/>).</param>
-        protected override void NavigateToCore(string uri)
+        /// <inheritdoc />
+        protected override void NavigateToCore(string uri, bool forceLoad)
         {
-            _jsRuntime.InvokeAsync<object>(Interop.NavigateTo, uri);
+            _jsRuntime.InvokeAsync<object>(Interop.NavigateTo, uri, forceLoad);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Services/IUriHelper.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Services/IUriHelper.cs
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.Blazor.Services
         /// </summary>
         /// <param name="uri">The destination URI. This can be absolute, or relative to the base URI
         /// (as returned by <see cref="GetBaseUri"/>).</param>
-        void NavigateTo(string uri);
+        /// <param name="forceLoad">Indicator to force load the URI, even if it's not a blazor route.</param>
+        void NavigateTo(string uri, bool forceLoad = false);
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Services/UriHelperBase.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Services/UriHelperBase.cs
@@ -44,10 +44,11 @@ namespace Microsoft.AspNetCore.Blazor.Services
         /// </summary>
         /// <param name="uri">The destination URI. This can be absolute, or relative to the base URI
         /// (as returned by <see cref="GetBaseUri"/>).</param>
-        public void NavigateTo(string uri)
+        /// <param name="forceLoad">Indicator to force load the URI, even if it's not a blazor route.</param>
+        public void NavigateTo(string uri, bool forceLoad = false)
         {
             EnsureInitialized();
-            NavigateToCore(uri);
+            NavigateToCore(uri, forceLoad);
         }
 
         /// <summary>
@@ -55,7 +56,8 @@ namespace Microsoft.AspNetCore.Blazor.Services
         /// </summary>
         /// <param name="uri">The destination URI. This can be absolute, or relative to the base URI
         /// (as returned by <see cref="GetBaseUri"/>).</param>
-        protected abstract void NavigateToCore(string uri);
+        /// <param name="forceLoad">Indicator to force load the URI, even if it's not a blazor route.</param>
+        protected abstract void NavigateToCore(string uri, bool forceLoad);
 
         /// <summary>
         /// Called to initialize BaseURI and current URI before those values the first time.


### PR DESCRIPTION
**PR issued to solve**
* Add UrlHelper.NavigateTo overload that forces a full page reload #979
* Handle FileResult from controller service #962 
* Combine MVC razor pages with Blazor pages #1069 
* Helps with Routing enhancements #293

Basically when you have a MVC Server that serves the Blazor Client and on the other hand sends File Downloads (for example). It was not possible to load the MVC Uri outside of Blazor's internal routing. 
With this PR, it's now possible to use the following block of code to load a Uri outside of Blazor's routing:

```csharp
@inject Microsoft.AspNetCore.Blazor.Services.IUriHelper UriHelper
<button onclick=@GoToMvcRoute>Navigate to Controller Action!</button>
<button onclick=@DontGoToMvcRoute>Don't Navigate to Controller Action!</button>

@functions {
    void GoToMvcRoute()
    {
        UriHelper.NavigateTo("/controller/action", forceLoad: true);

    }
    void DontGoToMvcRoute()
    {
        UriHelper.NavigateTo("/controller/action");

    }
}
````

**Tests**
Not really sure how to test this in the current suite, maybe add an additional AspNetHosted project with 
a server that also serves via MVC? I simply tested on "my machine" to make sure it's loading the page. 


**Caveats**
The mapping of the controllers still have to happen on Startup.cs (which is normal):
````csharp
            app.UseMvcWithDefaultRoute();
            app.UseBlazor<Client.Program>();
````
**Impact**
No impact on current usages of IUriHelper (default parameter)

If you know a better name for the parameter, I'm all ears! 
* byPassInternalRouting?