### PR TITLE
Fix #1450 Skip compilation on non-C# projects

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
+++ b/src/Microsoft.AspNetCore.Blazor.Build/targets/RazorCompilation.targets
@@ -315,7 +315,7 @@
       $(ResolvedCodeAnalysisRuleSet);
       @(AdditionalFiles)"
     Outputs="@(_BlazorTempAssembly);$(NonExistentFile)"
-    Condition="'$(DesignTimeBuild)'!='true'">
+    Condition="'$(DesignTimeBuild)'!='true' AND '$(Language)'=='C#' AND '@(BlazorDeclaration)' != ''">
 
     <MakeDir Directories="%(_BlazorTempAssembly.RelativeDir)" />
 


### PR DESCRIPTION
This change skips our 'temp' compilation that we do to implement 2-phase
build for defining components in .cshtml when the project is not C# OR
when the project has no .cshtml files.

This should make the rest of the build-time Blazor functionality work
for non-C# projects.

This should also make the build faster when you have the Blazor targets
imported in a C# project with no .cshtml files.