### PR TITLE
Fixing types of UIEventArgs properties.

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/UIEventArgs.cs
+++ b/src/Microsoft.AspNetCore.Blazor/UIEventArgs.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.Blazor
         /// <summary>
         /// A count of consecutive clicks that happened in a short amount of time, incremented by one.
         /// </summary>
-        public float Detail { get; set; }
+        public long Detail { get; set; }
 
         /// <summary>
         /// The data that underlies a drag-and-drop operation, known as the drag data store.
@@ -258,7 +258,7 @@ namespace Microsoft.AspNetCore.Blazor
         /// <summary>
         /// A count of consecutive clicks that happened in a short amount of time, incremented by one.
         /// </summary>
-        public float Detail { get; set; }
+        public long Detail { get; set; }
 
         /// <summary>
         /// The X coordinate of the mouse pointer in global (screen) coordinates.
@@ -403,7 +403,7 @@ namespace Microsoft.AspNetCore.Blazor
         /// <summary>
         /// A count of consecutive clicks that happened in a short amount of time, incremented by one.
         /// </summary>
-        public float Detail { get; set; }
+        public long Detail { get; set; }
 
         /// <summary>
         /// A list of <see cref="UITouchPoint"/> for every point of contact currently touching the surface.


### PR DESCRIPTION
Hi, 
I found out that some properties of [UIEventArgs ](https://github.com/aspnet/Blazor/blob/master/src/Microsoft.AspNetCore.Blazor/UIEventArgs.cs)objects doesn't match with either w3 standard or with their description.

Example:
`public float Detail { get; set; }` 
should be based on [mozilla](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/detail) or [w3](https://www.w3.org/TR/uievents/#interface-uievent)
`public long Detail { get; set; }`
Even the description of property says, that it represents count of clicks incremented by 1, therefor  representing them by `long` makes more sense to me.

I found several other properties with mismatching types. I can fix them and propose fixes in this PR, but at first I would like to get some feedback on this.

Thanks.
