### PR TITLE
Added Proteced Property for the `RenderHandle` of the `BlazorComponent`

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
@@ -32,6 +32,16 @@ namespace Microsoft.AspNetCore.Blazor.Components
 
         private readonly RenderFragment _renderFragment;
         private RenderHandle _renderHandle;
+
+        /// <summary>
+        /// Exposes the RenderHandle to any sub-classes
+        /// </summary>
+        /// <value>RenderHandle</value>
+        protected RenderHandle RenderHandle {
+            get => _renderHandle;
+            set => _renderHandle = value;
+        }
+
         private bool _hasCalledInit;
         private bool _hasNeverRendered = true;
         private bool _hasPendingQueuedRender;


### PR DESCRIPTION
What: Added a `protected` property to `BlazorComponent` that exposes the `RenderHandle` to sub-classes.

Why: This allows sub-classes to be instantiated individually with the ability to set the `RenderHandle` from the sub-class's `IComponent.Init` method, which prevents the `BlazorComponent` to not have the ability to be rendered when accessed as `BlazorComponent`.