### PR TITLE
Install ASP.NET Core runtime

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,9 +4,12 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions"><!-- Used only in development when running the template contents directly from source -->
     <AspNetCorePackageVersion>2.1.0</AspNetCorePackageVersion>
+    <AspNetCoreRuntimeVersion>2.1.2</AspNetCoreRuntimeVersion>
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15811</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.2.0-preview1-34576</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
+    <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.2</MicrosoftNETCoreApp21PackageVersion>
     <SignalRPackageVersion>1.0.0</SignalRPackageVersion>
     <TemplateBlazorPackageVersion>0.6.0-preview1-20180807.1</TemplateBlazorPackageVersion>
     <RazorPackageVersion>2.1.0</RazorPackageVersion>

--- a/build/repo.props
+++ b/build/repo.props
@@ -33,4 +33,9 @@
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp20PackageVersion)" />
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp21PackageVersion)" />
   </ItemGroup>
+
+  <ItemGroup> 
+   <AspNetCoreRuntime Include="$(AspNetCoreRuntimeVersion)" /> 
+ </ItemGroup> 
+ 
 </Project>


### PR DESCRIPTION
This will make sure the build script includes the ASP.NET Core runtime
when running on local .NET. The effect of this is that our test projects
and apps will 'roll forward' unto the newest runtime without us
hardcoding it.