### PR TITLE
Temporarily disable HtmlBlockPass

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorExtensionInitializer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorExtensionInitializer.cs
@@ -79,7 +79,9 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             builder.Features.Add(new EventHandlerLoweringPass());
             builder.Features.Add(new RefLoweringPass());
             builder.Features.Add(new BindLoweringPass());
-            builder.Features.Add(new HtmlBlockPass());
+
+            // Temporarily disabled for 0.5.1
+            // builder.Features.Add(new HtmlBlockPass());
 
             builder.Features.Add(new ComponentTagHelperDescriptorProvider());
             builder.Features.Add(new BindTagHelperDescriptorProvider());

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RenderingRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RenderingRazorIntegrationTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
                 frame => AssertFrame.Text(frame, "there", 2));
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void SupportsElementsAsStaticBlock()
         {
             // Arrange/Act
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
                 frame => AssertFrame.Markup(frame, "<myelem>Hello</myelem>", 0));
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void CreatesSeparateMarkupFrameForEachTopLevelStaticElement()
         {
             // The JavaScript-side rendering code does not rely on this behavior. It supports
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
                 frame => AssertFrame.Attribute(frame, "myattr", "val", 2));
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void SupportsSelfClosingElementsAsStaticBlock()
         {
             // Arrange/Act
@@ -155,7 +155,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
                 frame => AssertFrame.Markup(frame, "<input attr=\"123\">", 1));
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void SupportsVoidHtmlElements()
         {
             // Arrange/Act

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
@@ -19,7 +19,10 @@ namespace Test
             builder.AddAttribute(1, "MyAttr", "abc");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Blazor.RenderFragment)((builder2) => {
                 builder2.AddContent(3, "Some text");
-                builder2.AddMarkupContent(4, "<some-child a=\"1\">Nested text</some-child>");
+                builder2.OpenElement(4, "some-child");
+                builder2.AddAttribute(5, "a", "1");
+                builder2.AddContent(6, "Nested text");
+                builder2.CloseElement();
             }
             ));
             builder.CloseComponent();

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
@@ -13,7 +13,12 @@ Document -
                 ComponentExtensionNode - (31:1,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
                     HtmlContent - (57:1,26 [9] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (57:1,26 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Some text
-                    HtmlBlock -  - <some-child a="1">Nested text</some-child>
+                    HtmlElement - (66:1,35 [42] x:\dir\subdir\Test\TestComponent.cshtml) - some-child
+                        HtmlAttribute -  -  - 
+                            HtmlAttributeValue -  - 
+                                IntermediateToken -  - Html - 1
+                        HtmlContent - (84:1,53 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+                            IntermediateToken - (84:1,53 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Nested text
                     ComponentAttributeExtensionNode - (52:1,21 [3] x:\dir\subdir\Test\TestComponent.cshtml) - MyAttr - MyAttr
                         HtmlContent - (52:1,21 [3] x:\dir\subdir\Test\TestComponent.cshtml)
                             IntermediateToken - (52:1,21 [3] x:\dir\subdir\Test\TestComponent.cshtml) - Html - abc

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.codegen.cs
@@ -16,7 +16,12 @@ namespace Test
         {
             base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
-            builder.AddMarkupContent(1, "<child>hello</child>");
+            builder.AddAttribute(1, "ChildContent", (Microsoft.AspNetCore.Blazor.RenderFragment)((builder2) => {
+                builder2.OpenElement(2, "child");
+                builder2.AddContent(3, "hello");
+                builder2.CloseElement();
+            }
+            ));
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.ir.txt
@@ -11,4 +11,6 @@ Document -
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 ComponentExtensionNode - (31:1,0 [47] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
-                    HtmlBlock -  - <child>hello</child>
+                    HtmlElement - (44:1,13 [20] x:\dir\subdir\Test\TestComponent.cshtml) - child
+                        HtmlContent - (51:1,20 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+                            IntermediateToken - (51:1,20 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - hello

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithDocType/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithDocType/TestComponent.codegen.cs
@@ -15,7 +15,9 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<div>\n</div>");
+            builder.OpenElement(0, "div");
+            builder.AddContent(1, "\n");
+            builder.CloseElement();
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithDocType/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithDocType/TestComponent.ir.txt
@@ -10,4 +10,6 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <div>\n</div>
+                HtmlElement - (17:1,0 [13] x:\dir\subdir\Test\TestComponent.cshtml) - div
+                    HtmlContent - (22:1,5 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (22:1,5 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
@@ -19,11 +19,13 @@ namespace Test
             builder.AddAttribute(1, "SomeProp", "val");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Blazor.RenderFragment)((builder2) => {
                 builder2.AddContent(3, "\n    Some ");
-                builder2.AddMarkupContent(4, "<el>further</el>");
-                builder2.AddContent(5, " content\n");
+                builder2.OpenElement(4, "el");
+                builder2.AddContent(5, "further");
+                builder2.CloseElement();
+                builder2.AddContent(6, " content\n");
             }
             ));
-            builder.AddComponentReferenceCapture(6, (__value) => {
+            builder.AddComponentReferenceCapture(7, (__value) => {
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                   myInstance = (Test.MyComponent)__value;
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
@@ -13,7 +13,9 @@ Document -
                 ComponentExtensionNode - (31:1,0 [96] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
                     HtmlContent - (76:1,45 [11] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (76:1,45 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n    Some 
-                    HtmlBlock -  - <el>further</el>
+                    HtmlElement - (87:2,9 [16] x:\dir\subdir\Test\TestComponent.cshtml) - el
+                        HtmlContent - (91:2,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+                            IntermediateToken - (91:2,13 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - further
                     HtmlContent - (103:2,25 [10] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (103:2,25 [10] x:\dir\subdir\Test\TestComponent.cshtml) - Html -  content\n
                     RefExtensionNode - (49:1,18 [10] x:\dir\subdir\Test\TestComponent.cshtml) - myInstance - Test.MyComponent

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (49:1,18 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (1176:28,18 [10] )
+Generated Location: (1251:30,18 [10] )
 |myInstance|
 
 Source Location: (143:5,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Test.MyComponent myInstance;
 |
-Generated Location: (1430:38,12 [44] )
+Generated Location: (1505:40,12 [44] )
 |
     private Test.MyComponent myInstance;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -17,7 +17,9 @@ namespace Test
             base.BuildRenderTree(builder);
             builder.AddContent(0, "My value");
             builder.AddContent(1, "\n\n");
-            builder.AddMarkupContent(2, "<h1>Hello</h1>");
+            builder.OpenElement(2, "h1");
+            builder.AddContent(3, "Hello");
+            builder.CloseElement();
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -14,4 +14,6 @@ Document -
                     IntermediateToken - (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - "My value"
                 HtmlContent - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
-                HtmlBlock -  - <h1>Hello</h1>
+                HtmlElement - (17:2,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
+                    HtmlContent - (21:2,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (21:2,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -18,7 +18,9 @@ namespace Test
             builder.OpenComponent<Test.SomeOtherComponent>(0);
             builder.CloseComponent();
             builder.AddContent(1, "\n\n");
-            builder.AddMarkupContent(2, "<h1>Hello</h1>");
+            builder.OpenElement(2, "h1");
+            builder.AddContent(3, "Hello");
+            builder.CloseElement();
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -13,4 +13,6 @@ Document -
                 ComponentExtensionNode - (36:2,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - SomeOtherComponent - Test.SomeOtherComponent
                 HtmlContent - (58:2,22 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (58:2,22 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
-                HtmlBlock -  - <h1>Hello</h1>
+                HtmlElement - (62:4,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
+                    HtmlContent - (66:4,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (66:4,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -15,7 +15,9 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello</h1>");
+            builder.OpenElement(0, "h1");
+            builder.AddContent(1, "Hello");
+            builder.CloseElement();
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -10,4 +10,6 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello</h1>
+                HtmlElement - (17:2,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
+                    HtmlContent - (21:2,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (21:2,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
@@ -16,10 +16,12 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello, world!</h1>");
-            builder.AddContent(1, "\n\nWelcome to your new app.\n\n");
-            builder.OpenComponent<Test.SurveyPrompt>(2);
-            builder.AddAttribute(3, "Title", "");
+            builder.OpenElement(0, "h1");
+            builder.AddContent(1, "Hello, world!");
+            builder.CloseElement();
+            builder.AddContent(2, "\n\nWelcome to your new app.\n\n");
+            builder.OpenComponent<Test.SurveyPrompt>(3);
+            builder.AddAttribute(4, "Title", "");
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
@@ -11,7 +11,9 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello, world!</h1>
+                HtmlElement - (44:3,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - h1
+                    HtmlContent - (48:3,4 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (48:3,4 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello, world!
                 HtmlContent - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\nWelcome to your new app.\n\n
                 ComponentExtensionNode - (98:7,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - SurveyPrompt - Test.SurveyPrompt

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
@@ -16,10 +16,12 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello, world!</h1>");
-            builder.AddContent(1, "\n\nWelcome to your new app.\n\n");
-            builder.OpenComponent<Test.SurveyPrompt>(2);
-            builder.AddAttribute(3, "Title", "<div>Test!</div>");
+            builder.OpenElement(0, "h1");
+            builder.AddContent(1, "Hello, world!");
+            builder.CloseElement();
+            builder.AddContent(2, "\n\nWelcome to your new app.\n\n");
+            builder.OpenComponent<Test.SurveyPrompt>(3);
+            builder.AddAttribute(4, "Title", "<div>Test!</div>");
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
@@ -11,7 +11,9 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello, world!</h1>
+                HtmlElement - (44:3,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - h1
+                    HtmlContent - (48:3,4 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (48:3,4 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello, world!
                 HtmlContent - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\nWelcome to your new app.\n\n
                 ComponentExtensionNode - (98:7,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - SurveyPrompt - Test.SurveyPrompt

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -15,9 +15,11 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello</h1>");
-            builder.AddContent(1, "\n\n");
-            builder.AddContent(2, "My value");
+            builder.OpenElement(0, "h1");
+            builder.AddContent(1, "Hello");
+            builder.CloseElement();
+            builder.AddContent(2, "\n\n");
+            builder.AddContent(3, "My value");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -10,7 +10,9 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello</h1>
+                HtmlElement - (0:0,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
+                    HtmlContent - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello
                 HtmlContent - (14:0,14 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (14:0,14 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
                 CSharpExpression - (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -15,9 +15,11 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello</h1>");
-            builder.AddContent(1, "\n\n");
-            builder.OpenComponent<Test.SomeOtherComponent>(2);
+            builder.OpenElement(0, "h1");
+            builder.AddContent(1, "Hello");
+            builder.CloseElement();
+            builder.AddContent(2, "\n\n");
+            builder.OpenComponent<Test.SomeOtherComponent>(3);
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -10,7 +10,9 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello</h1>
+                HtmlElement - (31:1,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
+                    HtmlContent - (35:1,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (35:1,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello
                 HtmlContent - (45:1,14 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (45:1,14 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
                 ComponentExtensionNode - (49:3,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - SomeOtherComponent - Test.SomeOtherComponent

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -16,7 +16,9 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello</h1>");
+            builder.OpenElement(0, "h1");
+            builder.AddContent(1, "Hello");
+            builder.CloseElement();
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -11,4 +11,6 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello</h1>
+                HtmlElement - (0:0,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
+                    HtmlContent - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+                        IntermediateToken - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello

--- a/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/HtmlBlockPassTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/HtmlBlockPassTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
 
         private HtmlBlockPass Pass { get; }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_RewritesHtml_Basic()
         {
             // Arrange
@@ -60,7 +60,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_RewritesHtml_CSharpInAttributes()
         {
             // Arrange
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_RewritesHtml_CSharpInBody()
         {
             // Arrange
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_RewritesHtml_EmptyNonvoid()
         {
             // Arrange
@@ -126,7 +126,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_RewritesHtml_Void()
         {
             // Arrange
@@ -144,7 +144,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_CannotRewriteHtml_CSharpInCode()
         {
             // Arrange
@@ -167,7 +167,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Empty(documentNode.FindDescendantNodes<HtmlBlockIntermediateNode>());
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_CannotRewriteHtml_Script()
         {
             // Arrange
@@ -191,7 +191,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
         }
 
         // The unclosed tag will have errors, so we won't rewrite it or its parent.
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_CannotRewriteHtml_Errors()
         {
             // Arrange
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Empty(documentNode.FindDescendantNodes<HtmlBlockIntermediateNode>());
         }
 
-        [Fact]
+        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
         public void Execute_RewritesHtml_MismatchedClosingTag()
         {
             // Arrange


### PR DESCRIPTION
We've received a number of bug reports about 0.5.0 having regressions for markup that people are commonly using (#1204, #1203, #1198, #1193). It looks like each of these relate to the new optimization in 0.5.0 that represents static HTML as markup frames.

It's not yet totally decided, but one possible way forwards for us would be:

* Via this PR, temporarily disable the compiler part of markup blocks and release as 0.5.1 tomorrow
   * This wouldn't stop people from using `MarkupString` (etc) as the runtime bits would be left enabled. I don't think any of the bugs above relate to the runtime bits anyway.
   * People just trying to render HTML as normal like before would no longer be affected.
* We also collect precise repro cases for each of the above issues
* We fix any `HtmlBlockPass` issues or any runtime issues and re-enable it in 0.6.0 (or 0.5.2 if we decide to do a further patch).

We'll make a final call on this tomorrow morning. cc @rynowak @danroth27 