### PR TITLE
Fix #1298

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,15 +4,17 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions"><!-- Used only in development when running the template contents directly from source -->
     <AspNetCorePackageVersion>2.1.0</AspNetCorePackageVersion>
-    <AspNetCoreRuntimeVersion>2.1.2</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>2.1.3</AspNetCoreRuntimeVersion>
     <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15811</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>2.2.0-preview1-34576</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>2.1.2</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreRazorDesignPackageVersion>2.1.2</MicrosoftAspNetCoreRazorDesignPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.2</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.3</MicrosoftNETCoreApp21PackageVersion>
     <SignalRPackageVersion>1.0.0</SignalRPackageVersion>
     <TemplateBlazorPackageVersion>0.6.0-preview1-20180807.1</TemplateBlazorPackageVersion>
-    <RazorPackageVersion>2.1.1</RazorPackageVersion>
+    <RazorPackageVersion>2.1.0</RazorPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -12,7 +12,7 @@
     <MicrosoftNETCoreApp21PackageVersion>2.1.2</MicrosoftNETCoreApp21PackageVersion>
     <SignalRPackageVersion>1.0.0</SignalRPackageVersion>
     <TemplateBlazorPackageVersion>0.6.0-preview1-20180807.1</TemplateBlazorPackageVersion>
-    <RazorPackageVersion>2.1.0</RazorPackageVersion>
+    <RazorPackageVersion>2.1.1</RazorPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />

--- a/samples/HostedInAspNet.Server/HostedInAspNet.Server.csproj
+++ b/samples/HostedInAspNet.Server/HostedInAspNet.Server.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MonoSanity/MonoSanity.csproj
+++ b/samples/MonoSanity/MonoSanity.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ServerSideBlazor.Server/ServerSideBlazor.Server.csproj
+++ b/samples/ServerSideBlazor.Server/ServerSideBlazor.Server.csproj
@@ -5,12 +5,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCorePackageVersion)" />
+      <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+      <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Server\Microsoft.AspNetCore.Blazor.Server.csproj" />
-        <ProjectReference Include="..\ServerSideBlazor.Client\ServerSideBlazor.Client.csproj" />
+      <ProjectReference Include="..\..\src\Microsoft.AspNetCore.Blazor.Server\Microsoft.AspNetCore.Blazor.Server.csproj" />
+      <ProjectReference Include="..\ServerSideBlazor.Client\ServerSideBlazor.Client.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.csproj
@@ -21,7 +21,7 @@
       <NuspecProperties>
       version=$(PackageVersion);
       publishDir=$([MSBuild]::NormalizeDirectory($(IntermediatePackDir)));
-      razorversion=$(RazorPackageVersion);</NuspecProperties>
+      razorversion=$(MicrosoftAspNetCoreRazorDesignPackageVersion);</NuspecProperties>
     </PropertyGroup>
     <ItemGroup>
       <_TargetFramework Include="$(TargetFrameworks)" />
@@ -44,7 +44,7 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Blazor.TagHelperWorkaround\Microsoft.AspNetCore.Blazor.TagHelperWorkaround.csproj" />
 
     <!-- Intentionally include Razor.Design's MSBuild assets for everyone who reference Blazor.Build -->
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(RazorPackageVersion)" PrivateAssets="None" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" PrivateAssets="None" />
 
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="$(AspNetCorePackageVersion)" />

--- a/src/Microsoft.AspNetCore.Blazor.Build/ReferenceFromSource.props
+++ b/src/Microsoft.AspNetCore.Blazor.Build/ReferenceFromSource.props
@@ -23,7 +23,7 @@
   <Import Project="$(MSBuildThisFileDirectory)targets/All.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(RazorPackageVersion)"/>
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
   </ItemGroup>
 
   <!-- This is used as a P2P when building the repo. Normal Blazor projects will get this as a reference through the Blazor.Build package -->

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/.template.config.src/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/.template.config.src/template.json
@@ -95,13 +95,6 @@
       "replaces": "$(TemplateBlazorPackageVersion)",
       "defaultValue": "${TemplateBlazorVersion}"
     },
-    "AspNetCorePackageVersionSymbol": {
-      "type": "parameter",
-      "datatype": "string",
-      "description": "Intended for internal use only.",
-      "replaces": " Version=\"$(AspNetCorePackageVersion)\"",
-      "defaultValue": ""
-    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Client/BlazorHosted-CSharp.Client.csproj
@@ -12,6 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="$(TemplateBlazorPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="$(TemplateBlazorPackageVersion)" PrivateAssets="all" />
+
+    <!-- Temporary workaround until we have a version of these packages that has the right Razor reference -->
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorHosted-CSharp/BlazorHosted-CSharp.Server/BlazorHosted-CSharp.Server.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="$(TemplateBlazorPackageVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary-CSharp/.template.config.src/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary-CSharp/.template.config.src/template.json
@@ -56,13 +56,6 @@
       "replaces": "$(TemplateBlazorPackageVersion)",
       "defaultValue": "${TemplateBlazorVersion}"
     },
-    "AspNetCorePackageVersionSymbol": {
-      "type": "parameter",
-      "datatype": "string",
-      "description": "Intended for internal use only.",
-      "replaces": " Version=\"$(AspNetCorePackageVersion)\"",
-      "defaultValue": ""
-    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary-CSharp/BlazorLibrary-CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorLibrary-CSharp/BlazorLibrary-CSharp.csproj
@@ -21,6 +21,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="$(TemplateBlazorPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="$(TemplateBlazorPackageVersion)" PrivateAssets="all" />
+
+    
+    <!-- Temporary workaround until we have a version of these packages that has the right Razor reference -->
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/.template.config.src/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/.template.config.src/template.json
@@ -87,13 +87,6 @@
       "replaces": "$(TemplateBlazorPackageVersion)",
       "defaultValue": "${TemplateBlazorVersion}"
     },
-    "AspNetCorePackageVersionSymbol": {
-      "type": "parameter",
-      "datatype": "string",
-      "description": "Intended for internal use only.",
-      "replaces": " Version=\"$(AspNetCorePackageVersion)\"",
-      "defaultValue": ""
-    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/BlazorServerSide-CSharp.App/BlazorServerSide-CSharp.App.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/BlazorServerSide-CSharp.App/BlazorServerSide-CSharp.App.csproj
@@ -15,6 +15,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="$(TemplateBlazorPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="$(TemplateBlazorPackageVersion)" PrivateAssets="all" />
+
+    
+    <!-- Temporary workaround until we have a version of these packages that has the right Razor reference -->
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/BlazorServerSide-CSharp.Server/BlazorServerSide-CSharp.Server.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/BlazorServerSide-CSharp.Server/BlazorServerSide-CSharp.Server.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="$(TemplateBlazorPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/BlazorServerSide-CSharp.Server/BlazorServerSide-CSharp.Server.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/BlazorServerSide-CSharp.Server/BlazorServerSide-CSharp.Server.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="$(TemplateBlazorPackageVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/.template.config.src/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/.template.config.src/template.json
@@ -56,13 +56,6 @@
       "replaces": "$(TemplateBlazorPackageVersion)",
       "defaultValue": "${TemplateBlazorVersion}"
     },
-    "AspNetCorePackageVersionSymbol": {
-      "type": "parameter",
-      "datatype": "string",
-      "description": "Intended for internal use only.",
-      "replaces": " Version=\"$(AspNetCorePackageVersion)\"",
-      "defaultValue": ""
-    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/BlazorStandalone-CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/BlazorStandalone-CSharp.csproj
@@ -13,6 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="$(TemplateBlazorPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="$(TemplateBlazorPackageVersion)" PrivateAssets="all" />
+
+    <!-- Temporary workaround until we have a version of these packages that has the right Razor reference -->
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" />
+
     <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="$(TemplateBlazorPackageVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Microsoft.AspNetCore.Blazor.E2ETest.csproj
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Microsoft.AspNetCore.Blazor.E2ETest.csproj
@@ -9,9 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(AspNetCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(AspNetCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCorePackageVersion)" />
+    <!-- 
+      Lots of specific versions used here because:
+      1. We want to require 2.1.0 in our libraries
+      2. We have a special requirement for Razor.Design at 2.1.2 - this is OK because it's non-transitive
+      3. We want to test against 2.1.3 in our applications
+
+    -->
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Selenium.Support" Version="3.12.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.12.0" />

--- a/test/testapps/TestServer/TestServer.csproj
+++ b/test/testapps/TestServer/TestServer.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(AspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="$(MicrosoftAspNetCoreAppPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="$(MicrosoftAspNetCoreRazorDesignPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change lifts our Razor dependencies to 2.1.1. This is needed
because by default ASP.NET Core projects will depend on 2.1.1 - which
results in a conflict trying to use the Blazor compiler. The Blazor
compiler will load the 2.1.0 msbuild tasks, which then break loading the
2.1.1 tasks.

Since this is happening in the MSBuild process, we can't really write
any code to sort this out. We have to make sure the versions match.

In general the guidance for ASP.NET Core is that projects will **compile
against** 2.1.1 so this won't be a problem in the future unless a user
project specifically lifts ASP.NET Core to a higher version. If that's
the case they will also have to live `Microsoft.AspNetCore.Razor.Design`
to match.