### PR TITLE
Add routing enhancements

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor/Routing/RouteCollection.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/RouteCollection.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
     {
         internal IEnumerable<RouteEntry> Routes { get; }
 
-        private RouteCollection(IEnumerable<RouteEntry> routes)
+        internal RouteCollection(IEnumerable<RouteEntry> routes)
         {
             Routes = routes;
         }

--- a/src/Microsoft.AspNetCore.Blazor/Routing/RouteCollection.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/RouteCollection.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.AspNetCore.Blazor.Components;
+
+namespace Microsoft.AspNetCore.Blazor.Routing
+{
+    /// <summary>
+    /// A collection of routes to components.
+    /// </summary>
+    public class RouteCollection
+    {
+        internal IEnumerable<RouteEntry> Routes { get; }
+
+        private RouteCollection(IEnumerable<RouteEntry> routes)
+        {
+            Routes = routes;
+        }
+
+        /// <summary>
+        /// Searches a list of components to find routes.
+        /// </summary>
+        /// <param name="types">The components.</param>
+        /// <returns></returns>
+        public static RouteCollection ResolveRoutes(IEnumerable<Type> types)
+        {
+            var routes = new List<RouteEntry>();
+            foreach (var type in types)
+            {
+                var routeAttributes = type.GetCustomAttributes<RouteAttribute>(inherit: true);
+                foreach (var routeAttribute in routeAttributes)
+                {
+                    var template = TemplateParser.ParseTemplate(routeAttribute.Template);
+                    var entry = new RouteEntry(template, type);
+                    routes.Add(entry);
+                }
+            }
+
+            return new RouteCollection(routes);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor/Routing/RouteNotFoundException.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/RouteNotFoundException.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Microsoft.AspNetCore.Blazor.Routing
+{
+    /// <summary>
+    /// Represents when a route could not be found.
+    /// </summary>
+    [Serializable]
+    public class RouteNotFoundException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.Blazor.Routing.RouteNotFoundException"></see> class.
+        /// </summary>
+        public RouteNotFoundException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.Blazor.Routing.RouteNotFoundException"></see> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public RouteNotFoundException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Microsoft.AspNetCore.Blazor.Routing.RouteNotFoundException"></see> class with a specified error message
+        /// and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public RouteNotFoundException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor/Routing/RouteNotFoundException.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/RouteNotFoundException.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        /// <param name="inner">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
         public RouteNotFoundException(string message, Exception inner) : base(message, inner)
         {
         }

--- a/src/Microsoft.AspNetCore.Blazor/Routing/RouteTable.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/RouteTable.cs
@@ -46,7 +46,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         }
 
         /// <summary>
-        /// Removes a route collection to the table.
+        /// Removes a route collection from the table.
         /// </summary>
         /// <param name="collection">The routes.</param>
         /// <param name="regenerateRouteCache">Whether to regenerate the ordered route list.</param>

--- a/src/Microsoft.AspNetCore.Blazor/Routing/RouteTable.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/RouteTable.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
     public class RouteTable
     {
         private readonly HashSet<RouteCollection> _collections;
-        private RouteEntry[] _routes;
+        internal RouteEntry[] Routes { get; private set; }
 
         /// <summary>
         /// Creates a new empty table.
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         /// </summary>
         public void RegenerateRouteCache()
         {
-            _routes = _collections.SelectMany(x => x.Routes).Distinct().OrderBy(id => id, RoutePrecedence).ToArray();
+            Routes = _collections.SelectMany(x => x.Routes).Distinct().OrderBy(id => id, RoutePrecedence).ToArray();
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
 
         internal void Route(RouteContext routeContext)
         {
-            foreach (var route in _routes)
+            foreach (var route in Routes)
             {
                 route.Match(routeContext);
                 if (routeContext.Handler != null)

--- a/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         public Router()
         {
             RouteTable = new RouteTable();
-            _assemblyRoutes = new Dictionary<Assembly, RouteCollection>();
+            _assemblyRoutes = new Dictionary<Assembly, RouteCollection>(new AssemblyComparer());
         }
 
         /// <inheritdoc />
@@ -230,6 +230,19 @@ namespace Microsoft.AspNetCore.Blazor.Routing
             if (_renderHandle.IsInitialized)
             {
                 Refresh();
+            }
+        }
+
+        private class AssemblyComparer : IEqualityComparer<Assembly>
+        {
+            public bool Equals(Assembly x, Assembly y)
+            {
+                return string.Equals(x?.FullName, y?.FullName, StringComparison.Ordinal);
+            }
+
+            public int GetHashCode(Assembly obj)
+            {
+                return obj.FullName.GetHashCode();
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
@@ -158,9 +158,9 @@ namespace Microsoft.AspNetCore.Blazor.Routing
             var locationPath = UriHelper.ToBaseRelativePath(BaseUri, LocationAbsolute);
             locationPath = StringUntilAny(locationPath, _queryOrHashStartChar);
 
-            ComponentResult result;
             try
             {
+                ComponentResult result;
                 try
                 {
                     result = GetComponentForPath(locationPath);
@@ -169,15 +169,20 @@ namespace Microsoft.AspNetCore.Blazor.Routing
                 {
                     result = HandleMissingRoute();
                 }
+
+                if (result != null)
+                {
+                    RenderHandle.Render(builder => Render(builder, result.Handler, result.ComponentParameters));
+                }
             }
             catch (Exception e)
             {
-                result = HandleError(e);
-            }
+                ComponentResult result = HandleError(e);
 
-            if (result != null)
-            {
-                RenderHandle.Render(builder => Render(builder, result.Handler, result.ComponentParameters));
+                if (result != null)
+                {
+                    RenderHandle.Render(builder => Render(builder, result.Handler, result.ComponentParameters));
+                }
             }
         }
 
@@ -225,7 +230,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         /// </summary>
         /// <param name="e">The error that occured.</param>
         /// <returns>The component to be rendered, or null to cancel render.</returns>
-        /// <exception cref="Exception"></exception>
+        /// <exception cref="Exception">If no error route exist, the error is rethrown</exception>
         protected virtual ComponentResult HandleError(Exception e)
         {
             if (ErrorRoute == null)

--- a/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
@@ -29,11 +29,19 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         /// Gets or sets the assembly that should be searched, along with its referenced
         /// assemblies, for components matching the URI.
         /// </summary>
-        [Parameter] private Assembly AppAssembly { get; set; }
+        [Parameter] protected Assembly AppAssembly { get; set; }
 
-        [Parameter] private string FallbackRoute { get; set; }
+        /// <summary>
+        /// Gets or sets the route that should be displayed when another route fails to be
+        /// resolved.
+        /// </summary>
+        [Parameter] protected string FallbackRoute { get; set; }
 
-        [Parameter] private string ErrorRoute { get; set; }
+        /// <summary>
+        /// Gets or sets the route that should be displayed when an error occuring when
+        /// refreshing.
+        /// </summary>
+        [Parameter] protected string ErrorRoute { get; set; }
 
         /// <summary>
         /// Gets the route table containing all enabled routes.

--- a/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         /// <summary>
         /// Gets or sets the base URI of this router.
         /// </summary>
-        protected string BaseUri { get; set; }
+        [Parameter] protected string BaseUri { get; set; }
 
         /// <summary>
         /// Gets or sets the current absolute location URI.
@@ -74,7 +74,10 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         public void Init(RenderHandle renderHandle)
         {
             RenderHandle = renderHandle;
-            BaseUri = UriHelper.GetBaseUri();
+            if (BaseUri == null)
+            {
+                BaseUri = UriHelper.GetBaseUri();
+            }
             LocationAbsolute = UriHelper.GetAbsoluteUri();
             UriHelper.OnLocationChanged += OnLocationChanged;
         }

--- a/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Routing/Router.cs
@@ -19,9 +19,20 @@ namespace Microsoft.AspNetCore.Blazor.Routing
     {
         static readonly char[] _queryOrHashStartChar = new[] { '?', '#' };
 
-        RenderHandle _renderHandle;
-        string _baseUri;
-        string _locationAbsolute;
+        /// <summary>
+        /// Gets or sets the render handle for this router.
+        /// </summary>
+        protected RenderHandle RenderHandle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base URI of this router.
+        /// </summary>
+        protected string BaseUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current absolute location URI.
+        /// </summary>
+        protected string LocationAbsolute { get; set; }
 
         [Inject] private IUriHelper UriHelper { get; set; }
 
@@ -62,9 +73,9 @@ namespace Microsoft.AspNetCore.Blazor.Routing
         /// <inheritdoc />
         public void Init(RenderHandle renderHandle)
         {
-            _renderHandle = renderHandle;
-            _baseUri = UriHelper.GetBaseUri();
-            _locationAbsolute = UriHelper.GetAbsoluteUri();
+            RenderHandle = renderHandle;
+            BaseUri = UriHelper.GetBaseUri();
+            LocationAbsolute = UriHelper.GetAbsoluteUri();
             UriHelper.OnLocationChanged += OnLocationChanged;
         }
 
@@ -136,9 +147,12 @@ namespace Microsoft.AspNetCore.Blazor.Routing
             builder.CloseComponent();
         }
 
-        private void Refresh()
+        /// <summary>
+        /// Handles the refreshing of the router and rendering the output.
+        /// </summary>
+        protected virtual void Refresh()
         {
-            var locationPath = UriHelper.ToBaseRelativePath(_baseUri, _locationAbsolute);
+            var locationPath = UriHelper.ToBaseRelativePath(BaseUri, LocationAbsolute);
             locationPath = StringUntilAny(locationPath, _queryOrHashStartChar);
 
             ComponentResult result;
@@ -160,7 +174,7 @@ namespace Microsoft.AspNetCore.Blazor.Routing
 
             if (result != null)
             {
-                _renderHandle.Render(builder => Render(builder, result.Handler, result.ComponentParameters));
+                RenderHandle.Render(builder => Render(builder, result.Handler, result.ComponentParameters));
             }
         }
 
@@ -234,8 +248,8 @@ namespace Microsoft.AspNetCore.Blazor.Routing
 
         private void OnLocationChanged(object sender, string newAbsoluteUri)
         {
-            _locationAbsolute = newAbsoluteUri;
-            if (_renderHandle.IsInitialized)
+            LocationAbsolute = newAbsoluteUri;
+            if (RenderHandle.IsInitialized)
             {
                 Refresh();
             }

--- a/test/Microsoft.AspNetCore.Blazor.Test/Routing/RouteTableTests.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/Routing/RouteTableTests.cs
@@ -311,10 +311,10 @@ namespace Microsoft.AspNetCore.Blazor.Test.Routing
             {
                 try
                 {
-                    return new RouteTable(_routeTemplates
-                        .Select(rt => new RouteEntry(TemplateParser.ParseTemplate(rt.Item1), rt.Item2))
-                        .OrderBy(id => id, RouteTable.RoutePrecedence)
-                        .ToArray());
+                    RouteTable table = new RouteTable();
+                    table.AddRoutes(new RouteCollection(_routeTemplates.Select(rt =>
+                        new RouteEntry(TemplateParser.ParseTemplate(rt.Item1), rt.Item2))));
+                    return table;
                 }
                 catch (InvalidOperationException ex) when (ex.InnerException is InvalidOperationException)
                 {


### PR DESCRIPTION
Attempts to add some functionality from #293 plus some other features/bug fixes.

- Makes router extensible (Many aspects are now virtual methods)
- Adds 404 handling via virtual method, defaults to a fallback route parameter
- Adds error handling via virtual method, defaults to a error route parameter
- Cache components per assembly
- Allow adding and removing of assemblies from router
- Makes route tables "routes" get only
- Enables route inheritance (from component base classes)
- Fixes component assembly searching (Now checks to see whether blazor is indirectly referenced)
- Step closer to nested routers (BaseURI is now a parameter, and you have a lot more control over which assemblies are loaded)
- Step closer to late/lazy loaded modules (You can add and remove assemblies from routers at runtime)

One important change was that RouteTables cannot be cached per assembly, as the order of the routes inside the table specifies the matching order, meaning instead the routes must be cached (route collection) and then merged and ordered. 

At the moment the unit tests etc have not been updated, only the core logic just to see what you think.

In the future if an error occurs elsewhere inside the application, it might be an idea to hook into the "handleerror" method to route to an error page. For now it just handles routing errors.