### PR TITLE
preventDefault for form onsubmit handlers. Fixes #951

### DIFF
--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/EventTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/EventTest.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Interactions;
+using OpenQA.Selenium.Support.UI;
+using System;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -107,6 +109,23 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
 
             actions.Perform();
             WaitAssert.Equal("onmousedown,onmouseup,", () => output.Text);
+        }
+
+        [Fact]
+        public void PreventDefault_AppliesToFormOnSubmitHandlers()
+        {
+            var appElement = MountTestComponent<EventPreventDefaultComponent>();
+
+            appElement.FindElement(By.Id("form-1-button")).Click();
+            WaitAssert.Equal("Event was handled", () => appElement.FindElement(By.Id("event-handled")).Text);
+        }
+
+        [Fact]
+        public void PreventDefault_DotNotApplyByDefault()
+        {
+            var appElement = MountTestComponent<EventPreventDefaultComponent>();
+            appElement.FindElement(By.Id("form-2-button")).Click();
+            Assert.Contains("about:blank", Browser.Url);
         }
     }
 }

--- a/test/testapps/BasicTestApp/EventPreventDefaultComponent.cshtml
+++ b/test/testapps/BasicTestApp/EventPreventDefaultComponent.cshtml
@@ -1,0 +1,39 @@
+<h3>Prevent default</h3>
+
+<p>
+    Currently we don't call <code>preventDefault</code> by default on DOM events in most cases.
+    The one exception is for form submit events: in that case, if you have a C# onsubmit handler,
+    you almost certainly don't really want to perform a server-side post, especially given that
+    it would occur <em>before</em> an async event handler.
+</p>
+<p>
+    Later, it's likely that we'll add a syntax for controlling whether any given event handler
+    triggers a synchronous <code>preventDefault</code> before the event handler runs.
+</p>
+
+<h2>Form with onsubmit handler</h2>
+
+<form action="about:blank" onsubmit=@(() => { })>
+    <button id="form-1-button" onclick=@HandleClick>Click me</button>
+</form>
+
+<h2>Form without onsubmit handler</h2>
+
+<form action="about:blank">
+    <button id="form-2-button" onclick=@HandleClick>Click me</button>
+</form>
+
+@if (didHandleEvent)
+{
+    <p id="event-handled">Event was handled</p>
+}
+
+@functions {
+    bool didHandleEvent;
+
+    async Task HandleClick()
+    {
+        await Task.Delay(250); // To give time for default action if it's going to occur
+        didHandleEvent = true;
+    }
+}

--- a/test/testapps/BasicTestApp/Index.cshtml
+++ b/test/testapps/BasicTestApp/Index.cshtml
@@ -34,6 +34,7 @@
     <option value="BasicTestApp.AfterRenderInteropComponent">After-render interop component</option>
     <option value="BasicTestApp.EventCasesComponent">Event cases</option>
     <option value="BasicTestApp.EventBubblingComponent">Event bubbling</option>
+    <option value="BasicTestApp.EventPreventDefaultComponent">Event preventDefault</option>
     <option value="BasicTestApp.RouterTest.TestRouter">Router</option>
   </select>
 


### PR DESCRIPTION
This is very much just a special case, and longer term we'll want to do something better. Specifically, we'd like to have a proper way to control whether `preventDefault` is applied to C#-handled events.

The special case here is "if you have a C# `onsubmit` handler, then call `preventDefault` on those events". There's basically no way you *wouldn't* want to `preventDefault` those events, since (if async) the event handler would run *after* the default navigation event, which is totally useless. So I think the special case is OK as a stopgap measure.

The alternative could be that we say we're not changing the behavior, and people should explicitly put `type="button"` on buttons inside forms. @rynowak @danroth27 let me know if you feel strongly either way. UPDATE: Putting `type="button"` on buttons inside form doesn't solve the wider issue, e.g., hitting enter on an textbox inside the form, so the workaround in the PR has got to be better.