### PR TITLE
ILWipe: Remove AsyncStateMachineAttribute

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.BuildTools/Core/ILWipe/AssemblyItem.cs
+++ b/src/Microsoft.AspNetCore.Blazor.BuildTools/Core/ILWipe/AssemblyItem.cs
@@ -40,6 +40,18 @@ namespace Microsoft.AspNetCore.Blazor.BuildTools.Core.ILWipe
                 return; // Nothing to do
             }
 
+            if (Method.HasCustomAttributes)
+            {
+                for (int i = 0; i < Method.CustomAttributes.Count; i++)
+                {
+                    if (Method.CustomAttributes[i].AttributeType.FullName == "System.Runtime.CompilerServices.AsyncStateMachineAttribute")
+                    {
+                        Method.CustomAttributes.RemoveAt(i);
+                        break;
+                    }
+                }
+            }
+
             // We don't want to actually remove the method definition from the assembly, because
             // then you'd have an assembly that was invalid (it could contain calls to the method
             // that no longer exists). Instead, remove all the instructions from its body, and


### PR DESCRIPTION
From methods that get trimmed, we should remove the `AsyncStateMachineAttribute` if present because it will root the generated private async state machine type which the linker is hence unable to remove.

In my test, this helped the linker to remove the following nested struct from `HttpClientHandler`
```csharp
[CompilerGenerated]
[StructLayout(LayoutKind.Auto)]
private struct <SendAsync>d__64 : IAsyncStateMachine
{
	void IAsyncStateMachine.MoveNext()
	{
		throw ILWipeHelpers.CreateMethodWipedException();
	}

	[DebuggerHidden]
	void IAsyncStateMachine.SetStateMachine(IAsyncStateMachine stateMachine)
	{
		throw ILWipeHelpers.CreateMethodWipedException();
	}

	public int <>1__state;

	public AsyncTaskMethodBuilder<HttpResponseMessage> <>t__builder;

	public HttpClientHandler <>4__this;

	public HttpRequestMessage request;

	public CancellationToken cancellationToken;

	private HttpWebRequest <wrequest>5__2;

	private HttpWebResponse <wresponse>5__3;

	private CancellationTokenRegistration <>7__wrap3;

	private HttpContent <content>5__5;

	private ConfiguredTaskAwaitable.ConfiguredTaskAwaiter <>u__1;

	private Stream <stream>5__6;

	private ConfiguredTaskAwaitable<Stream>.ConfiguredTaskAwaiter <>u__2;

	private ConfiguredTaskAwaitable<WebResponse>.ConfiguredTaskAwaiter <>u__3;

	private TaskAwaiter<HttpResponseMessage> <>u__4;
}
```

The `System.Net.Http.dll` stays at 66kb nontheless.
The removal of the attribute allows the entire state machine to be removed which can enable further linking as its fields will no longer keep them alive.

Another idea would be to remove all attributes from these methods which would be the tradeoff of code that would possibly discover these methods via those attributes and eventually run into the `MethodWipedException` exception vs. not finding them in the first place. On the other hand, ILWipe will strip targeted types and methods in the BCL and its unlikely to reflect on the BCL based on attributes.