### PR TITLE
Fixed exporting platform to window object

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Environment.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Environment.ts
@@ -2,10 +2,12 @@
 // so that consumers can be agnostic about which implementation they use.
 // Basic alternative to having an actual DI container.
 import { Platform } from './Platform/Platform';
+import { exportBlazor } from './GlobalExports';
 
 export let platform: Platform;
 
 export function setPlatform(platformInstance: Platform) {
   platform = platformInstance;
+  exportBlazor();
   return platform;
 }

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/GlobalExports.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/GlobalExports.ts
@@ -5,13 +5,17 @@ import { attachRootComponentToElement } from './Rendering/Renderer';
 import { Pointer } from './Platform/Platform';
 
 // Make the following APIs available in global scope for invocation from JS
-window['Blazor'] = {
-  platform,
-  navigateTo,
+export function exportBlazor() {
+  window['Blazor'] = {
+    platform,
+    navigateTo,
+  
+    _internal: {
+      attachRootComponentToElement,
+      http: httpInternalFunctions,
+      uriHelper: uriHelperInternalFunctions
+    }
+  };
+}
 
-  _internal: {
-    attachRootComponentToElement,
-    http: httpInternalFunctions,
-    uriHelper: uriHelperInternalFunctions
-  }
-};
+

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/GlobalExports.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/GlobalExports.ts
@@ -18,4 +18,4 @@ export function exportBlazor() {
   };
 }
 
-
+exportBlazor();


### PR DESCRIPTION
Recently versions are not exporting platform to window object correctly.
When GlobalExports.ts gets called, platform from Enviroment.ts is undefined and gets set only when Environment.setPlatform(monoPlatform) is called on boot.