### PR TITLE
Make HttpClientHandler wiping more conservative. Fixes #1484

### DIFF
--- a/samples/MonoSanityClient/Examples.cs
+++ b/samples/MonoSanityClient/Examples.cs
@@ -33,7 +33,7 @@ namespace MonoSanityClient
 
         public static void InvokeWipedMethod()
         {
-            new HttpClientHandler();
+            new HttpClientHandler().Dispose();
         }
 
         public static string EvaluateJavaScript(string expression)

--- a/src/mono/bclwipe/System.Net.Http.txt
+++ b/src/mono/bclwipe/System.Net.Http.txt
@@ -1,3 +1,14 @@
 # HttpClientHandler brings in about 500KB and will never be used under WebAssembly anyway
-# (we have a separate browser-compatible handler)
-System.Net.Http.HttpClientHandler
+# (we have a separate browser-compatible handler).
+#
+# To avoid causing issues for Flurl.Http (https://github.com/aspnet/Blazor/issues/1484),
+# we only wipe the minimal set of methods that pull in the large dependency graph and
+# don't do anything useful under WebAssembly anyway. It would be preferable if Flurl.Http
+# didn't use HttpClientHandler in the case where a custom handler has been configured,
+# but at the time of writing it does.
+
+# SendAsync contains the bulk of the outbound references to HttpWebRequest etc.
+System.Net.Http.HttpClientHandler::SendAsync
+
+# Dispose references ServicePointManager which is huge
+System.Net.Http.HttpClientHandler::Dispose


### PR DESCRIPTION
This wiping config change doesn't have any meaningful effect on the default app payload size, but it means that Flurl.Http can work in the scenario described at #1484 [1].

It's awkward that Flurl.Http instantiates a default `HttpMessageHandler` even when you're configuring it to use a custom HttpClient, but it does, so this change is to stop wiping the constructor, and just throw if you actually call `SendAsync` (or `Dispose`, which pulls in a huge graph of dependencies from `ServicePointManager`).

Longer term we can hopefully remove the special cases around System.Net.Http, but it depends on exactly what Mono provides in the BCL when they supply a built-in working `HttpClient` and what effect that has on bundle size.

[1] The scenario is:

```csharp
FlurlHttp.Configure(settings =>
{
    settings.HttpClientFactory = new MyHttpClientFactory();
});
```

with

```csharp
class MyHttpClientFactory : DefaultHttpClientFactory
{
    public override HttpClient CreateHttpClient(HttpMessageHandler handler)
        => new HttpClient(new BrowserHttpMessageHandler());
}
```

Notice that the problematic scenario is when we're *not* overriding `CreateMessageHandler`, because if we did, then there wouldn't be a problem anyway and this PR would not be required. In fact that was the original workaround proposed at #1484.