### PR TITLE
Add repository in nuspec files

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.nuspec
+++ b/src/Microsoft.AspNetCore.Blazor.Build/Microsoft.AspNetCore.Blazor.Build.nuspec
@@ -8,6 +8,7 @@
     <description>Build mechanism for Blazor applications.</description>
     <licenseUrl>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</licenseUrl>
     <projectUrl>https://asp.net/</projectUrl>
+    <repository type="git" url="https://github.com/aspnet/Blazor" />
     <dependencies>
       <dependency id="Microsoft.AspNetCore.Razor.Design" version="$razorversion$" include="all" />
       <dependency id="Microsoft.AspNetCore.Blazor.Analyzers" version="$version$" include="all" />

--- a/src/Microsoft.AspNetCore.Blazor.Templates/Microsoft.AspNetCore.Blazor.Templates.nuspec
+++ b/src/Microsoft.AspNetCore.Blazor.Templates/Microsoft.AspNetCore.Blazor.Templates.nuspec
@@ -7,7 +7,8 @@
     <description>Templates for ASP.NET Core Blazor</description>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <language>en-US</language>
-    <projectUrl>https://github.com/aspnet/blazor</projectUrl>
+    <projectUrl>https://asp.net/</projectUrl>
+    <repository type="git" url="https://github.com/aspnet/Blazor" />
     <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>


### PR DESCRIPTION
Also changes `<projectUrl>` in `Microsoft.AspNetCore.Blazor.Templates.nuspec` to be consistent with the rest.
`<licenseUrl>` is also inconsistent between those two but i have no idea if this is intentional