### PR TITLE
Use $(TargetDir) instead of $(ProjectDir)$(OutputPath)

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Analyzers/Microsoft.AspNetCore.Blazor.Analyzers.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Analyzers/Microsoft.AspNetCore.Blazor.Analyzers.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,5 +32,5 @@
   <ItemGroup>
     <Compile Include="..\shared\BlazorApi.cs" Link="shared\%(Filename)%(Extension)" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Blazor.MonoRuntime.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Blazor.MonoRuntime.targets
@@ -44,7 +44,7 @@
       <_BlazorStatisticsReportImportance Condition="'$(BlazorOutputStatistics)' != ''">high</_BlazorStatisticsReportImportance>
     </PropertyGroup>
 
-    <Message Importance="high" Text="Blazor Build result -> @(_BlazorStatisticsOutput->Distinct()->Count()) files in $(ProjectDir)$(OutputPath)dist" />
+    <Message Importance="high" Text="Blazor Build result -> @(_BlazorStatisticsOutput->Distinct()->Count()) files in $(TargetDir)dist" />
     <Message Importance="$(_BlazorStatisticsReportImportance)" Text="%(_BlazorStatisticsOutput.Identity)" />
   </Target>
 
@@ -158,17 +158,17 @@
 
     <ItemGroup Label="Static content to copy to the output folder">
       <BlazorItemOutput Include="@(MonoAsmjsFile)">
-        <TargetOutputPath>$(ProjectDir)$(OutputPath)$(BaseBlazorRuntimeAsmjsOutputPath)%(FileName)%(Extension)</TargetOutputPath>
+        <TargetOutputPath>$(TargetDir)$(BaseBlazorRuntimeAsmjsOutputPath)%(FileName)%(Extension)</TargetOutputPath>
         <Type>AsmJs</Type>
         <IsStatic>true</IsStatic>
       </BlazorItemOutput>
       <BlazorItemOutput Include="@(MonoWasmFile)">
-        <TargetOutputPath>$(ProjectDir)$(OutputPath)$(BaseBlazorRuntimeWasmOutputPath)%(FileName)%(Extension)</TargetOutputPath>
+        <TargetOutputPath>$(TargetDir)$(BaseBlazorRuntimeWasmOutputPath)%(FileName)%(Extension)</TargetOutputPath>
         <Type>WebAssembly</Type>
         <IsStatic>true</IsStatic>
       </BlazorItemOutput>
       <BlazorItemOutput Include="@(BlazorJsFile)">
-        <TargetOutputPath>$(ProjectDir)$(OutputPath)$(BaseBlazorJsOutputPath)%(FileName)%(Extension)</TargetOutputPath>
+        <TargetOutputPath>$(TargetDir)$(BaseBlazorJsOutputPath)%(FileName)%(Extension)</TargetOutputPath>
         <Type>BlazorRuntime</Type>
         <IsStatic>true</IsStatic>
       </BlazorItemOutput>
@@ -176,7 +176,7 @@
 
     <ItemGroup Label="Static content supplied by NuGet packages">
       <_BlazorPackageContentOutput Include="@(BlazorPackageContentFile)" Condition="%(SourcePackage) != ''">
-        <TargetOutputPath>$(ProjectDir)$(OutputPath)$(BaseBlazorPackageContentOutputPath)%(SourcePackage)\%(RecursiveDir)\%(Filename)%(Extension)</TargetOutputPath>
+        <TargetOutputPath>$(TargetDir)$(BaseBlazorPackageContentOutputPath)%(SourcePackage)\%(RecursiveDir)\%(Filename)%(Extension)</TargetOutputPath>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </_BlazorPackageContentOutput>
       <BlazorItemOutput Include="@(_BlazorPackageContentOutput)" />
@@ -243,7 +243,7 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Final output paths">
-      <BlazorRuntimeBinOutputPath>$(ProjectDir)$(OutputPath)$(BaseBlazorRuntimeBinOutputPath)</BlazorRuntimeBinOutputPath>
+      <BlazorRuntimeBinOutputPath>$(TargetDir)$(BaseBlazorRuntimeBinOutputPath)</BlazorRuntimeBinOutputPath>
     </PropertyGroup>
 
     <MakeDir Directories="$(BlazorIntermediateOutputPath)" />
@@ -638,11 +638,11 @@
       <_BlazorBootJson Include="$(BlazorBootJsonIntermediateOutputPath)" />
       <_BlazorBootJsonEmbeddedContentFile Include="$(BlazorBootJsonIntermediateOutputDir)_content\**\*.*" />
       <BlazorItemOutput Include="@(_BlazorBootJson)">
-        <TargetOutputPath>$(ProjectDir)$(OutputPath)$(BlazorBootJsonOutputPath)</TargetOutputPath>
+        <TargetOutputPath>$(TargetDir)$(BlazorBootJsonOutputPath)</TargetOutputPath>
         <Type>BootJson</Type>
       </BlazorItemOutput>
       <BlazorItemOutput Include="@(_BlazorBootJsonEmbeddedContentFile)">
-        <TargetOutputPath>$(ProjectDir)$(OutputPath)dist/_content/%(RecursiveDir)%(FileName)%(Extension)</TargetOutputPath>
+        <TargetOutputPath>$(TargetDir)dist/_content/%(RecursiveDir)%(FileName)%(Extension)</TargetOutputPath>
       </BlazorItemOutput>
       <FileWrites Include="$(BlazorBootJsonIntermediateOutputPath)" />
       <FileWrites Include="@(_BlazorBootJsonEmbeddedContentFile)" />

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/Microsoft.AspNetCore.Blazor.Build.Test.csproj
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/Microsoft.AspNetCore.Blazor.Build.Test.csproj
@@ -36,7 +36,7 @@
 
   <!-- A bit of msbuild magic to support reference resolver tests -->
   <Target Name="CreateReferenceHintPathsList" AfterTargets="Build">
-    <WriteLinesToFile Lines="@(ReferencePath)" File="$(ProjectDir)$(OutputPath)referenceHints.txt" WriteOnlyWhenDifferent="true" Overwrite="true" />
+    <WriteLinesToFile Lines="@(ReferencePath)" File="$(TargetDir)referenceHints.txt" WriteOnlyWhenDifferent="true" Overwrite="true" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves https://github.com/aspnet/Blazor/issues/1179

Prevents errors when `$(OutputPath)` is an absolute path.