### PR TITLE
Amend link for [docs]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The best way to get your bug fixed is to be as detailed as you can be about the 
 Providing a minimal project with steps to reproduce the problem is ideal.
 Here are questions you can answer before you file a bug to make sure you're not missing any important information.
 
-1. Did you read the [documentation](https://github.com/aspnet/blazor/wiki)?
+1. Did you read the [documentation](https://blazor.net/docs/index.html)?
 2. Did you include the snippet of broken code in the issue?
 3. What are the *EXACT* steps to reproduce this problem?
 4. What specific version or build are you using?


### PR DESCRIPTION
The current link for docs points to the wiki which does not have a lot of documentation. Suggest pointing to https://blazor.net/docs/index.html