### PR TITLE
"Fixed" mode and E2E tests for <CascadingValue>

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Components/CascadingValue.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/CascadingValue.cs
@@ -42,11 +42,11 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// change notifications. Set this flag only if you will not change
         /// <see cref="Value"/> during the component's lifetime.
         /// </summary>
-        [Parameter] private bool Fixed { get; set; }
+        [Parameter] private bool IsFixed { get; set; }
 
         object ICascadingValueComponent.CurrentValue => Value;
 
-        bool ICascadingValueComponent.CurrentValueIsFixed => Fixed;
+        bool ICascadingValueComponent.CurrentValueIsFixed => IsFixed;
 
         /// <inheritdoc />
         public void Init(RenderHandle renderHandle)
@@ -63,11 +63,11 @@ namespace Microsoft.AspNetCore.Blazor.Components
 
             var hasSuppliedValue = false;
             var previousValue = Value;
-            var previousFixed = Fixed;
+            var previousFixed = IsFixed;
             Value = default;
             ChildContent = null;
             Name = null;
-            Fixed = false;
+            IsFixed = false;
 
             foreach (var parameter in parameters)
             {
@@ -88,9 +88,9 @@ namespace Microsoft.AspNetCore.Blazor.Components
                         throw new ArgumentException($"The parameter '{nameof(Name)}' for component '{nameof(CascadingValue<T>)}' does not allow null or empty values.");
                     }
                 }
-                else if (parameter.Name.Equals(nameof(Fixed), StringComparison.OrdinalIgnoreCase))
+                else if (parameter.Name.Equals(nameof(IsFixed), StringComparison.OrdinalIgnoreCase))
                 {
-                    Fixed = (bool)parameter.Value;
+                    IsFixed = (bool)parameter.Value;
                 }
                 else
                 {
@@ -98,9 +98,9 @@ namespace Microsoft.AspNetCore.Blazor.Components
                 }
             }
 
-            if (_hasSetParametersPreviously && Fixed != previousFixed)
+            if (_hasSetParametersPreviously && IsFixed != previousFixed)
             {
-                throw new InvalidOperationException($"The value of {nameof(Fixed)} cannot be changed dynamically.");
+                throw new InvalidOperationException($"The value of {nameof(IsFixed)} cannot be changed dynamically.");
             }
 
             _hasSetParametersPreviously = true;
@@ -145,11 +145,11 @@ namespace Microsoft.AspNetCore.Blazor.Components
         void ICascadingValueComponent.Subscribe(ComponentState subscriber)
         {
 #if DEBUG
-            if (Fixed)
+            if (IsFixed)
             {
                 // Should not be possible. User code cannot trigger this.
                 // Checking only to catch possible future framework bugs.
-                throw new InvalidOperationException($"Cannot subscribe to a {typeof(CascadingValue<>).Name} when {nameof(Fixed)} is true.");
+                throw new InvalidOperationException($"Cannot subscribe to a {typeof(CascadingValue<>).Name} when {nameof(IsFixed)} is true.");
             }
 #endif
 

--- a/src/Microsoft.AspNetCore.Blazor/Components/ICascadingValueComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/ICascadingValueComponent.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Blazor.Components
 
         object CurrentValue { get; }
 
+        bool CurrentValueIsFixed { get; }
+
         void Subscribe(ComponentState subscriber);
 
         void Unsubscribe(ComponentState subscriber);

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/ServerExecutionTests/TestSubclasses.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/ServerExecutionTests/TestSubclasses.cs
@@ -56,4 +56,12 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.ServerExecutionTests
         {
         }
     }
+
+    public class ServerCascadingValueTest : CascadingValueTest
+    {
+        public ServerCascadingValueTest(BrowserFixture browserFixture, ToggleExecutionModeServerFixture<Program> serverFixture, ITestOutputHelper output)
+            : base(browserFixture, serverFixture.WithServerExecution(), output)
+        {
+        }
+    }
 }

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/CascadingValueTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/CascadingValueTest.cs
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BasicTestApp;
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure;
+using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure.ServerFixtures;
+using OpenQA.Selenium;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
+{
+    public class CascadingValueTest : BasicTestAppTestBase
+    {
+        public CascadingValueTest(
+            BrowserFixture browserFixture,
+            ToggleExecutionModeServerFixture<Program> serverFixture,
+            ITestOutputHelper output)
+            : base(browserFixture, serverFixture, output)
+        {
+            Navigate(ServerPathBase, noReload: !serverFixture.UsingAspNetHost);
+            MountTestComponent<BasicTestApp.CascadingValueTest.CascadingValueSupplier>();
+        }
+        
+        [Fact]
+        public void CanUpdateValuesMatchedByType()
+        {
+            var currentCount = Browser.FindElement(By.Id("current-count"));
+            var incrementButton = Browser.FindElement(By.Id("increment-count"));
+
+            // We have the correct initial value
+            WaitAssert.Equal("100", () => currentCount.Text);
+
+            // Updates are propagated
+            incrementButton.Click();
+            WaitAssert.Equal("101", () => currentCount.Text);
+            incrementButton.Click();
+            WaitAssert.Equal("102", () => currentCount.Text);
+
+            // Didn't re-render unrelated descendants
+            Assert.Equal("1", Browser.FindElement(By.Id("receive-by-interface-num-renders")).Text);
+        }
+
+        [Fact]
+        public void CanUpdateValuesMatchedByName()
+        {
+            var currentFlag1Value = Browser.FindElement(By.Id("flag-1"));
+            var currentFlag2Value = Browser.FindElement(By.Id("flag-2"));
+
+            WaitAssert.Equal("False", () => currentFlag1Value.Text);
+            WaitAssert.Equal("False", () => currentFlag2Value.Text);
+
+            // Observe that the correct cascading parameter updates
+            Browser.FindElement(By.Id("toggle-flag-1")).Click();
+            WaitAssert.Equal("True", () => currentFlag1Value.Text);
+            WaitAssert.Equal("False", () => currentFlag2Value.Text);
+            Browser.FindElement(By.Id("toggle-flag-2")).Click();
+            WaitAssert.Equal("True", () => currentFlag1Value.Text);
+            WaitAssert.Equal("True", () => currentFlag2Value.Text);
+
+            // Didn't re-render unrelated descendants
+            Assert.Equal("1", Browser.FindElement(By.Id("receive-by-interface-num-renders")).Text);
+        }
+
+        [Fact]
+        public void CanUpdateFixedValuesMatchedByInterface()
+        {
+            var currentCount = Browser.FindElement(By.Id("current-count"));
+            var decrementButton = Browser.FindElement(By.Id("decrement-count"));
+
+            // We have the correct initial value
+            WaitAssert.Equal("100", () => currentCount.Text);
+
+            // Updates are propagated
+            decrementButton.Click();
+            WaitAssert.Equal("99", () => currentCount.Text);
+            decrementButton.Click();
+            WaitAssert.Equal("98", () => currentCount.Text);
+
+            // Renders the descendant the same number of times we triggered
+            // events on it, because we always re-render components after they
+            // have an event
+            Assert.Equal("3", Browser.FindElement(By.Id("receive-by-interface-num-renders")).Text);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Blazor.Test/CascadingParameterTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/CascadingParameterTest.cs
@@ -248,7 +248,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
                 builder.OpenComponent<CascadingValue<string>>(0);
                 builder.AddAttribute(1, "Value", providedValue);
-                builder.AddAttribute(2, "Fixed", true);
+                builder.AddAttribute(2, "IsFixed", true);
                 builder.AddAttribute(3, RenderTreeBuilder.ChildContent, new RenderFragment(childBuilder =>
                 {
                     if (shouldIncludeChild)
@@ -306,7 +306,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             var component = new TestComponent(builder =>
             {
                 builder.OpenComponent<CascadingValue<object>>(0);
-                builder.AddAttribute(1, "Fixed", isFixed);
+                builder.AddAttribute(1, "IsFixed", isFixed);
                 builder.AddAttribute(2, "Value", new object());
                 builder.CloseComponent();
             });
@@ -316,7 +316,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act/Assert
             isFixed = true;
             var ex = Assert.Throws<InvalidOperationException>(() => component.TriggerRender());
-            Assert.Equal("The value of Fixed cannot be changed dynamically.", ex.Message);
+            Assert.Equal("The value of IsFixed cannot be changed dynamically.", ex.Message);
         }
 
         [Fact]
@@ -330,7 +330,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
                 builder.OpenComponent<CascadingValue<object>>(0);
                 if (isFixed) // Showing also that "unset" is treated as "false"
                 {
-                    builder.AddAttribute(1, "Fixed", true);
+                    builder.AddAttribute(1, "IsFixed", true);
                 }
                 builder.AddAttribute(2, "Value", new object());
                 builder.CloseComponent();
@@ -341,7 +341,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act/Assert
             isFixed = false;
             var ex = Assert.Throws<InvalidOperationException>(() => component.TriggerRender());
-            Assert.Equal("The value of Fixed cannot be changed dynamically.", ex.Message);
+            Assert.Equal("The value of IsFixed cannot be changed dynamically.", ex.Message);
         }
 
         private static T FindComponent<T>(CapturedBatch batch, out int componentId)

--- a/test/Microsoft.AspNetCore.Blazor.Test/ParameterCollectionTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/ParameterCollectionTest.cs
@@ -327,6 +327,8 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             public object CurrentValue { get; }
 
+            public bool CurrentValueIsFixed => false;
+
             public bool CanSupplyValue(Type valueType, string valueName)
                 => throw new NotImplementedException();
 

--- a/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueIntermediary.cshtml
+++ b/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueIntermediary.cshtml
@@ -1,0 +1,9 @@
+@*
+    The only purpose of this component is to validate that cascaded value updates
+    can pass through entirely unrelated components that wouldn't normally rerender
+    their children when they themselves are being rerendered.
+*@
+
+<CascadingValueReceiveByType />
+<CascadingValueReceiveByName />
+<CascadingValueReceiveFixedByInterface />

--- a/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueReceiveByName.cshtml
+++ b/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueReceiveByName.cshtml
@@ -1,0 +1,16 @@
+@*
+    This component is to show that we can differentiate cascaded values
+    by name if they are of the same type.
+*@
+
+<p>
+    Flag 1: <strong id="flag-1">@MyFlag1</strong>
+</p>
+<p>
+    Flag 2: <strong id="flag-2">@MyFlag2</strong>
+</p>
+
+@functions {
+    [CascadingParameter(Name = "TestFlag1")] bool MyFlag1 { get; set; }
+    [CascadingParameter(Name = "TestFlag2")] bool MyFlag2 { get; set; }
+}

--- a/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueReceiveByType.cshtml
+++ b/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueReceiveByType.cshtml
@@ -1,0 +1,8 @@
+<p>
+    Current count:
+    <strong id="current-count">@CurrentCounter.NumClicks</strong>
+</p>
+
+@functions {
+    [CascadingParameter] CounterDTO CurrentCounter { get; set; }
+}

--- a/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueReceiveFixedByInterface.cshtml
+++ b/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueReceiveFixedByInterface.cshtml
@@ -1,0 +1,21 @@
+@*
+    This component is to show that:
+
+    1. We can match a cascading parameter based on interface
+    2. Since the supplied value is fixed (see CascadingValueSupplier.cshtml),
+       ancestor renders don't trigger descendant renders even though the
+       supplied value type is mutable.
+*@
+
+@{ numRenders++; }
+<p>
+    @(nameof(CascadingValueReceiveFixedByInterface)) render count:
+    <strong id="receive-by-interface-num-renders">@numRenders</strong>
+    <button id="decrement-count" onclick=@Ancestor.DecrementCount>Decrement</button>
+</p>
+
+@functions {
+    int numRenders = 0;
+
+    [CascadingParameter] ICanDecrement Ancestor { get; set; }
+}

--- a/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueSupplier.cshtml
+++ b/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueSupplier.cshtml
@@ -6,7 +6,7 @@
     Each of the CascadingValue components here is configured differently for the test.
 *@
 
-<CascadingValue Value=this Fixed=true>
+<CascadingValue Value=this IsFixed=true>
     <CascadingValue Value=counterState>
         <CascadingValue Name="TestFlag1" Value="currentFlagValue1">
             <CascadingValue Name="TestFlag2" Value="currentFlagValue2">

--- a/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueSupplier.cshtml
+++ b/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueSupplier.cshtml
@@ -1,0 +1,33 @@
+@implements ICanDecrement
+
+@*
+    While it looks somewhat ridiculous to nest so many CascadingValue components,
+    it simplifies the E2E test and is not intended as a representative use case.
+    Each of the CascadingValue components here is configured differently for the test.
+*@
+
+<CascadingValue Value=this Fixed=true>
+    <CascadingValue Value=counterState>
+        <CascadingValue Name="TestFlag1" Value="currentFlagValue1">
+            <CascadingValue Name="TestFlag2" Value="currentFlagValue2">
+                <CascadingValueIntermediary />
+            </CascadingValue>
+        </CascadingValue>
+    </CascadingValue>
+</CascadingValue>
+
+<p><button id="increment-count" onclick=@counterState.IncrementCount>Increment</button></p>
+<p><label><input type="checkbox" id="toggle-flag-1" bind=currentFlagValue1 /> Flag 1</label></p>
+<p><label><input type="checkbox" id="toggle-flag-2" bind=currentFlagValue2 /> Flag 2</label></p>
+
+@functions {
+    CounterDTO counterState = new CounterDTO { NumClicks = 100 };
+    bool currentFlagValue1;
+    bool currentFlagValue2;
+
+    public void DecrementCount()
+    {
+        counterState.NumClicks--;
+        StateHasChanged();
+    }
+}

--- a/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueTypes.cs
+++ b/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueTypes.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace BasicTestApp.CascadingValueTest
+{
+    public class CounterDTO
+    {
+        public int NumClicks { get; set; }
+
+        public void IncrementCount()
+        {
+            NumClicks++;
+        }
+    }
+
+    public interface ICanDecrement
+    {
+        void DecrementCount();
+    }
+}

--- a/test/testapps/BasicTestApp/Index.cshtml
+++ b/test/testapps/BasicTestApp/Index.cshtml
@@ -41,6 +41,7 @@
         <option value="BasicTestApp.HtmlEncodedChildContent">ChildContent HTML Encoded Block</option>
         <option value="BasicTestApp.RazorTemplates">Razor Templates</option>
         <option value="BasicTestApp.MultipleChildContent">Multiple child content</option>
+        <option value="BasicTestApp.CascadingValueTest.CascadingValueSupplier">Cascading values</option>
     </select>
 
   @if (SelectedComponentType != null)


### PR DESCRIPTION
This is a follow-up to #1545.

It's a perf optimization that allows the framework to skip the subscription tracking and parameter snapshotting that it normally has to do when cascading parameters might change value. The intended use case is for things like "form context" or anywhere you do:

    <CascadingValue Value=this>...</CascadingValue>

... because if the `Value` instance is constant for the lifetime of the `<CascadingValue>`, we can make this really cheap.

If developers fail to apply this optimization when they could, nothing bad happens. We only expect this optimization to be used by our framework components and more advanced component authors who have proactively read docs about this.

**Also, E2E tests**

It was convenient to chain the E2E tests for cascading parameter/value in general to this PR. As usual, the E2E tests are not meant to cover every possible combination of use cases and error scenarios (that's in the unit tests); the E2E tests are a representative sample of high-level common scenarios.