### PR TITLE
Add Blazor.temporaryOnConnectionClose to fix #1339

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Boot.Server.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Boot.Server.ts
@@ -47,6 +47,10 @@ function boot() {
       );
     })
     .catch(unhandledError);
+
+  // Temporary undocumented API to help with https://github.com/aspnet/Blazor/issues/1339
+  // This will be replaced once we implement proper connection management (reconnects, etc.)
+  window['Blazor'].onServerConnectionClose = connection.onclose.bind(connection);
 }
 
 function unhandledError(err) {


### PR DESCRIPTION
This API will be removed once we implement proper connection management (reconnects, etc.)