### PR TITLE
Merge sibling nodes during markup block rewrite

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeFrame.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeFrame.cs
@@ -334,6 +334,9 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
                 case RenderTreeFrameType.Text:
                     return $"Text: (seq={Sequence}, len=n/a) {EscapeNewlines(TextContent)}";
 
+                case RenderTreeFrameType.Markup:
+                    return $"Markup: (seq={Sequence}, len=n/a) {EscapeNewlines(TextContent)}";
+
                 case RenderTreeFrameType.ElementReferenceCapture:
                     return $"ElementReferenceCapture: (seq={Sequence}, len=n/a) {ElementReferenceCaptureAction}";
             }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/ComponentRenderingRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/ComponentRenderingRazorIntegrationTest.cs
@@ -488,5 +488,71 @@ namespace Test
                 frames,
                 frame => AssertFrame.Text(frame, "<span>Hi</span>"));
         }
+
+        // Integration test for HTML block rewriting
+        [Fact]
+        public void Render_HtmlBlock_Integration()
+        {
+            // Arrange
+            AdditionalSyntaxTrees.Add(Parse(@"
+using Microsoft.AspNetCore.Blazor;
+using Microsoft.AspNetCore.Blazor.Components;
+namespace Test
+{
+    public class MyComponent : BlazorComponent
+    {
+        [Parameter]
+        RenderFragment ChildContent { get; set; }
+    }
+}
+"));
+
+            var component = CompileToComponent(@"
+@addTagHelper *, TestAssembly
+
+<html>
+  <head><meta><meta></head>
+  <body>
+    <MyComponent>
+      <div><span></span><span></span></div>
+      <div>@(""hi"")</div>
+      <div><span></span><span></span></div>
+      <div></div>
+      <div>@(""hi"")</div>
+      <div></div>
+  </MyComponent>
+  </body>
+</html>");
+
+            // Act
+            var frames = GetRenderTree(component);
+
+            // Assert: component frames are correct
+            Assert.Collection(
+                frames,
+                frame => AssertFrame.Element(frame, "html", 9, 0),
+                frame => AssertFrame.Whitespace(frame, 1),
+                frame => AssertFrame.Markup(frame, "<head><meta><meta></head>\n  ", 2),
+                frame => AssertFrame.Element(frame, "body", 5, 3),
+                frame => AssertFrame.Whitespace(frame, 4),
+                frame => AssertFrame.Component(frame, "Test.MyComponent", 2, 5),
+                frame => AssertFrame.Attribute(frame, RenderTreeBuilder.ChildContent, 6),
+                frame => AssertFrame.Whitespace(frame, 16),
+                frame => AssertFrame.Whitespace(frame, 17));
+
+            // Assert: Captured ChildContent frames are correct
+            var childFrames = GetFrames((RenderFragment)frames[6].AttributeValue);
+            Assert.Collection(
+                childFrames,
+                frame => AssertFrame.Whitespace(frame, 7),
+                frame => AssertFrame.Markup(frame, "<div><span></span><span></span></div>\n      ", 8),
+                frame => AssertFrame.Element(frame, "div", 2, 9),
+                frame => AssertFrame.Text(frame, "hi", 10),
+                frame => AssertFrame.Whitespace(frame, 11),
+                frame => AssertFrame.Markup(frame, "<div><span></span><span></span></div>\n      <div></div>\n      ", 12),
+                frame => AssertFrame.Element(frame, "div", 2, 13),
+                frame => AssertFrame.Text(frame, "hi", 14),
+                frame => AssertFrame.Markup(frame, "\n      <div></div>\n  ", 15));
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RenderingRazorIntegrationTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RenderingRazorIntegrationTest.cs
@@ -175,9 +175,9 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             var frames = GetRenderTree(component);
 
             // Assert
-            Assert.Collection(frames,
-                frame => AssertFrame.Text(frame, "Start", 0),
-                frame => AssertFrame.Text(frame, "End", 1));
+            Assert.Collection(
+                frames,
+                frame => AssertFrame.Markup(frame, "StartEnd", 0));
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.codegen.cs
@@ -19,11 +19,10 @@ namespace Test
             builder.AddAttribute(1, "SomeProp", "val");
             builder.AddAttribute(2, "ChildContent", (Microsoft.AspNetCore.Blazor.RenderFragment)((builder2) => {
                 builder2.AddContent(3, "\n    Some ");
-                builder2.AddMarkupContent(4, "<el>further</el>");
-                builder2.AddContent(5, " content\n");
+                builder2.AddMarkupContent(4, "<el>further</el> content\n");
             }
             ));
-            builder.AddComponentReferenceCapture(6, (__value) => {
+            builder.AddComponentReferenceCapture(5, (__value) => {
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                   myInstance = (Test.MyComponent)__value;
 

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.ir.txt
@@ -13,9 +13,7 @@ Document -
                 ComponentExtensionNode - (31:1,0 [96] x:\dir\subdir\Test\TestComponent.cshtml) - MyComponent - Test.MyComponent
                     HtmlContent - (76:1,45 [11] x:\dir\subdir\Test\TestComponent.cshtml)
                         IntermediateToken - (76:1,45 [11] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n    Some 
-                    HtmlBlock -  - <el>further</el>
-                    HtmlContent - (103:2,25 [10] x:\dir\subdir\Test\TestComponent.cshtml)
-                        IntermediateToken - (103:2,25 [10] x:\dir\subdir\Test\TestComponent.cshtml) - Html -  content\n
+                    HtmlBlock -  - <el>further</el> content\n
                     RefExtensionNode - (49:1,18 [10] x:\dir\subdir\Test\TestComponent.cshtml) - myInstance - Test.MyComponent
                     ComponentAttributeExtensionNode -  - SomeProp - 
                         HtmlContent - (71:1,40 [3] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Component_WithRef_WithChildContent/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 Source Location: (49:1,18 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |myInstance|
-Generated Location: (1176:28,18 [10] )
+Generated Location: (1131:27,18 [10] )
 |myInstance|
 
 Source Location: (143:5,12 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Test.MyComponent myInstance;
 |
-Generated Location: (1430:38,12 [44] )
+Generated Location: (1385:37,12 [44] )
 |
     private Test.MyComponent myInstance;
 |

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
@@ -16,10 +16,9 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello, world!</h1>");
-            builder.AddContent(1, "\n\nWelcome to your new app.\n\n");
-            builder.OpenComponent<Test.SurveyPrompt>(2);
-            builder.AddAttribute(3, "Title", "");
+            builder.AddMarkupContent(0, "<h1>Hello, world!</h1>\n\nWelcome to your new app.\n\n");
+            builder.OpenComponent<Test.SurveyPrompt>(1);
+            builder.AddAttribute(2, "Title", "");
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_772/TestComponent.ir.txt
@@ -11,9 +11,7 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello, world!</h1>
-                HtmlContent - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\nWelcome to your new app.\n\n
+                HtmlBlock -  - <h1>Hello, world!</h1>\n\nWelcome to your new app.\n\n
                 ComponentExtensionNode - (98:7,0 [23] x:\dir\subdir\Test\TestComponent.cshtml) - SurveyPrompt - Test.SurveyPrompt
                     ComponentAttributeExtensionNode - (119:7,21 [0] x:\dir\subdir\Test\TestComponent.cshtml) - Title - Title
                         HtmlContent - (119:7,21 [0] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
@@ -16,10 +16,9 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello, world!</h1>");
-            builder.AddContent(1, "\n\nWelcome to your new app.\n\n");
-            builder.OpenComponent<Test.SurveyPrompt>(2);
-            builder.AddAttribute(3, "Title", "<div>Test!</div>");
+            builder.AddMarkupContent(0, "<h1>Hello, world!</h1>\n\nWelcome to your new app.\n\n");
+            builder.OpenComponent<Test.SurveyPrompt>(1);
+            builder.AddAttribute(2, "Title", "<div>Test!</div>");
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/Regression_773/TestComponent.ir.txt
@@ -11,9 +11,7 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello, world!</h1>
-                HtmlContent - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (66:3,22 [32] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\nWelcome to your new app.\n\n
+                HtmlBlock -  - <h1>Hello, world!</h1>\n\nWelcome to your new app.\n\n
                 ComponentExtensionNode - (98:7,0 [41] x:\dir\subdir\Test\TestComponent.cshtml) - SurveyPrompt - Test.SurveyPrompt
                     ComponentAttributeExtensionNode - (119:7,21 [16] x:\dir\subdir\Test\TestComponent.cshtml) - Title - Title
                         HtmlContent - (119:7,21 [16] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -15,9 +15,8 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello</h1>");
-            builder.AddContent(1, "\n\n");
-            builder.AddContent(2, "My value");
+            builder.AddMarkupContent(0, "<h1>Hello</h1>\n\n");
+            builder.AddContent(1, "My value");
         }
         #pragma warning restore 1998
     }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.ir.txt
@@ -10,8 +10,6 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello</h1>
-                HtmlContent - (14:0,14 [4] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (14:0,14 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
+                HtmlBlock -  - <h1>Hello</h1>\n\n
                 CSharpExpression - (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
                     IntermediateToken - (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - "My value"

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -15,9 +15,8 @@ namespace Test
         protected override void BuildRenderTree(Microsoft.AspNetCore.Blazor.RenderTree.RenderTreeBuilder builder)
         {
             base.BuildRenderTree(builder);
-            builder.AddMarkupContent(0, "<h1>Hello</h1>");
-            builder.AddContent(1, "\n\n");
-            builder.OpenComponent<Test.SomeOtherComponent>(2);
+            builder.AddMarkupContent(0, "<h1>Hello</h1>\n\n");
+            builder.OpenComponent<Test.SomeOtherComponent>(1);
             builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/TestFiles/RuntimeCodeGenerationTest/TrailingWhiteSpace_WithComponent/TestComponent.ir.txt
@@ -10,7 +10,5 @@ Document -
             MethodDeclaration -  - protected override - void - BuildRenderTree
                 CSharpCode - 
                     IntermediateToken -  - CSharp - base.BuildRenderTree(builder);
-                HtmlBlock -  - <h1>Hello</h1>
-                HtmlContent - (45:1,14 [4] x:\dir\subdir\Test\TestComponent.cshtml)
-                    IntermediateToken - (45:1,14 [4] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n\n
+                HtmlBlock -  - <h1>Hello</h1>\n\n
                 ComponentExtensionNode - (49:3,0 [22] x:\dir\subdir\Test\TestComponent.cshtml) - SomeOtherComponent - Test.SomeOtherComponent


### PR DESCRIPTION
This change adds the ability to merge sibling nodes when possible during
markup block rewriting. We retain that invariant that each markup block
is a valid chunk of markup containing properly nested tags.

We still haven't done any work to remove whitespace yet, so most of the
cases where this comes into play right now will merge an element with
its surrounding whitespace.