### PR TITLE
Add -c option in the blazor server

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Cli/Server/Program.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Cli/Server/Program.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 
@@ -8,12 +9,19 @@ namespace Microsoft.AspNetCore.Blazor.Cli.Server
 {
     internal class Program
     {
-        internal static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
+        internal static IWebHost BuildWebHost(string[] args)
+        {
+            var switchMappings = new Dictionary<string, string>
+            {
+                { "-c", "Configuration" },
+            };
+
+            return WebHost.CreateDefaultBuilder(args)
                 .UseConfiguration(new ConfigurationBuilder()
-                    .AddCommandLine(args)
+                    .AddCommandLine(args, switchMappings)
                     .Build())
                 .UseStartup<Startup>()
                 .Build();
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/BlazorStandalone-CSharp.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/BlazorStandalone-CSharp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RunCommand>dotnet</RunCommand>
-    <RunArguments>blazor serve</RunArguments>
+    <RunArguments>blazor serve -c $(Configuration)</RunArguments>
     <RestoreAdditionalProjectSources Condition="'$(IncludeCustomRestoreSourcesSymbol)'=='true'">
       https://dotnet.myget.org/f/blazor-dev/api/v3/index.json;
     </RestoreAdditionalProjectSources>

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/ServerFixtures/AspNetSiteServerFixture.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/ServerFixtures/AspNetSiteServerFixture.cs
@@ -31,6 +31,7 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
                 "--urls", "http://127.0.0.1:0",
                 "--contentroot", sampleSitePath,
                 "--environment", Environment.ToString(),
+                "--configuration", BuildConfiguration,
             });
         }
     }

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/ServerFixtures/DevHostServerFixture.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/ServerFixtures/DevHostServerFixture.cs
@@ -22,7 +22,8 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
             {
                 "--urls", "http://127.0.0.1:0",
                 "--contentroot", ContentRoot,
-                "--pathbase", PathBase
+                "--pathbase", PathBase,
+                "--configuration", BuildConfiguration,
             };
 
             if (!string.IsNullOrEmpty(Environment))

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/ServerFixtures/WebHostServerFixture.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Infrastructure/ServerFixtures/WebHostServerFixture.cs
@@ -11,6 +11,12 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures
     {
         private IWebHost _host;
 
+#if DEBUG
+        public string BuildConfiguration { get; set; } = "Debug";
+#else
+        public string BuildConfiguration { get; set; } = "Release";
+#endif
+
         protected override string StartAndGetRootUri()
         {
             _host = CreateWebHost();

--- a/test/testapps/BasicTestApp/BasicTestApp.csproj
+++ b/test/testapps/BasicTestApp/BasicTestApp.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <!-- Local alternative to <RunArguments>blazor serve</RunArguments> -->
     <RunCommand>dotnet</RunCommand>
-    <RunArguments>run --project ../../../src/Microsoft.AspNetCore.Blazor.Cli serve --pathbase /subdir</RunArguments>
+    <RunArguments>run --project ../../../src/Microsoft.AspNetCore.Blazor.Cli serve --pathbase /subdir -- --configuration $(Configuration)</RunArguments>
   </PropertyGroup>
 
   <!-- Local alternative to <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" /> -->


### PR DESCRIPTION
- Pass configuration using MSBuild variable $(Configuration)
- Parse command line parameters -c or --configuration to match dotnet command way of defining configuration

See #261