### PR TITLE
Give Renderer knowledge of component parents

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         public void AddComponent(Type componentType, string domElementSelector)
         {
             var component = InstantiateComponent(componentType);
-            var componentId = AssignComponentId(component);
+            var componentId = AssignRootComponentId(component);
 
             // The only reason we're calling this synchronously is so that, if it throws,
             // we get the exception back *before* attempting the first UpdateDisplay

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRenderer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         public void AddComponent(Type componentType, string domElementSelector)
         {
             var component = InstantiateComponent(componentType);
-            var componentId = AssignComponentId(component);
+            var componentId = AssignRootComponentId(component);
 
             var attachComponentTask = _jsRuntime.InvokeAsync<object>(
                 "Blazor._internal.attachRootComponentToElement",

--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeDiffBuilder.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/RenderTreeDiffBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
             var editsBuffer = batchBuilder.EditsBuffer;
             var editsBufferStartLength = editsBuffer.Count;
 
-            var diffContext = new DiffContext(renderer, batchBuilder, oldTree.Array, newTree.Array);
+            var diffContext = new DiffContext(renderer, batchBuilder, componentId, oldTree.Array, newTree.Array);
             AppendDiffEntriesForRange(ref diffContext, 0, oldTree.Count, 0, newTree.Count);
 
             var editsSegment = editsBuffer.ToSegment(editsBufferStartLength, editsBuffer.Count);
@@ -638,7 +638,8 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
                 throw new InvalidOperationException($"Child component already exists during {nameof(InitializeNewComponentFrame)}");
             }
 
-            diffContext.Renderer.InstantiateChildComponentOnFrame(ref frame);
+            var parentComponentId = diffContext.ComponentId;
+            diffContext.Renderer.InstantiateChildComponentOnFrame(ref frame, parentComponentId);
             var childComponentInstance = frame.Component;
 
             // Set initial parameters
@@ -718,16 +719,19 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
             public readonly ArrayBuilder<RenderTreeEdit> Edits;
             public readonly ArrayBuilder<RenderTreeFrame> ReferenceFrames;
             public readonly Dictionary<string, int> AttributeDiffSet;
+            public readonly int ComponentId;
             public int SiblingIndex;
 
             public DiffContext(
                 Renderer renderer,
                 RenderBatchBuilder batchBuilder,
+                int componentId,
                 RenderTreeFrame[] oldTree,
                 RenderTreeFrame[] newTree)
             {
                 Renderer = renderer;
                 BatchBuilder = batchBuilder;
+                ComponentId = componentId;
                 OldTree = oldTree;
                 NewTree = newTree;
                 Edits = batchBuilder.EditsBuffer;

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/ComponentState.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/ComponentState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
     internal class ComponentState
     {
         private readonly int _componentId; // TODO: Change the type to 'long' when the Mono runtime has more complete support for passing longs in .NET->JS calls
+        private readonly ComponentState _parentComponentState;
         private readonly IComponent _component;
         private readonly Renderer _renderer;
         private RenderTreeBuilder _renderTreeBuilderCurrent;
@@ -27,9 +28,11 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// <param name="renderer">The <see cref="Renderer"/> with which the new instance should be associated.</param>
         /// <param name="componentId">The externally visible identifier for the <see cref="IComponent"/>. The identifier must be unique in the context of the <see cref="Renderer"/>.</param>
         /// <param name="component">The <see cref="IComponent"/> whose state is being tracked.</param>
-        public ComponentState(Renderer renderer, int componentId, IComponent component)
+        /// <param name="parentComponentState">The <see cref="ComponentState"/> for the parent component, or null if this is a root component.</param>
+        public ComponentState(Renderer renderer, int componentId, IComponent component, ComponentState parentComponentState)
         {
             _componentId = componentId;
+            _parentComponentState = parentComponentState;
             _component = component ?? throw new ArgumentNullException(nameof(component));
             _renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
             _renderTreeBuilderCurrent = new RenderTreeBuilder(renderer);
@@ -89,5 +92,10 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
 
         public void NotifyRenderCompleted()
             => (_component as IHandleAfterRender)?.OnAfterRender();
+
+        // TODO: Remove this once we can remove TemporaryGetParentComponentIdForTest
+        // from Renderer.cs and corresponding unit test.
+        public int? TemporaryParentComponentIdForTests
+            => _parentComponentState?._componentId;
     }
 }

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorIntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorIntegrationTestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -368,7 +368,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             public RenderTreeFrame[] LatestBatchReferenceFrames { get; private set; }
 
             public void AttachComponent(IComponent component)
-                => AssignComponentId(component);
+                => AssignRootComponentId(component);
 
             protected override void UpdateDisplay(in RenderBatch renderBatch)
             {

--- a/test/Microsoft.AspNetCore.Blazor.Test/LayoutTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/LayoutTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Blazor.Components;
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
         {
             _renderer = new TestRenderer();
             _layoutDisplayComponent = new LayoutDisplay();
-            _layoutDisplayComponentId = _renderer.AssignComponentId(_layoutDisplayComponent);
+            _layoutDisplayComponentId = _renderer.AssignRootComponentId(_layoutDisplayComponent);
         }
 
         [Fact]

--- a/test/shared/TestRenderer.cs
+++ b/test/shared/TestRenderer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -24,8 +24,8 @@ namespace Microsoft.AspNetCore.Blazor.Test.Helpers
         public List<CapturedBatch> Batches { get; }
             = new List<CapturedBatch>();
 
-        public new int AssignComponentId(IComponent component)
-            => base.AssignComponentId(component);
+        public new int AssignRootComponentId(IComponent component)
+            => base.AssignRootComponentId(component);
 
         public new void DispatchEvent(int componentId, int eventHandlerId, UIEventArgs args)
             => base.DispatchEvent(componentId, eventHandlerId, args);


### PR DESCRIPTION
Until now, `Renderer` knew which components were the children of another (i.e., the ones in its most recent render tree), but didn't track the relationship in the opposite direction because it didn't need to.

We now do need to be able to walk up the ancestry hierarchy, because this is essential for the upcoming "passing parameters down the hierarchy" feature (when a new child is added, we have to be able to walk up the ancestry to find matches for its ambient params).

Notes:

* It's kind of awkward, but there was no direct way to unit test this until the rest of the "hierarchical parameters" feature is implemented, because it's just an internal implementation detail. So I've temporarily added an `internal` method for exposing the hierarchy to tests. I'll remove this later.
* While implementing this, it became clear that `AssignComponentId` would need to be split into two variants. Previously it was used publicly but for root components only, and privately for non-root components. I've now reflected this in the code by renaming the `public` variant to `AssignRootComponentId`, and having only the `private` variant accept a `parentComponentId`.