### PR TITLE
Add Cascading flag to Parameter

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Components/Parameter.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/Parameter.cs
@@ -23,13 +23,13 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// Gets a value to indicate whether the parameter is cascading, meaning that it
         /// was supplied by a <see cref="CascadingValue{T}"/>.
         /// </summary>
-        public bool IsCascading { get; }
+        public bool Cascading { get; }
 
-        internal Parameter(string name, object value, bool isCascading)
+        internal Parameter(string name, object value, bool cascading)
         {
             Name = name;
             Value = value;
-            IsCascading = isCascading;
+            Cascading = cascading;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Components/Parameter.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/Parameter.cs
@@ -19,10 +19,17 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// </summary>
         public object Value { get; }
 
-        internal Parameter(string name, object value)
+        /// <summary>
+        /// Gets a value to indicate whether the parameter is cascading, meaning that it
+        /// was supplied by a <see cref="CascadingValue{T}"/>.
+        /// </summary>
+        public bool IsCascading { get; }
+
+        internal Parameter(string name, object value, bool isCascading)
         {
             Name = name;
             Value = value;
+            IsCascading = isCascading;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Components/ParameterEnumerator.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/ParameterEnumerator.cs
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
                 _currentIndex = nextIndex;
 
                 ref var frame = ref _frames[_currentIndex];
-                _current = new Parameter(frame.AttributeName, frame.AttributeValue);
+                _current = new Parameter(frame.AttributeName, frame.AttributeValue, false);
 
                 return true;
             }
@@ -124,7 +124,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
                     _currentIndex = nextIndex;
 
                     var state = _cascadingParameters[_currentIndex];
-                    _current = new Parameter(state.LocalValueName, state.ValueSupplier.CurrentValue);
+                    _current = new Parameter(state.LocalValueName, state.ValueSupplier.CurrentValue, true);
                     return true;
                 }
                 else

--- a/test/Microsoft.AspNetCore.Blazor.Test/ParameterCollectionTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/ParameterCollectionTest.cs
@@ -60,8 +60,8 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Assert
             Assert.Collection(ToEnumerable(parameterCollection),
-                AssertParameter("attribute 1", attribute1Value),
-                AssertParameter("attribute 2", attribute2Value));
+                AssertParameter("attribute 1", attribute1Value, false),
+                AssertParameter("attribute 2", attribute2Value, false));
         }
 
         [Fact]
@@ -82,8 +82,8 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Assert
             Assert.Collection(ToEnumerable(parameterCollection),
-                AssertParameter("attribute 1", attribute1Value),
-                AssertParameter("attribute 2", attribute2Value));
+                AssertParameter("attribute 1", attribute1Value, false),
+                AssertParameter("attribute 2", attribute2Value, false));
         }
 
         [Fact]
@@ -105,9 +105,9 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Assert
             Assert.Collection(ToEnumerable(parameterCollection),
-                AssertParameter("attribute 1", attribute1Value),
-                AssertParameter("attribute 2", attribute2Value),
-                AssertParameter("attribute 3", attribute3Value));
+                AssertParameter("attribute 1", attribute1Value, false),
+                AssertParameter("attribute 2", attribute2Value, true),
+                AssertParameter("attribute 3", attribute3Value, true));
         }
 
         [Fact]
@@ -291,12 +291,13 @@ namespace Microsoft.AspNetCore.Blazor.Test
             Assert.Same(myEntryValue, result);
         }
 
-        private Action<Parameter> AssertParameter(string expectedName, object expectedValue)
+        private Action<Parameter> AssertParameter(string expectedName, object expectedValue, bool expectedIsCascading)
         {
             return parameter =>
             {
                 Assert.Equal(expectedName, parameter.Name);
                 Assert.Same(expectedValue, parameter.Value);
+                Assert.Equal(expectedIsCascading, parameter.IsCascading);
             };
         }
 

--- a/test/Microsoft.AspNetCore.Blazor.Test/ParameterCollectionTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/ParameterCollectionTest.cs
@@ -297,7 +297,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
                 Assert.Equal(expectedName, parameter.Name);
                 Assert.Same(expectedValue, parameter.Value);
-                Assert.Equal(expectedIsCascading, parameter.IsCascading);
+                Assert.Equal(expectedIsCascading, parameter.Cascading);
             };
         }
 


### PR DESCRIPTION
... so that components that pass through an arbitrary set of parameters can choose to filter out cascading ones if they want.

This is a follow-up to #1545.