### PR TITLE
Fix method wiping

### DIFF
--- a/samples/MonoSanity/wwwroot/index.html
+++ b/samples/MonoSanity/wwwroot/index.html
@@ -37,6 +37,14 @@
   </fieldset>
 
   <fieldset>
+    <legend>Invoke wiped method</legend>
+    <form id="invokeWipedMethod">
+      <button type="submit" disabled>Go</button>
+      <div><textarea rows="5" cols="80" readonly id="invokeWipedMethodStackTrace"></textarea></div>
+    </form>
+  </fieldset>
+
+  <fieldset>
     <legend>Call JS from .NET</legend>
     <form id="callJs">
       <input id="callJsEvalExpression" value="location.href" />
@@ -100,6 +108,16 @@
         el('triggerExceptionMessageStackTrace').value = 'WARNING: No exception occurred';
       } catch (ex) {
         el('triggerExceptionMessageStackTrace').value = ex.toString();
+      }
+    };
+
+    el('invokeWipedMethod').onsubmit = function (evt) {
+      evt.preventDefault();
+      try {
+        invokeMonoMethod('MonoSanityClient', 'MonoSanityClient', 'Examples', 'InvokeWipedMethod', []);
+        el('invokeWipedMethodStackTrace').value = 'WARNING: No exception occurred';
+      } catch (ex) {
+        el('invokeWipedMethodStackTrace').value = ex.toString();
       }
     };
 

--- a/samples/MonoSanity/wwwroot/loader.js
+++ b/samples/MonoSanity/wwwroot/loader.js
@@ -80,6 +80,7 @@
       'mscorlib',
       'System',
       'System.Core',
+      'System.Net.Http',
     ];
 
     var allAssemblyUrls = loadAssemblyUrls

--- a/samples/MonoSanityClient/Examples.cs
+++ b/samples/MonoSanityClient/Examples.cs
@@ -5,6 +5,7 @@ using WebAssembly.JSInterop;
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Net.Http;
 
 namespace MonoSanityClient
 {
@@ -28,6 +29,11 @@ namespace MonoSanityClient
         public static void TriggerException(string message)
         {
             throw new InvalidOperationException(message);
+        }
+
+        public static void InvokeWipedMethod()
+        {
+            new HttpClientHandler();
         }
 
         public static string EvaluateJavaScript(string expression)

--- a/src/Microsoft.AspNetCore.Blazor.BuildTools/Core/ILWipe/MethodWipedExceptionMethod.cs
+++ b/src/Microsoft.AspNetCore.Blazor.BuildTools/Core/ILWipe/MethodWipedExceptionMethod.cs
@@ -23,7 +23,8 @@ namespace Microsoft.AspNetCore.Blazor.BuildTools.Core.ILWipe
             //     }
             // }
             var ilWipeHelpersType = new TypeDefinition("ILWipe", "ILWipeHelpers",
-                TypeAttributes.NotPublic | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit);
+                TypeAttributes.NotPublic | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+                moduleDefinition.TypeSystem.Object);
             moduleDefinition.Types.Add(ilWipeHelpersType);
 
             var methodAttributes =
@@ -38,6 +39,7 @@ namespace Microsoft.AspNetCore.Blazor.BuildTools.Core.ILWipe
 
             var notImplExceptionType = ImportEquivalentTypeFromMscorlib(moduleDefinition, typeof(NotImplementedException));
             var notImplExceptionCtor = new MethodReference(".ctor", moduleDefinition.TypeSystem.Void, notImplExceptionType);
+            notImplExceptionCtor.HasThis = true;
             notImplExceptionCtor.Parameters.Add(new ParameterDefinition(moduleDefinition.TypeSystem.String));
 
             var il = createMethodWipedExceptionMethod.Body.GetILProcessor();

--- a/src/Microsoft.AspNetCore.Blazor.BuildTools/Core/ILWipe/WipeAssembly.cs
+++ b/src/Microsoft.AspNetCore.Blazor.BuildTools/Core/ILWipe/WipeAssembly.cs
@@ -43,6 +43,12 @@ namespace Microsoft.AspNetCore.Blazor.BuildTools.Core.ILWipe
                 }
             }
 
+            // Also resolve referenced assemblies in the same directory
+            if (moduleDefinition.AssemblyResolver is DefaultAssemblyResolver resolver)
+            {
+                resolver.AddSearchDirectory(Path.GetDirectoryName(inputPath));
+            }
+
             moduleDefinition.Write(outputPath);
         }
     }

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/MonoSanityTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/MonoSanityTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure;
@@ -66,6 +66,14 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             Browser.FindElement(By.CssSelector("#triggerException button")).Click();
 
             Assert.Contains("Hello from test", GetValue(Browser, "triggerExceptionMessageStackTrace"));
+        }
+
+        [Fact]
+        public void ProvidesDiagnosticIfInvokingWipedMethod()
+        {
+            Browser.FindElement(By.CssSelector("#invokeWipedMethod button")).Click();
+
+            Assert.Contains("System.NotImplementedException: Cannot invoke method because it was wiped. See stack trace for details.", GetValue(Browser, "invokeWipedMethodStackTrace"));
         }
 
         [Fact]


### PR DESCRIPTION
While investigating linking, I found that `ilwipe` couldn't process certain assemblies, and in other cases wasn't throwing the expected clear message if you called a wiped method. This PR fixes the generated IL and adds an E2E test for it.