### PR TITLE
Fix publishing following recent build changes (now that $(OutDir) is relative)

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/Publish.targets
@@ -28,7 +28,7 @@
       <!-- Publish all the 'dist' files -->
       <_BlazorGCTPDIDistFiles Include="@(BlazorItemOutput->'%(TargetOutputPath)')" />
       <_BlazorGCTPDI Include="@(_BlazorGCTPDIDistFiles)">
-        <TargetPath>$(BlazorPublishDistDir)$([MSBuild]::MakeRelative('$(OutDir)dist\', %(Identity)))</TargetPath>
+        <TargetPath>$(BlazorPublishDistDir)$([MSBuild]::MakeRelative('$(TargetDir)dist\', %(Identity)))</TargetPath>
       </_BlazorGCTPDI>
 
       <ContentWithTargetPath Include="@(_BlazorGCTPDI)">


### PR DESCRIPTION
…we need to use `$(TargetDir)` instead, which is absolute.