### PR TITLE
Fix #1478 - Razor.Design not getting replaced in templates

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/.template.config.src/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorServerSide-CSharp/.template.config.src/template.json
@@ -87,6 +87,13 @@
       "replaces": "$(TemplateBlazorPackageVersion)",
       "defaultValue": "${TemplateBlazorVersion}"
     },
+    "TemplateRazorDesignPackageVersionSymbol": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "Specifies which version of the Razor.Design package to use.",
+      "replaces": "$(TemplateRazorDesignPackageVersion)",
+      "defaultValue": "${TemplateRazorDesignPackageVersion}"
+    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/.template.config.src/template.json
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/content/BlazorStandalone-CSharp/.template.config.src/template.json
@@ -56,6 +56,13 @@
       "replaces": "$(TemplateBlazorPackageVersion)",
       "defaultValue": "${TemplateBlazorVersion}"
     },
+    "TemplateRazorDesignPackageVersionSymbol": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "Specifies which version of the Razor.Design package to use.",
+      "replaces": "$(TemplateRazorDesignPackageVersion)",
+      "defaultValue": "${TemplateRazorDesignPackageVersion}"
+    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",


### PR DESCRIPTION
I missed defining the symbol in template.json