### PR TITLE
Add required fields to build nuspec

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.nuspec
+++ b/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.nuspec
@@ -4,7 +4,10 @@
     <id>Microsoft.AspNetCore.Blazor.Build</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <description>Build mechanism for Blazor applications.</description>
+    <licenseUrl>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</licenseUrl>
+    <projectUrl>https://asp.net/</projectUrl>
     <dependencies>
       <dependency id="Microsoft.AspNetCore.Razor.Design" version="$razorversion$" include="all" />
       <dependency id="Microsoft.AspNetCore.Blazor.Analyzers" version="$version$" include="all" />


### PR DESCRIPTION
These required fields are missing from the .Build nuspec, and this is blocking package upload.