### PR TITLE
Add ability to override blazor config

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorConfig.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorConfig.cs
@@ -7,45 +7,77 @@ using System.Linq;
 
 namespace Microsoft.AspNetCore.Blazor.Server
 {
-    internal class BlazorConfig
+    /// <summary>
+    /// Represents configuration options for the blazor client. 
+    /// </summary>
+    public class BlazorConfig
     {
-        public string SourceMSBuildPath { get; }
-        public string SourceOutputAssemblyPath { get; }
-        public string WebRootPath { get; }
-        public string DistPath
-            => Path.Combine(Path.GetDirectoryName(SourceOutputAssemblyPath), "dist");
-        public bool EnableAutoRebuilding { get; }
-        public bool EnableDebugging { get; }
+        /// <summary>
+        /// Path to the blazor client project.
+        /// </summary>
+        public string SourceMSBuildPath { get; set; }
 
+        /// <summary>
+        /// Path to the blazor client assembly from within the client project.
+        /// </summary>
+        public string SourceOutputAssemblyPath { get; set; }
+
+        /// <summary>
+        /// Path to wwwroot folder from within the client project.
+        /// </summary>
+        public string WebRootPath { get; set; }
+
+        /// <summary>
+        /// Path to the compiled client distributables.
+        /// </summary>
+        public string DistPath { get; set; }
+
+        /// <summary>
+        /// Whether to enable client auto rebuilding.
+        /// </summary>
+        public bool EnableAutoRebuilding { get; set; }
+
+        /// <summary>
+        /// Whether to enable mono debugging.
+        /// </summary>
+        public bool EnableDebugging { get; set; }
+
+        /// <summary>
+        /// Loads the config options stored within the .blazor.config file stored next to the assembly file for the client.
+        /// </summary>
+        /// <param name="assemblyPath">path to client assembly within server bin directory</param>
+        /// <returns></returns>
         public static BlazorConfig Read(string assemblyPath)
-            => new BlazorConfig(assemblyPath);
-
-        private BlazorConfig(string assemblyPath)
         {
+            var config = new BlazorConfig();
+
             // TODO: Instead of assuming the lines are in a specific order, either JSON-encode
             // the whole thing, or at least give the lines key prefixes (e.g., "reload:<someuri>")
             // so we're not dependent on order and all lines being present.
 
             var configFilePath = Path.ChangeExtension(assemblyPath, ".blazor.config");
             var configLines = File.ReadLines(configFilePath).ToList();
-            SourceMSBuildPath = configLines[0];
+            config.SourceMSBuildPath = configLines[0];
 
-            if (SourceMSBuildPath == ".")
+            if (config.SourceMSBuildPath == ".")
             {
-                SourceMSBuildPath = assemblyPath;
+                config.SourceMSBuildPath = assemblyPath;
             }
 
-            var sourceMsBuildDir = Path.GetDirectoryName(SourceMSBuildPath);
-            SourceOutputAssemblyPath = Path.Combine(sourceMsBuildDir, configLines[1]);
+            var sourceMsBuildDir = Path.GetDirectoryName(config.SourceMSBuildPath);
+            config.SourceOutputAssemblyPath = Path.Combine(sourceMsBuildDir, configLines[1]);
+            config.DistPath = Path.Combine(Path.GetDirectoryName(config.SourceOutputAssemblyPath), "dist");
 
             var webRootPath = Path.Combine(sourceMsBuildDir, "wwwroot");
             if (Directory.Exists(webRootPath))
             {
-                WebRootPath = webRootPath;
+                config.WebRootPath = webRootPath;
             }
 
-            EnableAutoRebuilding = configLines.Contains("autorebuild:true", StringComparer.Ordinal);
-            EnableDebugging = configLines.Contains("debug:true", StringComparer.Ordinal);
+            config.EnableAutoRebuilding = configLines.Contains("autorebuild:true", StringComparer.Ordinal);
+            config.EnableDebugging = configLines.Contains("debug:true", StringComparer.Ordinal);
+
+            return config;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorOptions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Blazor.Server;
+
 namespace Microsoft.AspNetCore.Builder
 {
     /// <summary>
@@ -13,5 +15,10 @@ namespace Microsoft.AspNetCore.Builder
         /// Full path to the client assembly.
         /// </summary>
         public string ClientAssemblyPath { get; set; }
+
+        /// <summary>
+        /// Overrides blazor config file with custom options, if null .blazor.config file is loaded.
+        /// </summary>
+        public BlazorConfig Config { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server/Builder/BlazorApplicationBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Builder/BlazorApplicationBuilderExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Builder
             // Currently the items in it are bizarre and don't relate to their purpose,
             // hence all the path manipulation here. We shouldn't be hardcoding 'dist' here either.
             var env = (IHostingEnvironment)app.ApplicationServices.GetService(typeof(IHostingEnvironment));
-            var config = BlazorConfig.Read(options.ClientAssemblyPath);
+            var config = options.Config ?? BlazorConfig.Read(options.ClientAssemblyPath);
 
             if (env.IsDevelopment() && config.EnableAutoRebuilding)
             {


### PR DESCRIPTION
Adds the ability within the BlazorOptions to set a custom BlazorConfig, if none is provided, the standard .blazor.config file is loaded.

Quite useful when using customised development environments. I remotely start and debug the blazor server straight from visual studio on a different machine using ssh what means the paths need to be set at runtime instead of being read from the config file.