### PR TITLE
Remove useless call to StateHasChanged

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Blazor.RenderTree;
@@ -173,8 +173,10 @@ namespace Microsoft.AspNetCore.Blazor.Components
             {
                 parametersTask.ContinueWith(ContinueAfterLifecycleTask);
             }
-
-            StateHasChanged();
+            else
+            {
+                StateHasChanged();
+            }
         }
 
         private void ContinueAfterLifecycleTask(Task task)


### PR DESCRIPTION
This removes an unecessary call to StateHasChanged if task is not finished when we reach the "if" line 172

or we could remove StateHasChanged from ContinueAfterLifecycleTask as it's already called line 178 and 212

