### PR TITLE
Reenable markup blocks

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorExtensionInitializer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/BlazorExtensionInitializer.cs
@@ -79,9 +79,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             builder.Features.Add(new EventHandlerLoweringPass());
             builder.Features.Add(new RefLoweringPass());
             builder.Features.Add(new BindLoweringPass());
-
-            // Temporarily disabled for 0.5.1
-            // builder.Features.Add(new HtmlBlockPass());
+            builder.Features.Add(new HtmlBlockPass());
 
             builder.Features.Add(new ComponentTagHelperDescriptorProvider());
             builder.Features.Add(new BindTagHelperDescriptorProvider());

--- a/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/ComponentDocumentRewritePass.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Razor.Extensions/ComponentDocumentRewritePass.cs
@@ -414,6 +414,13 @@ namespace Microsoft.AspNetCore.Blazor.Razor
                     throw new InvalidOperationException("You need to call Push first.");
                 }
 
+                // This will decode any HTML entities into their textual equivalent.
+                //
+                // This is OK because an HtmlContent node is used with document.createTextNode
+                // in the DOM, which can accept content that has decoded entities.
+                //
+                // In the event that we merge HtmlContent into an HtmlBlock, we need to
+                // re-encode the entites. That's done in the HtmlBlock pass.
                 var tokens = _textSource.Tokenize(HtmlEntityService.Resolver);
                 return tokens;
             }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/ComponentRenderingRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/ComponentRenderingRazorIntegrationTest.cs
@@ -472,5 +472,21 @@ namespace Test
                 frame => AssertFrame.Attribute(frame, "onmouseover", 1),
                 frame => AssertFrame.Attribute(frame, "style", "background: #FFFFFF;", 2));
         }
+
+        // Text nodes decode HTML entities
+        [Fact]
+        public void Render_Component_HtmlEncoded()
+        {
+            // Arrange
+            var component = CompileToComponent(@"&lt;span&gt;Hi&lt/span&gt;");
+
+            // Act
+            var frames = GetRenderTree(component);
+
+            // Assert
+            Assert.Collection(
+                frames,
+                frame => AssertFrame.Text(frame, "<span>Hi</span>"));
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RuntimeCodeGenerationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RuntimeCodeGenerationTest.cs
@@ -1256,7 +1256,6 @@ namespace Test
         [Fact] // We don't process <!DOCTYPE ...> - we just skip them
         public void Component_WithDocType()
         {
-            GenerateBaselines = true;
             // Arrange
 
             // Act

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.codegen.cs
@@ -19,10 +19,7 @@ namespace Test
             builder.AddAttribute(1, "MyAttr", "abc");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Blazor.RenderFragment)((builder2) => {
                 builder2.AddContent(3, "Some text");
-                builder2.OpenElement(4, "some-child");
-                builder2.AddAttribute(5, "a", "1");
-                builder2.AddContent(6, "Nested text");
-                builder2.CloseElement();
+                builder2.AddMarkupContent(4, "<some-child a=\"1\">Nested text</some-child>");
             }
             ));
             builder.CloseComponent();

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithChildContent/TestComponent.ir.txt
@@ -13,12 +13,7 @@ Document -
                 ComponentExtensionNode - (31:1,0 [91] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
                     HtmlContent - (57:1,26 [9] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (57:1,26 [9] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Some text
-                    HtmlElement - (66:1,35 [42] x:\dir\subdir\Test\TestComponent.cshtml) - some-child
-                        HtmlAttribute -  -  - 
-                            HtmlAttributeValue -  - 
-                                IntermediateToken -  - Html - 1
-                        HtmlContent - (84:1,53 [11] x:\dir\subdir\Test\TestComponent.cshtml)
-                            IntermediateToken - (84:1,53 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Nested text
+                    HtmlBlock -  - <some-child a="1">Nested text</some-child>
                     ComponentAttributeExtensionNode - (52:1,21 [3] x:\dir\subdir\Test\TestComponent.cshtml) - MyAttr - MyAttr
                         HtmlContent - (52:1,21 [3] x:\dir\subdir\Test\TestComponent.cshtml)
                             IntermediateToken - (52:1,21 [3] x:\dir\subdir\Test\TestComponent.cshtml) - Html - abc

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.codegen.cs
@@ -17,9 +17,7 @@ namespace Test
             base.BuildRenderTree(builder);
             builder.OpenComponent<Test.MyComponent>(0);
             builder.AddAttribute(1, "ChildContent", (Microsoft.AspNetCore.Blazor.RenderFragment)((builder2) => {
-                builder2.OpenElement(2, "child");
-                builder2.AddContent(3, "hello");
-                builder2.CloseElement();
+                builder2.AddMarkupContent(2, "<child>hello</child>");
             }
             ));
             builder.CloseComponent();

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/ChildComponent_WithElementOnlyChildContent/TestComponent.ir.txt
@@ -11,6 +11,4 @@ Document -
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
                 ComponentExtensionNode - (31:1,0 [47] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
-                    HtmlElement - (44:1,13 [20] x:\dir\subdir\Test\TestComponent.cshtml) - child
-                        HtmlContent - (51:1,20 [5] x:\dir\subdir\Test\TestComponent.cshtml)
-                            IntermediateToken - (51:1,20 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - hello
+                    HtmlBlock -  - <child>hello</child>

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithDocType/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithDocType/TestComponent.codegen.cs
@@ -15,9 +15,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.OpenElement(0, "div");
-            builder.AddContent(1, "\n");
-            builder.CloseElement();
+            builder.AddMarkupContent(0, "<div>\n</div>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithDocType/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithDocType/TestComponent.ir.txt
@@ -10,6 +10,4 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (17:1,0 [13] x:\dir\subdir\Test\TestComponent.cshtml) - div
-                    HtmlContent - (22:1,5 [2] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (22:1,5 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                HtmlBlock -  - <div>\n</div>

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
@@ -19,13 +19,11 @@ namespace Test
             builder.AddAttribute(1, "SomeProp", "val");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Blazor.RenderFragment)((builder2) => {
                 builder2.AddContent(3, "\n    Some ");
-                builder2.OpenElement(4, "el");
-                builder2.AddContent(5, "further");
-                builder2.CloseElement();
-                builder2.AddContent(6, " content\n");
+                builder2.AddMarkupContent(4, "<el>further</el>");
+                builder2.AddContent(5, " content\n");
             }
             ));
-            builder.AddComponentReferenceCapture(7, (__value) => {
+            builder.AddComponentReferenceCapture(6, (__value) => {
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                   myInstance = (Test.MyComponent)__value;
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
@@ -13,9 +13,7 @@ Document -
                 ComponentExtensionNode - (31:1,0 [96] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
                     HtmlContent - (76:1,45 [11] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (76:1,45 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n    Some 
-                    HtmlElement - (87:2,9 [16] x:\dir\subdir\Test\TestComponent.cshtml) - el
-                        HtmlContent - (91:2,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
-                            IntermediateToken - (91:2,13 [7] x:\dir\subdir\Test\TestComponent.cshtml) - Html - further
+                    HtmlBlock -  - <el>further</el>
                     HtmlContent - (103:2,25 [10] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (103:2,25 [10] x:\dir\subdir\Test\TestComponent.cshtml) - Html -  content\n
                     RefExtensionNode - (49:1,18 [10] x:\dir\subdir\Test\TestComponent.cshtml) - myInstance - Test.MyComponent

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (49:1,18 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (1251:30,18 [10] )
+Generated Location: (1176:28,18 [10] )
 |myInstance|
 
 Source Location: (143:5,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Test.MyComponent myInstance;
 |
-Generated Location: (1505:40,12 [44] )
+Generated Location: (1430:38,12 [44] )
 |
     private Test.MyComponent myInstance;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -17,9 +17,7 @@ namespace Test
             base.BuildRenderTree(builder);
             builder.AddContent(0, "My value");
             builder.AddContent(1, "\n\n");
-            builder.OpenElement(2, "h1");
-            builder.AddContent(3, "Hello");
-            builder.CloseElement();
+            builder.AddMarkupContent(2, "<h1>Hello</h1>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -14,6 +14,4 @@ Document -
                     IntermediateToken - (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - "My value"
                 HtmlContent - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
-                HtmlElement - (17:2,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
-                    HtmlContent - (21:2,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (21:2,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello
+                HtmlBlock -  - <h1>Hello</h1>

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -18,9 +18,7 @@ namespace Test
             builder.OpenComponent<Test.SomeOtherComponent>(0);
             builder.CloseComponent();
             builder.AddContent(1, "\n\n");
-            builder.OpenElement(2, "h1");
-            builder.AddContent(3, "Hello");
-            builder.CloseElement();
+            builder.AddMarkupContent(2, "<h1>Hello</h1>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -13,6 +13,4 @@ Document -
                 ComponentExtensionNode - (36:2,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - SomeOtherComponent - Test.SomeOtherComponent
                 HtmlContent - (58:2,22 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (58:2,22 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
-                HtmlElement - (62:4,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
-                    HtmlContent - (66:4,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (66:4,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello
+                HtmlBlock -  - <h1>Hello</h1>

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -15,9 +15,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.OpenElement(0, "h1");
-            builder.AddContent(1, "Hello");
-            builder.CloseElement();
+            builder.AddMarkupContent(0, "<h1>Hello</h1>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -10,6 +10,4 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (17:2,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
-                    HtmlContent - (21:2,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (21:2,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello
+                HtmlBlock -  - <h1>Hello</h1>

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
@@ -16,12 +16,10 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.OpenElement(0, "h1");
-            builder.AddContent(1, "Hello, world!");
-            builder.CloseElement();
-            builder.AddContent(2, "\n\nWelcome to your new app.\n\n");
-            builder.OpenComponent<Test.SurveyPrompt>(3);
-            builder.AddAttribute(4, "Title", "");
+            builder.AddMarkupContent(0, "<h1>Hello, world!</h1>");
+            builder.AddContent(1, "\n\nWelcome to your new app.\n\n");
+            builder.OpenComponent<Test.SurveyPrompt>(2);
+            builder.AddAttribute(3, "Title", "");
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
@@ -11,9 +11,7 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (44:3,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - h1
-                    HtmlContent - (48:3,4 [13] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (48:3,4 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello, world!
+                HtmlBlock -  - <h1>Hello, world!</h1>
                 HtmlContent - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\nWelcome to your new app.\n\n
                 ComponentExtensionNode - (98:7,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - SurveyPrompt - Test.SurveyPrompt

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
@@ -16,12 +16,10 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.OpenElement(0, "h1");
-            builder.AddContent(1, "Hello, world!");
-            builder.CloseElement();
-            builder.AddContent(2, "\n\nWelcome to your new app.\n\n");
-            builder.OpenComponent<Test.SurveyPrompt>(3);
-            builder.AddAttribute(4, "Title", "<div>Test!</div>");
+            builder.AddMarkupContent(0, "<h1>Hello, world!</h1>");
+            builder.AddContent(1, "\n\nWelcome to your new app.\n\n");
+            builder.OpenComponent<Test.SurveyPrompt>(2);
+            builder.AddAttribute(3, "Title", "<div>Test!</div>");
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
@@ -11,9 +11,7 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (44:3,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - h1
-                    HtmlContent - (48:3,4 [13] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (48:3,4 [13] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello, world!
+                HtmlBlock -  - <h1>Hello, world!</h1>
                 HtmlContent - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\nWelcome to your new app.\n\n
                 ComponentExtensionNode - (98:7,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - SurveyPrompt - Test.SurveyPrompt

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -15,11 +15,9 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.OpenElement(0, "h1");
-            builder.AddContent(1, "Hello");
-            builder.CloseElement();
-            builder.AddContent(2, "\n\n");
-            builder.AddContent(3, "My value");
+            builder.AddMarkupContent(0, "<h1>Hello</h1>");
+            builder.AddContent(1, "\n\n");
+            builder.AddContent(2, "My value");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (0:0,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
-                    HtmlContent - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello
+                HtmlBlock -  - <h1>Hello</h1>
                 HtmlContent - (14:0,14 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (14:0,14 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
                 CSharpExpression - (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -15,11 +15,9 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.OpenElement(0, "h1");
-            builder.AddContent(1, "Hello");
-            builder.CloseElement();
-            builder.AddContent(2, "\n\n");
-            builder.OpenComponent<Test.SomeOtherComponent>(3);
+            builder.AddMarkupContent(0, "<h1>Hello</h1>");
+            builder.AddContent(1, "\n\n");
+            builder.OpenComponent<Test.SomeOtherComponent>(2);
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -10,9 +10,7 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (31:1,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
-                    HtmlContent - (35:1,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (35:1,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello
+                HtmlBlock -  - <h1>Hello</h1>
                 HtmlContent - (45:1,14 [4] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (45:1,14 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
                 ComponentExtensionNode - (49:3,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - SomeOtherComponent - Test.SomeOtherComponent

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -16,9 +16,7 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.OpenElement(0, "h1");
-            builder.AddContent(1, "Hello");
-            builder.CloseElement();
+            builder.AddMarkupContent(0, "<h1>Hello</h1>");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.ir.txt
@@ -11,6 +11,4 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlElement - (0:0,0 [14] x:\dir\subdir\Test\TestComponent.cshtml) - h1
-                    HtmlContent - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (4:0,4 [5] x:\dir\subdir\Test\TestComponent.cshtml) - Html - Hello
+                HtmlBlock -  - <h1>Hello</h1>

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
@@ -173,9 +173,9 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             Assert.Equal(
 @"
 <!--!-->
-<div><p>Some-Static-Text</p></div>
-<div id=""bar""><span>More-Static-Text</span></div>
-<div id=""baz""><span>Some-Dynamic-Text</span><span>But this is static</span></div>
+<!--!--><div><p>Some-Static-Text</p></div>
+<!--!--><div id=""bar""><span>More-Static-Text</span></div>
+<div id=""baz""><span>Some-Dynamic-Text</span><!--!--><span>But this is static</span></div>
 
 ",
                 appElement.FindElement(By.CssSelector("#foo")).GetAttribute("innerHTML"));
@@ -189,9 +189,9 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             Assert.Equal(
 @"
 <!--!-->
-<div><p>Some-Static-Text</p></div>
-<div id=""bar"">&lt;span&gt;More-Static-Text&lt;/span&gt;</div>
-<div id=""baz""><span>Some-Dynamic-Text</span><span>But this is static</span></div>
+<!--!--><div><p>Some-Static-Text</p></div>
+<!--!--><div id=""bar"">&lt;span&gt;More-Static-Text&lt;/span&gt;</div>
+<div id=""baz""><span>Some-Dynamic-Text</span><!--!--><span>But this is static</span></div>
 
 ",
                 appElement.FindElement(By.CssSelector("#foo")).GetAttribute("innerHTML"));

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
@@ -162,7 +162,7 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         {
             var appElement = MountTestComponent<HtmlBlockChildContent>();
             Assert.Equal("<p>Some-Static-Text</p>",
-                appElement.FindElement(By.CssSelector("#foo")).GetAttribute("innerHTML"));
+                appElement.FindElement(By.Id("foo")).GetAttribute("innerHTML"));
         }
 
         // Verifies we can rewite more complex HTML content into blocks
@@ -170,15 +170,18 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         public void CanRenderChildContent_MixedHtmlBlock()
         {
             var appElement = MountTestComponent<HtmlMixedChildContent>();
-            Assert.Equal(
-@"
-<!--!-->
-<!--!--><div><p>Some-Static-Text</p></div>
-<!--!--><div id=""bar""><span>More-Static-Text</span></div>
-<div id=""baz""><span>Some-Dynamic-Text</span><!--!--><span>But this is static</span></div>
 
-",
-                appElement.FindElement(By.CssSelector("#foo")).GetAttribute("innerHTML"));
+            var one = appElement.FindElement(By.Id("one"));
+            Assert.Equal("<p>Some-Static-Text</p>", one.GetAttribute("innerHTML"));
+
+            var two = appElement.FindElement(By.Id("two"));
+            Assert.Equal("<span>More-Static-Text</span>", two.GetAttribute("innerHTML"));
+
+            var three = appElement.FindElement(By.Id("three"));
+            Assert.Equal("Some-Dynamic-Text", three.GetAttribute("innerHTML"));
+
+            var four = appElement.FindElement(By.Id("four"));
+            Assert.Equal("But this is static", four.GetAttribute("innerHTML"));
         }
 
         // Verifies we can rewrite HTML blocks with encoded HTML
@@ -186,15 +189,18 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
         public void CanRenderChildContent_EncodedHtmlInBlock()
         {
             var appElement = MountTestComponent<HtmlEncodedChildContent>();
-            Assert.Equal(
-@"
-<!--!-->
-<!--!--><div><p>Some-Static-Text</p></div>
-<!--!--><div id=""bar"">&lt;span&gt;More-Static-Text&lt;/span&gt;</div>
-<div id=""baz""><span>Some-Dynamic-Text</span><!--!--><span>But this is static</span></div>
 
-",
-                appElement.FindElement(By.CssSelector("#foo")).GetAttribute("innerHTML"));
+            var one = appElement.FindElement(By.Id("one"));
+            Assert.Equal("<p>Some-Static-Text</p>", one.GetAttribute("innerHTML"));
+
+            var two = appElement.FindElement(By.Id("two"));
+            Assert.Equal("&lt;span&gt;More-Static-Text&lt;/span&gt;", two.GetAttribute("innerHTML"));
+
+            var three = appElement.FindElement(By.Id("three"));
+            Assert.Equal("Some-Dynamic-Text", three.GetAttribute("innerHTML"));
+
+            var four = appElement.FindElement(By.Id("four"));
+            Assert.Equal("But this is static", four.GetAttribute("innerHTML"));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
@@ -156,6 +156,47 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             Assert.Equal("somevalue", styledElement.GetAttribute("customattribute"));
         }
 
+        // Verifies we can render HTML content as a single block
+        [Fact]
+        public void CanRenderChildContent_StaticHtmlBlock()
+        {
+            var appElement = MountTestComponent<HtmlBlockChildContent>();
+            Assert.Equal("<p>Some-Static-Text</p>",
+                appElement.FindElement(By.CssSelector("#foo")).GetAttribute("innerHTML"));
+        }
+
+        // Verifies we can rewite more complex HTML content into blocks
+        [Fact]
+        public void CanRenderChildContent_MixedHtmlBlock()
+        {
+            var appElement = MountTestComponent<HtmlMixedChildContent>();
+            Assert.Equal(
+@"
+<!--!-->
+<div><p>Some-Static-Text</p></div>
+<div id=""bar""><span>More-Static-Text</span></div>
+<div id=""baz""><span>Some-Dynamic-Text</span><span>But this is static</span></div>
+
+",
+                appElement.FindElement(By.CssSelector("#foo")).GetAttribute("innerHTML"));
+        }
+
+        // Verifies we can rewrite HTML blocks with encoded HTML
+        [Fact]
+        public void CanRenderChildContent_EncodedHtmlInBlock()
+        {
+            var appElement = MountTestComponent<HtmlEncodedChildContent>();
+            Assert.Equal(
+@"
+<!--!-->
+<div><p>Some-Static-Text</p></div>
+<div id=""bar"">&lt;span&gt;More-Static-Text&lt;/span&gt;</div>
+<div id=""baz""><span>Some-Dynamic-Text</span><span>But this is static</span></div>
+
+",
+                appElement.FindElement(By.CssSelector("#foo")).GetAttribute("innerHTML"));
+        }
+
         [Fact]
         public void CanTriggerEventsOnChildComponents()
         {

--- a/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/HtmlBlockPassTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/HtmlBlockPassTest.cs
@@ -113,6 +113,30 @@ namespace Microsoft.AspNetCore.Blazor.Razor
         }
 
         [Fact]
+        public void Execute_RewritesHtml_EncodesHtmlEntities()
+        {
+            // Arrange
+            var document = CreateDocument(@"
+<div>
+    &lt;span&gt;Hi&lt;/span&gt;
+</div>");
+
+            var expected = NormalizeContent(@"
+<div>
+    &lt;span&gt;Hi&lt;/span&gt;
+</div>");
+
+            var documentNode = Lower(document);
+
+            // Act
+            Pass.Execute(document, documentNode);
+
+            // Assert
+            var block = documentNode.FindDescendantNodes<HtmlBlockIntermediateNode>().Single();
+            Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
+        }
+
+        [Fact]
         public void Execute_RewritesHtml_EmptyNonvoid()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/HtmlBlockPassTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Razor.Extensions.Test/HtmlBlockPassTest.cs
@@ -22,7 +22,11 @@ namespace Microsoft.AspNetCore.Blazor.Razor
                 b =>
                 {
                     BlazorExtensionInitializer.Register(b);
-                    b.Features.Remove(b.Features.OfType<HtmlBlockPass>().Single());
+
+                    if (b.Features.OfType<HtmlBlockPass>().Any())
+                    {
+                        b.Features.Remove(b.Features.OfType<HtmlBlockPass>().Single());
+                    }
                 }).Engine;
 
             Pass.Engine = Engine;
@@ -32,7 +36,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
 
         private HtmlBlockPass Pass { get; }
 
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_RewritesHtml_Basic()
         {
             // Arrange
@@ -60,7 +64,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_RewritesHtml_CSharpInAttributes()
         {
             // Arrange
@@ -83,7 +87,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_RewritesHtml_CSharpInBody()
         {
             // Arrange
@@ -108,7 +112,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_RewritesHtml_EmptyNonvoid()
         {
             // Arrange
@@ -126,7 +130,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_RewritesHtml_Void()
         {
             // Arrange
@@ -144,7 +148,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Equal(expected, block.Content, ignoreLineEndingDifferences: true);
         }
 
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_CannotRewriteHtml_CSharpInCode()
         {
             // Arrange
@@ -167,7 +171,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Empty(documentNode.FindDescendantNodes<HtmlBlockIntermediateNode>());
         }
 
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_CannotRewriteHtml_Script()
         {
             // Arrange
@@ -191,7 +195,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
         }
 
         // The unclosed tag will have errors, so we won't rewrite it or its parent.
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_CannotRewriteHtml_Errors()
         {
             // Arrange
@@ -209,7 +213,7 @@ namespace Microsoft.AspNetCore.Blazor.Razor
             Assert.Empty(documentNode.FindDescendantNodes<HtmlBlockIntermediateNode>());
         }
 
-        [Fact(Skip = "Temporarily disable compiling markup frames in 0.5.1")]
+        [Fact]
         public void Execute_RewritesHtml_MismatchedClosingTag()
         {
             // Arrange

--- a/test/testapps/BasicTestApp/HtmlBlockChildContent.cshtml
+++ b/test/testapps/BasicTestApp/HtmlBlockChildContent.cshtml
@@ -1,0 +1,1 @@
+<PassThroughContentComponent><div id="foo"><p>Some-Static-Text</p></div></PassThroughContentComponent>

--- a/test/testapps/BasicTestApp/HtmlEncodedChildContent.cshtml
+++ b/test/testapps/BasicTestApp/HtmlEncodedChildContent.cshtml
@@ -1,7 +1,7 @@
-<div id="foo">
+<div>
 <PassThroughContentComponent>
-<div><p>Some-Static-Text</p></div>
-<div id="bar">&lt;span&gt;More-Static-Text&lt;/span&gt;</div>
-<div id="baz"><span>@("Some-Dynamic-Text")</span><span>But this is static</span></div>
+<div id="one"><p>Some-Static-Text</p></div>
+<div id="two">&lt;span&gt;More-Static-Text&lt;/span&gt;</div>
+<div><span id="three">@("Some-Dynamic-Text")</span><span id="four">But this is static</span></div>
 </PassThroughContentComponent>
 </div>

--- a/test/testapps/BasicTestApp/HtmlEncodedChildContent.cshtml
+++ b/test/testapps/BasicTestApp/HtmlEncodedChildContent.cshtml
@@ -1,0 +1,7 @@
+<div id="foo">
+<PassThroughContentComponent>
+<div><p>Some-Static-Text</p></div>
+<div id="bar">&lt;span&gt;More-Static-Text&lt;/span&gt;</div>
+<div id="baz"><span>@("Some-Dynamic-Text")</span><span>But this is static</span></div>
+</PassThroughContentComponent>
+</div>

--- a/test/testapps/BasicTestApp/HtmlMixedChildContent.cshtml
+++ b/test/testapps/BasicTestApp/HtmlMixedChildContent.cshtml
@@ -1,7 +1,7 @@
-<div id="foo">
+<div>
 <PassThroughContentComponent>
-<div><p>Some-Static-Text</p></div>
-<div id="bar"><span>More-Static-Text</span></div>
-<div id="baz"><span>@("Some-Dynamic-Text")</span><span>But this is static</span></div>
+<div id="one"><p>Some-Static-Text</p></div>
+<div id="two"><span>More-Static-Text</span></div>
+<div><span id="three">@("Some-Dynamic-Text")</span><span id="four">But this is static</span></div>
 </PassThroughContentComponent>
 </div>

--- a/test/testapps/BasicTestApp/HtmlMixedChildContent.cshtml
+++ b/test/testapps/BasicTestApp/HtmlMixedChildContent.cshtml
@@ -1,0 +1,7 @@
+<div id="foo">
+<PassThroughContentComponent>
+<div><p>Some-Static-Text</p></div>
+<div id="bar"><span>More-Static-Text</span></div>
+<div id="baz"><span>@("Some-Dynamic-Text")</span><span>But this is static</span></div>
+</PassThroughContentComponent>
+</div>

--- a/test/testapps/BasicTestApp/Index.cshtml
+++ b/test/testapps/BasicTestApp/Index.cshtml
@@ -36,6 +36,9 @@
     <option value="BasicTestApp.EventBubblingComponent">Event bubbling</option>
     <option value="BasicTestApp.EventPreventDefaultComponent">Event preventDefault</option>
     <option value="BasicTestApp.RouterTest.TestRouter">Router</option>
+    <option value="BasicTestApp.HtmlBlockChildContent">ChildContent HTML Block</option>
+    <option value="BasicTestApp.HtmlMixedChildContent">ChildContent Mixed Block</option>
+    <option value="BasicTestApp.HtmlEncodedChildContent">ChildContent HTML Encoded Block</option>
   </select>
 
   @if (SelectedComponentType != null)


### PR DESCRIPTION
There were two problems here:
- We weren't incrementing child count inside child content - fixed in #1290
- We weren't dealing with HTML entities correctly (fixed in this PR)