### PR TITLE
Support streaming HTTP responses and HttpCompletionOption.ResponseHeadersRead

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpContent.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpContent.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.JSInterop;
+using Mono.WebAssembly.Interop;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Blazor.Browser.Http
+{
+    class BrowserHttpContent : HttpContent
+    {
+        static readonly IDictionary<int, TaskCompletionSource<byte[]>> _pendingResponses
+            = new Dictionary<int, TaskCompletionSource<byte[]>>();
+
+        readonly int _requestId;
+        byte[] _data;
+
+        public BrowserHttpContent(int requestId)
+        {
+            _requestId = requestId;
+        }
+
+        private async Task<byte[]> GetResponseData()
+        {
+            if (_data != null)
+            {
+                return _data;
+            }
+
+            var tcs = new TaskCompletionSource<byte[]>();
+            _pendingResponses.Add(_requestId, tcs);
+
+            ((MonoWebAssemblyJSRuntime)JSRuntime.Current).InvokeUnmarshalled<int, object>(
+                "Blazor._internal.http.getResponseData",
+                _requestId);
+
+            _data = await tcs.Task;
+            return _data;
+        }
+
+        private static byte[] AllocateArray(string length)
+        {
+            return new byte[Int32.Parse(length)];
+        }
+
+        private static void ReceiveResponseData(
+            string id,
+            byte[] responseData,
+            string errorText)
+        {
+            var idVal = Int32.Parse(id);
+            var tcs = _pendingResponses[idVal];
+            _pendingResponses.Remove(idVal);
+
+            if (errorText != null)
+            {
+                tcs.SetException(new HttpRequestException(errorText));
+            }
+            else
+            {
+                tcs.SetResult(responseData);
+            }
+        }
+
+        private void DiscardResponse()
+        {
+            if (_data == null)
+            {
+                ((MonoWebAssemblyJSRuntime)JSRuntime.Current).InvokeUnmarshalled<int, object>(
+                    "Blazor._internal.http.discardResponse",
+                    _requestId);
+            }
+        }
+
+        protected override async Task<Stream> CreateContentReadStreamAsync()
+        {
+            var data = await GetResponseData();
+            return new MemoryStream(data, writable: false);
+        }
+
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            var data = await GetResponseData();
+            await stream.WriteAsync(data, 0, data.Length);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            if (_data != null)
+            {
+                length = _data.Length;
+                return true;
+            }
+
+            length = 0;
+            return false;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            DiscardResponse();
+            base.Dispose(disposing);
+        }
+
+        ~BrowserHttpContent()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpContent.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpContent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.JSInterop;
@@ -67,12 +67,12 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
             }
         }
 
-        private void DiscardResponse()
+        private void CleanupFetchRequest()
         {
             if (_data == null)
             {
                 ((MonoWebAssemblyJSRuntime)JSRuntime.Current).InvokeUnmarshalled<int, object>(
-                    "Blazor._internal.http.discardResponse",
+                    "Blazor._internal.http.cleanupFetchRequest",
                     _requestId);
             }
         }
@@ -103,7 +103,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
 
         protected override void Dispose(bool disposing)
         {
-            DiscardResponse();
+            CleanupFetchRequest();
             base.Dispose(disposing);
         }
 

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpMessageHandler.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpMessageHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
         public static FetchCredentialsOption DefaultCredentials { get; set; }
             = FetchCredentialsOption.SameOrigin;
 
-        static object _idLock = new object();
+        static readonly object _idLock = new object();
         static int _nextRequestId = 0;
         static IDictionary<int, TaskCompletionSource<HttpResponseMessage>> _pendingRequests
             = new Dictionary<int, TaskCompletionSource<HttpResponseMessage>>();
@@ -89,7 +89,6 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
         private static void ReceiveResponse(
             string id,
             string responseDescriptorJson,
-            byte[] responseBodyData,
             string errorText)
         {
             TaskCompletionSource<HttpResponseMessage> tcs;
@@ -107,15 +106,10 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Http
             else
             {
                 var responseDescriptor = Json.Deserialize<ResponseDescriptor>(responseDescriptorJson);
-                var responseContent = responseBodyData == null ? null : new ByteArrayContent(responseBodyData);
+                var responseContent = new BrowserHttpContent(idVal);
                 var responseMessage = responseDescriptor.ToResponseMessage(responseContent);
                 tcs.SetResult(responseMessage);
             }
-        }
-
-        private static byte[] AllocateArray(string length)
-        {
-            return new byte[int.Parse(length)];
         }
 
         private static string GetDefaultCredentialsString()

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpReadStream.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Http/BrowserHttpReadStream.cs
@@ -1,0 +1,157 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.JSInterop;
+using Mono.WebAssembly.Interop;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Blazor.Browser.Http
+{
+    class BrowserHttpReadStream : Stream
+    {
+        static readonly IDictionary<int, TaskCompletionSource<int>> _pendingResponses
+            = new Dictionary<int, TaskCompletionSource<int>>();
+
+        readonly int _requestId;
+        int _bufferedBytesRemaining;
+
+        // temporary storage for passing to js
+        ArraySpan _arraySpan = new ArraySpan();
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public BrowserHttpReadStream(int requestId)
+        {
+            _requestId = requestId;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (count < 0 || buffer.Length - offset < count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            if (_bufferedBytesRemaining > 0)
+            {
+                return ReadBuffered();
+            }
+
+            var tcs = new TaskCompletionSource<int>();
+            _pendingResponses.Add(_requestId, tcs);
+
+            ((MonoWebAssemblyJSRuntime)JSRuntime.Current).InvokeUnmarshalled<int, object>(
+                "Blazor._internal.http.readChunk",
+                _requestId);
+
+            _bufferedBytesRemaining = await tcs.Task;
+            if (_bufferedBytesRemaining == 0)
+            {
+                return 0;
+            }
+
+            return ReadBuffered();
+
+            int ReadBuffered()
+            {
+                _arraySpan.Buffer = buffer;
+                _arraySpan.Offset = offset;
+                _arraySpan.Count = count;
+
+                ((MonoWebAssemblyJSRuntime)JSRuntime.Current).InvokeUnmarshalled<int, ArraySpan, object>(
+                    "Blazor._internal.http.retrieveChunk",
+                    _requestId,
+                    _arraySpan);
+
+                _arraySpan.Buffer = default;
+                _arraySpan.Offset = default;
+                _arraySpan.Count = default;
+
+                int bytesRead = Math.Min(_bufferedBytesRemaining, count);
+                _bufferedBytesRemaining = Math.Max(0, _bufferedBytesRemaining - count);
+                return bytesRead;
+            }
+        }
+
+        private static void StreamChunkRead(string id, string bytesRead, string errorText)
+        {
+            var idVal = Int32.Parse(id);
+
+            var tcs = _pendingResponses[idVal];
+            _pendingResponses.Remove(idVal);
+
+            if (errorText != null)
+            {
+                tcs.SetException(new HttpRequestException(errorText));
+            }
+            else
+            {
+                tcs.SetResult(Int32.Parse(bytesRead));
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            ((MonoWebAssemblyJSRuntime)JSRuntime.Current).InvokeUnmarshalled<int, object>(
+                "Blazor._internal.http.cleanupFetchRequest",
+                _requestId);
+        }
+
+        ~BrowserHttpReadStream()
+        {
+            Dispose(false);
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new PlatformNotSupportedException("Synchronous reads are not supported, use ReadAsync instead");
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        class ArraySpan
+        {
+            public byte[] Buffer { get; set; }
+            public int Offset { get; set; }
+            public int Count { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/StreamingHttpClientTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/StreamingHttpClientTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BasicTestApp.HttpClientTest;
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
+{
+    public class StreamingHttpClientTest : BasicTestAppTestBase, IClassFixture<AspNetSiteServerFixture>
+    {
+        readonly ServerFixture _apiServerFixture;
+        readonly IWebElement _appElement;
+        IWebElement _responseStatus;
+        IWebElement _responseStatusText;
+        IWebElement _testOutcome;
+
+        public StreamingHttpClientTest(
+            BrowserFixture browserFixture,
+            ToggleExecutionModeServerFixture<BasicTestApp.Program> devHostServerFixture,
+            AspNetSiteServerFixture apiServerFixture,
+            ITestOutputHelper output)
+            : base(browserFixture, devHostServerFixture, output)
+        {
+            apiServerFixture.BuildWebHostMethod = TestServer.Program.BuildWebHost;
+            _apiServerFixture = apiServerFixture;
+
+            Navigate(ServerPathBase, noReload: true);
+            _appElement = MountTestComponent<StreamingHttpRequestsComponent>();
+        }
+
+        [Fact]
+        public void CanStreamTime()
+        {
+            IssueRequest("/api/Streaming/TimeStream");
+            Assert.Equal("OK", _responseStatus.Text);
+            Assert.Equal("OK", _responseStatusText.Text);
+            Assert.Equal("OK", _testOutcome.Text);
+        }
+
+        private void IssueRequest(string relativeUri)
+        {
+            var targetUri = new Uri(_apiServerFixture.RootUri, relativeUri);
+            SetValue("request-uri", targetUri.AbsoluteUri);
+
+            _appElement.FindElement(By.Id("send-request")).Click();
+
+            new WebDriverWait(Browser, TimeSpan.FromSeconds(30)).Until(
+                driver => driver.FindElement(By.Id("test-outcome")).Text != "");
+            _responseStatus = _appElement.FindElement(By.Id("response-status"));
+            _responseStatusText = _appElement.FindElement(By.Id("response-status-text"));
+            _testOutcome = _appElement.FindElement(By.Id("test-outcome"));
+        }
+
+        private void SetValue(string elementId, string value)
+        {
+            var element = Browser.FindElement(By.Id(elementId));
+            element.Clear();
+            element.SendKeys(value);
+        }
+    }
+}

--- a/test/testapps/BasicTestApp/HttpClientTest/HttpRequestsComponent.cshtml
+++ b/test/testapps/BasicTestApp/HttpClientTest/HttpRequestsComponent.cshtml
@@ -1,5 +1,6 @@
-﻿@using System.Net
+@using System.Net
 @using System.Net.Http
+@using System.Threading
 @using Microsoft.AspNetCore.Blazor.Browser.Http
 @inject HttpClient Http
 
@@ -18,6 +19,11 @@
         <option value="PUT">PUT</option>
         <option value="DELETE">DELETE</option>
     </select>
+</p>
+
+<p>
+    <div>Cancel after:</div>
+    <input id="cancel-after" bind="@cancelAfter" size="60"/>
 </p>
 
 <p>
@@ -63,6 +69,7 @@
 @functions {
     string uri = "http://api.icndb.com/jokes/random";
     string method = "GET";
+    string cancelAfter = "";
     string requestBody = "";
     List<RequestHeader> requestHeaders = new List<RequestHeader>();
     string requestReferrer = "";
@@ -111,7 +118,13 @@
                 };
             }
 
-            var response = await Http.SendAsync(requestMessage);
+            var cts = new CancellationTokenSource();
+            if (int.TryParse(cancelAfter, out int timeout))
+            {
+                cts.CancelAfter(timeout);
+            }
+
+            var response = await Http.SendAsync(requestMessage, cts.Token);
             responseStatusCode = response.StatusCode;
             responseBody = await response.Content.ReadAsStringAsync();
             var allHeaders = response.Headers.Concat(response.Content?.Headers

--- a/test/testapps/BasicTestApp/HttpClientTest/StreamingHttpRequestsComponent.cshtml
+++ b/test/testapps/BasicTestApp/HttpClientTest/StreamingHttpRequestsComponent.cshtml
@@ -1,0 +1,89 @@
+@using System.Net
+@using System.Net.Http
+@inject HttpClient Http
+
+<h1>Streaming HTTP request tester</h1>
+
+<p>
+    <div>URI:</div>
+    <input id="request-uri" bind="@uri" size="60"/>
+</p>
+
+<button id="send-request" onclick="@DoRequest">Request</button>
+
+@if (responseStatusCode.HasValue)
+{
+    <h2>Response</h2>
+    <p><div>Status:</div><span id="response-status">@responseStatusCode</span></p>
+    <p><div>StatusText:</div><span id="response-status-text">@responseStatusText</span></p>
+    <pre>@responseText</pre>
+}
+
+<span id="test-outcome">@testOutcome</span>
+
+@functions {
+    string uri = "";
+    HttpStatusCode? responseStatusCode;
+    string responseStatusText;
+    string testOutcome;
+    string responseText;
+
+    async Task DoRequest()
+    {
+        responseStatusCode = null;
+        responseStatusText = null;
+        responseText = null;
+        testOutcome = null;
+
+        try
+        {
+            int acceptableReadings = 0;
+            int unacceptableReadings = 0;
+            Microsoft.AspNetCore.Blazor.Browser.Http.BrowserHttpMessageHandler.StreamingEnabled = true;
+            using (var response = await Http.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead))
+            {
+                responseStatusCode = response.StatusCode;
+                responseStatusText = response.ReasonPhrase;
+                using (var stream = await response.Content.ReadAsStreamAsync())
+                using (var reader = new System.IO.StreamReader(stream))
+                {
+                    string line;
+                    while ((line = await reader.ReadLineAsync()) != null)
+                    {
+                        responseText = line;
+                        StateHasChanged();
+
+                        var dateTime = DateTime.ParseExact(line, "o", System.Globalization.CultureInfo.InvariantCulture);
+                        var diff = DateTime.UtcNow - dateTime;
+                        if (diff.TotalMilliseconds > 50)
+                        {
+                            if (unacceptableReadings++ > 3)
+                            {
+                                testOutcome = "NOK";
+                                break;
+                            }
+                        }
+                        else if (acceptableReadings++ > 3)
+                        {
+                            testOutcome = "OK";
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            if (ex is AggregateException)
+            {
+                ex = ex.InnerException;
+            }
+            responseStatusCode = HttpStatusCode.SeeOther;
+            testOutcome = ex.Message + Environment.NewLine + ex.StackTrace;
+        }
+        finally
+        {
+            Microsoft.AspNetCore.Blazor.Browser.Http.BrowserHttpMessageHandler.StreamingEnabled = false;
+        }
+    }
+}

--- a/test/testapps/BasicTestApp/Index.cshtml
+++ b/test/testapps/BasicTestApp/Index.cshtml
@@ -22,6 +22,7 @@
         <option value="BasicTestApp.HierarchicalImportsTest.Subdir.ComponentUsingImports">Imports statement</option>
         <option value="BasicTestApp.HttpClientTest.HttpRequestsComponent">HttpClient tester</option>
         <option value="BasicTestApp.HttpClientTest.BinaryHttpRequestsComponent">Binary HttpClient tester</option>
+        <option value="BasicTestApp.HttpClientTest.StreamingHttpRequestsComponent">Streaming HttpClient tester</option>
         <option value="BasicTestApp.HttpClientTest.CookieCounterComponent">HttpClient cookies</option>
         <option value="BasicTestApp.BindCasesComponent">bind cases</option>
         <option value="BasicTestApp.DataDashComponent">data-* attribute rendering</option>

--- a/test/testapps/TestServer/Controllers/SlowController.cs
+++ b/test/testapps/TestServer/Controllers/SlowController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace TestServer.Controllers
+{
+    [Route("api/[controller]/[action]")]
+    public class SlowController : Controller
+    {
+        [HttpGet]
+        public async Task<string> SayHello(int delay)
+        {
+            await Task.Delay(delay);
+            return "Hello";
+        }
+    }
+}

--- a/test/testapps/TestServer/Controllers/StreamingController.cs
+++ b/test/testapps/TestServer/Controllers/StreamingController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestServer.Controllers
+{
+    [Route("api/[controller]/[action]")]
+    public class StreamingController : Controller
+    {
+        [HttpGet]
+        public async Task TimeStream(CancellationToken cancellationToken)
+        {
+            Response.ContentType = "text/plain";
+            using (var writer = new StreamWriter(Response.Body))
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await writer.WriteLineAsync(DateTime.UtcNow.ToString("o"));
+                    await writer.FlushAsync();
+                    await Task.Delay(1000, cancellationToken);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This delays reading the response body as  `ArrayBuffer`  by moving it into a custom `HttpContent` type which allows `httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead` to work as intended.
Additionally this introduces optional support for streaming the response body if supported by the browser and enabled by the user (controlled via `BrowserHttpMessageHandler.StreamingSupported` and `BrowserHttpMessageHandler.StreamingEnabled`).
Streaming is not enabled by default because the default behavior of `HttpClient` is to buffer anyway while the streaming mode increases the overhead (many interop transitions, Tasks allocated for every `ReadAsync` call).
Last but not least a small change to cascade the `CancellationToken` to an `abortController` on the JS side so an in-flight fetch request can be properly canceled.
fixes #1384