### PR TITLE
Avoid OnAfterRender allocating to capture 'this'

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
@@ -189,7 +189,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
             }
         }
 
-        private void HandleException(Exception ex)
+        private static void HandleException(Exception ex)
         {
             if (ex is AggregateException && ex.InnerException != null)
             {


### PR DESCRIPTION
Ultra-trivial tweak I noticed while doing some unrelated work.

Currently, if you override `OnAfterRender` and return a non-null `Task`, then the [base class's use of `ContinueWith`](https://github.com/aspnet/Blazor/blob/b3301d8f7a3cda9bc63a9b536309fa385d2776cf/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs#L224) will have to allocate in order to capture the `this` value so it can call `HandleException` as an instance method.

However we can make `HandleException` static so no allocation will occur in `IHandleAfterRender.OnAfterRender`. This suggestion is courtesy of [Roslyn CLR Heap Allocation analyzer](https://github.com/Microsoft/RoslynClrHeapAllocationAnalyzer).