### PR TITLE
fix #1200: include credentials when fetching blazor.boot.json to enable windows auth

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/BootCommon.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/BootCommon.ts
@@ -1,7 +1,7 @@
 export async function fetchBootConfigAsync() {
   // Later we might make the location of this configurable (e.g., as an attribute on the <script>
   // element that's importing this file), but currently there isn't a use case for that.
-  const bootConfigResponse = await fetch('_framework/blazor.boot.json');
+  const bootConfigResponse = await fetch('_framework/blazor.boot.json', { method: 'Get', credentials: 'include' });
   return bootConfigResponse.json() as Promise<BootJsonData>;
 }
 


### PR DESCRIPTION
Included the suggested change by @radek7210 in issue #1200.
 - Resolves problem in both Client-side and Server-side
 - I could only reproduce this issue locally on an AD domain-connected computer and on an Azure App Service behind Azure AD authentication

Addresses #1200