### PR TITLE
Add webpack to prereqs on readme page for the less initiated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To get started with Blazor and build your first Blazor web app check out our [ge
 
 Prerequisites:
 - [Node.js](https://nodejs.org/) (>8.3)
+- webpack
+      npm install webpack -g
 - Restore Git submodules by running the following command at the repo root:
 
       git submodule update --init --recursive


### PR DESCRIPTION
Was looking to contribute and ran into missing prerequisite webpack.  That was the only other thing needed for building.