### PR TITLE
Route events based on delegate target, not component ID

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/BrowserRenderer.ts
@@ -1,6 +1,4 @@
-import { System_Array, MethodHandle } from '../Platform/Platform';
-import { RenderBatch, ArraySegment, ArrayRange, RenderTreeEdit, RenderTreeFrame, EditType, FrameType, ArrayValues } from './RenderBatch/RenderBatch';
-import { platform } from '../Environment';
+import { RenderBatch, ArraySegment, RenderTreeEdit, RenderTreeFrame, EditType, FrameType, ArrayValues } from './RenderBatch/RenderBatch';
 import { EventDelegator } from './EventDelegator';
 import { EventForDotNet, UIEventArgs } from './EventForDotNet';
 import { LogicalElement, toLogicalElement, insertLogicalChild, removeLogicalChild, getLogicalParent, getLogicalChild, createAndInsertLogicalContainer, isSvgElement } from './LogicalElements';
@@ -9,16 +7,14 @@ const selectValuePropname = '_blazorSelectValue';
 const sharedTemplateElemForParsing = document.createElement('template');
 const sharedSvgElemForParsing = document.createElementNS('http://www.w3.org/2000/svg', 'g');
 const preventDefaultEvents: { [eventType: string]: boolean } = { submit: true };
-let raiseEventMethod: MethodHandle;
-let renderComponentMethod: MethodHandle;
 
 export class BrowserRenderer {
   private eventDelegator: EventDelegator;
   private childComponentLocations: { [componentId: number]: LogicalElement } = {};
 
   constructor(private browserRendererId: number) {
-    this.eventDelegator = new EventDelegator((event, componentId, eventHandlerId, eventArgs) => {
-      raiseEvent(event, this.browserRendererId, componentId, eventHandlerId, eventArgs);
+    this.eventDelegator = new EventDelegator((event, eventHandlerId, eventArgs) => {
+      raiseEvent(event, this.browserRendererId, eventHandlerId, eventArgs);
     });
   }
 
@@ -32,7 +28,7 @@ export class BrowserRenderer {
       throw new Error(`No element is currently associated with component ${componentId}`);
     }
 
-    this.applyEdits(batch, componentId, element, 0, edits, referenceFrames);
+    this.applyEdits(batch, element, 0, edits, referenceFrames);
   }
 
   public disposeComponent(componentId: number) {
@@ -47,7 +43,7 @@ export class BrowserRenderer {
     this.childComponentLocations[componentId] = element;
   }
 
-  private applyEdits(batch: RenderBatch, componentId: number, parent: LogicalElement, childIndex: number, edits: ArraySegment<RenderTreeEdit>, referenceFrames: ArrayValues<RenderTreeFrame>) {
+  private applyEdits(batch: RenderBatch, parent: LogicalElement, childIndex: number, edits: ArraySegment<RenderTreeEdit>, referenceFrames: ArrayValues<RenderTreeFrame>) {
     let currentDepth = 0;
     let childIndexAtCurrentDepth = childIndex;
 
@@ -67,7 +63,7 @@ export class BrowserRenderer {
           const frameIndex = editReader.newTreeIndex(edit);
           const frame = batch.referenceFramesEntry(referenceFrames, frameIndex);
           const siblingIndex = editReader.siblingIndex(edit);
-          this.insertFrame(batch, componentId, parent, childIndexAtCurrentDepth + siblingIndex, referenceFrames, frame, frameIndex);
+          this.insertFrame(batch, parent, childIndexAtCurrentDepth + siblingIndex, referenceFrames, frame, frameIndex);
           break;
         }
         case EditType.removeFrame: {
@@ -81,7 +77,7 @@ export class BrowserRenderer {
           const siblingIndex = editReader.siblingIndex(edit);
           const element = getLogicalChild(parent, childIndexAtCurrentDepth + siblingIndex);
           if (element instanceof Element) {
-            this.applyAttribute(batch, componentId, element, frame);
+            this.applyAttribute(batch, element, frame);
           } else {
             throw new Error(`Cannot set attribute on non-element child`);
           }
@@ -145,12 +141,12 @@ export class BrowserRenderer {
     }
   }
 
-  private insertFrame(batch: RenderBatch, componentId: number, parent: LogicalElement, childIndex: number, frames: ArrayValues<RenderTreeFrame>, frame: RenderTreeFrame, frameIndex: number): number {
+  private insertFrame(batch: RenderBatch, parent: LogicalElement, childIndex: number, frames: ArrayValues<RenderTreeFrame>, frame: RenderTreeFrame, frameIndex: number): number {
     const frameReader = batch.frameReader;
     const frameType = frameReader.frameType(frame);
     switch (frameType) {
       case FrameType.element:
-        this.insertElement(batch, componentId, parent, childIndex, frames, frame, frameIndex);
+        this.insertElement(batch, parent, childIndex, frames, frame, frameIndex);
         return 1;
       case FrameType.text:
         this.insertText(batch, parent, childIndex, frame);
@@ -161,7 +157,7 @@ export class BrowserRenderer {
         this.insertComponent(batch, parent, childIndex, frame);
         return 1;
       case FrameType.region:
-        return this.insertFrameRange(batch, componentId, parent, childIndex, frames, frameIndex + 1, frameIndex + frameReader.subtreeLength(frame));
+        return this.insertFrameRange(batch, parent, childIndex, frames, frameIndex + 1, frameIndex + frameReader.subtreeLength(frame));
       case FrameType.elementReferenceCapture:
         if (parent instanceof Element) {
           applyCaptureIdToElement(parent, frameReader.elementReferenceCaptureId(frame)!);
@@ -178,7 +174,7 @@ export class BrowserRenderer {
     }
   }
 
-  private insertElement(batch: RenderBatch, componentId: number, parent: LogicalElement, childIndex: number, frames: ArrayValues<RenderTreeFrame>, frame: RenderTreeFrame, frameIndex: number) {
+  private insertElement(batch: RenderBatch, parent: LogicalElement, childIndex: number, frames: ArrayValues<RenderTreeFrame>, frame: RenderTreeFrame, frameIndex: number) {
     const frameReader = batch.frameReader;
     const tagName = frameReader.elementName(frame)!;
     const newDomElementRaw = tagName === 'svg' || isSvgElement(parent) ?
@@ -192,11 +188,11 @@ export class BrowserRenderer {
     for (let descendantIndex = frameIndex + 1; descendantIndex < descendantsEndIndexExcl; descendantIndex++) {
       const descendantFrame = batch.referenceFramesEntry(frames, descendantIndex);
       if (frameReader.frameType(descendantFrame) === FrameType.attribute) {
-        this.applyAttribute(batch, componentId, newDomElementRaw, descendantFrame);
+        this.applyAttribute(batch, newDomElementRaw, descendantFrame);
       } else {
         // As soon as we see a non-attribute child, all the subsequent child frames are
         // not attributes, so bail out and insert the remnants recursively
-        this.insertFrameRange(batch, componentId, newElement, 0, frames, descendantIndex, descendantsEndIndexExcl);
+        this.insertFrameRange(batch, newElement, 0, frames, descendantIndex, descendantsEndIndexExcl);
         break;
       }
     }
@@ -228,10 +224,9 @@ export class BrowserRenderer {
     }
   }
 
-  private applyAttribute(batch: RenderBatch, componentId: number, toDomElement: Element, attributeFrame: RenderTreeFrame) {
+  private applyAttribute(batch: RenderBatch, toDomElement: Element, attributeFrame: RenderTreeFrame) {
     const frameReader = batch.frameReader;
     const attributeName = frameReader.attributeName(attributeFrame)!;
-    const browserRendererId = this.browserRendererId;
     const eventHandlerId = frameReader.attributeEventHandlerId(attributeFrame);
 
     if (eventHandlerId) {
@@ -240,7 +235,7 @@ export class BrowserRenderer {
       if (firstTwoChars !== 'on' || !eventName) {
         throw new Error(`Attribute has nonzero event handler ID, but attribute name '${attributeName}' does not start with 'on'.`);
       }
-      this.eventDelegator.setListener(toDomElement, eventName, componentId, eventHandlerId);
+      this.eventDelegator.setListener(toDomElement, eventName, eventHandlerId);
       return;
     }
 
@@ -315,11 +310,11 @@ export class BrowserRenderer {
     }
   }
 
-  private insertFrameRange(batch: RenderBatch, componentId: number, parent: LogicalElement, childIndex: number, frames: ArrayValues<RenderTreeFrame>, startIndex: number, endIndexExcl: number): number {
+  private insertFrameRange(batch: RenderBatch, parent: LogicalElement, childIndex: number, frames: ArrayValues<RenderTreeFrame>, startIndex: number, endIndexExcl: number): number {
     const origChildIndex = childIndex;
     for (let index = startIndex; index < endIndexExcl; index++) {
       const frame = batch.referenceFramesEntry(frames, index);
-      const numChildrenInserted = this.insertFrame(batch, componentId, parent, childIndex, frames, frame, index);
+      const numChildrenInserted = this.insertFrame(batch, parent, childIndex, frames, frame, index);
       childIndex += numChildrenInserted;
 
       // Skip over any descendants, since they are already dealt with recursively
@@ -355,14 +350,13 @@ function countDescendantFrames(batch: RenderBatch, frame: RenderTreeFrame): numb
   }
 }
 
-function raiseEvent(event: Event, browserRendererId: number, componentId: number, eventHandlerId: number, eventArgs: EventForDotNet<UIEventArgs>) {
+function raiseEvent(event: Event, browserRendererId: number, eventHandlerId: number, eventArgs: EventForDotNet<UIEventArgs>) {
   if (preventDefaultEvents[event.type]) {
     event.preventDefault();
   }
 
   const eventDescriptor = {
     browserRendererId,
-    componentId,
     eventHandlerId,
     eventArgsType: eventArgs.type
   };

--- a/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventDelegator.ts
+++ b/src/Microsoft.AspNetCore.Blazor.Browser.JS/src/Rendering/EventDelegator.ts
@@ -1,4 +1,4 @@
-﻿import { EventForDotNet, UIEventArgs } from './EventForDotNet';
+import { EventForDotNet, UIEventArgs } from './EventForDotNet';
 
 const nonBubblingEvents = toLookup([
   'abort', 'blur', 'change', 'error', 'focus', 'load', 'loadend', 'loadstart', 'mouseenter', 'mouseleave',
@@ -6,7 +6,7 @@ const nonBubblingEvents = toLookup([
 ]);
 
 export interface OnEventCallback {
-  (event: Event, componentId: number, eventHandlerId: number, eventArgs: EventForDotNet<UIEventArgs>): void;
+  (event: Event, eventHandlerId: number, eventArgs: EventForDotNet<UIEventArgs>): void;
 }
 
 // Responsible for adding/removing the eventInfo on an expando property on DOM elements, and
@@ -23,7 +23,7 @@ export class EventDelegator {
     this.eventInfoStore = new EventInfoStore(this.onGlobalEvent.bind(this));
   }
 
-  public setListener(element: Element, eventName: string, componentId: number, eventHandlerId: number) {
+  public setListener(element: Element, eventName: string, eventHandlerId: number) {
     // Ensure we have a place to store event info for this element
     let infoForElement: EventHandlerInfosForElement = element[this.eventsCollectionKey];
     if (!infoForElement) {
@@ -36,7 +36,7 @@ export class EventDelegator {
       this.eventInfoStore.update(oldInfo.eventHandlerId, eventHandlerId);
     } else {
       // Go through the whole flow which might involve registering a new global handler
-      const newInfo = { element, eventName, componentId, eventHandlerId };
+      const newInfo = { element, eventName, eventHandlerId };
       this.eventInfoStore.add(newInfo);
       infoForElement[eventName] = newInfo;
     }
@@ -80,7 +80,7 @@ export class EventDelegator {
           }
 
           const handlerInfo = handlerInfos[evt.type];
-          this.onEvent(evt, handlerInfo.componentId, handlerInfo.eventHandlerId, eventArgs);
+          this.onEvent(evt, handlerInfo.eventHandlerId, eventArgs);
         }
       }
 
@@ -161,7 +161,6 @@ interface EventHandlerInfosForElement {
 interface EventHandlerInfo {
   element: Element;
   eventName: string;
-  componentId: number;
   eventHandlerId: number;
 }
 

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
@@ -37,9 +37,6 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
             _browserRendererId = RendererRegistry.Current.Add(this);
         }
 
-        internal void DispatchBrowserEvent(int componentId, int eventHandlerId, UIEventArgs eventArgs)
-            => DispatchEvent(componentId, eventHandlerId, eventArgs);
-
         /// <summary>
         /// Attaches a new root component to the renderer,
         /// causing it to be displayed in the specified DOM element.

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRendererEventDispatcher.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRendererEventDispatcher.cs
@@ -23,7 +23,6 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
             var eventArgs = ParseEventArgsJson(eventDescriptor.EventArgsType, eventArgsJson);
             var renderer = RendererRegistry.Current.Find(eventDescriptor.BrowserRendererId);
             renderer.DispatchEvent(
-                eventDescriptor.ComponentId,
                 eventDescriptor.EventHandlerId,
                 eventArgs);
         }
@@ -70,11 +69,6 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
             /// For framework use only.
             /// </summary>
             public int BrowserRendererId { get; set; }
-
-            /// <summary>
-            /// For framework use only.
-            /// </summary>
-            public int ComponentId { get; set; }
 
             /// <summary>
             /// For framework use only.

--- a/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/BlazorComponent.cs
@@ -200,7 +200,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
             Console.Error.WriteLine($"[{ex.GetType().FullName}] {ex.Message}\n{ex.StackTrace}");
         }
 
-        Task IHandleEvent.HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg args)
+        Task IHandleEvent.HandleEvent<TArg>(EventHandlerInvoker<TArg> invoker, TArg args)
         {
             // We want to be sure that the handler really is one of this component type's
             // methods/lambdas. When the framework calls this, that invariant is always
@@ -210,14 +210,14 @@ namespace Microsoft.AspNetCore.Blazor.Components
             // equivalent to what the framework would do for a real event handler, and isn't
             // some kind of hack to force arbitrary components to re-render (that's something
             // that components opt into by exposing suitable public methods).
-            if (!binding.CheckDelegateTarget(this))
+            if (!invoker.CheckDelegateTarget(this))
             {
                 throw new InvalidOperationException($"The event handler is not associated with " +
                     $"this component. Application code should not invoke {nameof(IHandleEvent)}" +
                     $".{nameof(IHandleEvent.HandleEvent)} directly.");
             }
 
-            var task = binding.Invoke(args);
+            var task = invoker.Invoke(args);
 
             // After each event, we synchronously re-render (unless !ShouldRender())
             // This just saves the developer the trouble of putting "StateHasChanged();"

--- a/src/Microsoft.AspNetCore.Blazor/Components/ComponentEvents.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/ComponentEvents.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Blazor.Components
+{
+    /// <summary>
+    /// Provides methods to invoke callbacks using component event handler semantics.
+    /// That is, if the event handler target is a component, it is able to run its own
+    /// logic around the callback (for example, to re-render that component afterwards).
+    /// </summary>
+    public static class ComponentEvents
+    {
+        /// <summary>
+        /// Invokes the supplied callback, treating it as an event handler. This allows the target to
+        /// perform event handler behaviors (e.g., for components, automatically re-rendering after the
+        /// handler is invoked).
+        /// </summary>
+        /// <param name="handler">The event handler callback.</param>
+        /// <param name="eventArgs">An argument for the event handler callback.</param>
+        /// <returns>A <see cref="Task"/> representing any asynchronous work being performed as a result.</returns>
+        public static Task InvokeEventHandler<TArg>(MulticastDelegate handler, TArg eventArgs)
+        {
+            if (handler == null)
+            {
+                // It's useful to allow null, because components will often take optional
+                // event handler parameters. This saves the component author the trouble
+                // of putting "if (SomeParam != null) { ... }" around all their calls.
+                return Task.CompletedTask;
+            }
+
+            // By wrapping the handler delegate in EventHandlerInvoker<TArg>:
+            // [1] We prevent further access to the underlying delegate. This is useful because it
+            //     avoids possible confusion with the target calling ComponentEvents.InvokeEventHandler
+            //     with it again (which would be an infinite loop).
+            // [2] We capture the TArg such that when invoker.Invoke gets called later, it can check for
+            //     the common case where "handler is Action<TArg>" or similar, and if so, invoke it
+            //     efficiently by casting to that type and not having to using DynamicInvoke.
+            var invoker = new EventHandlerInvoker<TArg>(handler);
+            if (handler.Target is IHandleEvent handleEventTarget)
+            {
+                return handleEventTarget.HandleEvent(invoker, eventArgs);
+            }
+            else
+            {
+                // For other delegates, there's nothing to do besides invoke them directly
+                return invoker.Invoke(eventArgs);
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor/Components/EventHandlerInvoker.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/EventHandlerInvoker.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.AspNetCore.Blazor.Components
 {
     /// <summary>
-    /// A bound event handler delegate.
+    /// Provides the ability to invoke an event handler.
     /// </summary>
     public readonly struct EventHandlerInvoker<TArg>
     {
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
         }
 
         /// <summary>
-        /// Invokes the delegate associated with this binding.
+        /// Invokes the associated event handler delegate.
         /// </summary>
         /// <param name="eventArg">The argument for the event handler.</param>
         /// <returns></returns>

--- a/src/Microsoft.AspNetCore.Blazor/Components/IHandleEvent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/IHandleEvent.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// <summary>
         /// Notifies the component that one of its event handlers has been triggered.
         /// </summary>
-        /// <param name="binding">The event binding.</param>
+        /// <param name="invoker">The event invoker.</param>
         /// <param name="eventArgs">Arguments for the event handler.</param>
-        Task HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg eventArgs);
+        Task HandleEvent<TArg>(EventHandlerInvoker<TArg> invoker, TArg eventArgs);
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Components/IHandleEvent.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Components/IHandleEvent.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Blazor.Components
 {
@@ -12,7 +14,7 @@ namespace Microsoft.AspNetCore.Blazor.Components
         /// Notifies the component that one of its event handlers has been triggered.
         /// </summary>
         /// <param name="binding">The event binding.</param>
-        /// <param name="args">Arguments for the event handler.</param>
-        void HandleEvent(EventHandlerInvoker binding, UIEventArgs args);
+        /// <param name="eventArgs">Arguments for the event handler.</param>
+        Task HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg eventArgs);
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/ComponentState.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/ComponentState.cs
@@ -95,20 +95,6 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
             }
         }
 
-        public void DispatchEvent(EventHandlerInvoker binding, UIEventArgs eventArgs)
-        {
-            if (_component is IHandleEvent handleEventComponent)
-            {
-                handleEventComponent.HandleEvent(binding, eventArgs);
-            }
-            else
-            {
-                throw new InvalidOperationException(
-                    $"The component of type {_component.GetType().FullName} cannot receive " +
-                    $"events because it does not implement {typeof(IHandleEvent).FullName}.");
-            }
-        }
-
         public void NotifyRenderCompleted()
             => (_component as IHandleAfterRender)?.OnAfterRender();
 

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         private bool _isBatchInProgress;
 
         private int _lastEventHandlerId = 0;
-        private readonly Dictionary<int, MulticastDelegate> _eventBindings = new Dictionary<int, MulticastDelegate>();
+        private readonly Dictionary<int, MulticastDelegate> _eventHandlers = new Dictionary<int, MulticastDelegate>();
 
         /// <summary>
         /// Constructs an instance of <see cref="Renderer"/>.
@@ -87,14 +87,14 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// <param name="eventArgs">Arguments to be passed to the event handler.</param>
         public Task DispatchEvent(int eventHandlerId, UIEventArgs eventArgs)
         {
-            if (_eventBindings.TryGetValue(eventHandlerId, out var binding))
+            if (_eventHandlers.TryGetValue(eventHandlerId, out var @delegate))
             {
                 // The event handler might request multiple renders in sequence. Capture them
                 // all in a single batch.
                 try
                 {
                     _isBatchInProgress = true;
-                    return ComponentEvents.InvokeEventHandler(binding, eventArgs);
+                    return ComponentEvents.InvokeEventHandler(@delegate, eventArgs);
                 }
                 finally
                 {
@@ -131,7 +131,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
 
             if (frame.AttributeValue is MulticastDelegate @delegate)
             {
-               _eventBindings.Add(id, @delegate);
+               _eventHandlers.Add(id, @delegate);
             }
 
             frame = frame.WithAttributeEventHandlerId(id);
@@ -223,7 +223,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
             var count = eventHandlerIds.Count;
             for (var i = 0; i < count; i++)
             {
-                _eventBindings.Remove(array[i]);
+                _eventHandlers.Remove(array[i]);
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
@@ -83,10 +83,9 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// <summary>
         /// Notifies the specified component that an event has occurred.
         /// </summary>
-        /// <param name="componentId">The unique identifier for the component within the scope of this <see cref="Renderer"/>.</param>
         /// <param name="eventHandlerId">The <see cref="RenderTreeFrame.AttributeEventHandlerId"/> value from the original event attribute.</param>
         /// <param name="eventArgs">Arguments to be passed to the event handler.</param>
-        public Task DispatchEvent(int componentId, int eventHandlerId, UIEventArgs eventArgs)
+        public Task DispatchEvent(int eventHandlerId, UIEventArgs eventArgs)
         {
             if (_eventBindings.TryGetValue(eventHandlerId, out var binding))
             {

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/CascadingValueTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/CascadingValueTest.cs
@@ -77,10 +77,9 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
             decrementButton.Click();
             WaitAssert.Equal("98", () => currentCount.Text);
 
-            // Renders the descendant the same number of times we triggered
-            // events on it, because we always re-render components after they
-            // have an event
-            Assert.Equal("3", Browser.FindElement(By.Id("receive-by-interface-num-renders")).Text);
+            // Doesn't re-render the descendant, because the event handler was only
+            // associated with the parent and we didn't change the descendant params.
+            Assert.Equal("1", Browser.FindElement(By.Id("receive-by-interface-num-renders")).Text);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Blazor.Test/ComponentEventsTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/ComponentEventsTest.cs
@@ -174,10 +174,10 @@ namespace Microsoft.AspNetCore.Blazor.Test
                 return ExpectedTask;
             }
 
-            Task IHandleEvent.HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg eventArgs)
+            Task IHandleEvent.HandleEvent<TArg>(EventHandlerInvoker<TArg> invoker, TArg eventArgs)
             {
                 DidCallHandleEvent = true;
-                return binding.Invoke(eventArgs);
+                return invoker.Invoke(eventArgs);
             }
         }
     }

--- a/test/Microsoft.AspNetCore.Blazor.Test/ComponentEventsTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/ComponentEventsTest.cs
@@ -1,0 +1,184 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Blazor.Components;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Blazor.Test
+{
+    public class ComponentEventsTest
+    {
+        [Fact]
+        public void IfDelegateIsNull_ReturnsCompletedTask()
+        {
+            var result = ComponentEvents.InvokeEventHandler(null, new object());
+            Assert.Same(Task.CompletedTask, result);
+        }
+
+        [Fact]
+        public void IfDelegateIsOnIHandleEvent_CallsHandleEvent()
+        {
+            // Arrange
+            var target = new TestHandleEvent();
+            var expectedArg = new TestArg();
+
+            // Act
+            var result = ComponentEvents.InvokeEventHandler((Action<TestArg>)target.MyMethod, expectedArg);
+
+            // Assert
+            Assert.True(target.DidCallHandleEvent);
+            Assert.Same(expectedArg, target.ReceivedArg);
+            Assert.Same(Task.CompletedTask, result);
+        }
+
+        [Fact]
+        public void IfDelegateIsOnIHandleEvent_CallsHandleEventAsync()
+        {
+            // Arrange
+            var target = new TestHandleEvent();
+            var expectedArg = new TestArg();
+
+            // Act
+            var result = ComponentEvents.InvokeEventHandler((Func<TestArg, Task>)target.MyMethodAsync, expectedArg);
+
+            // Assert
+            Assert.True(target.DidCallHandleEvent);
+            Assert.Same(expectedArg, target.ReceivedArg);
+            Assert.Same(target.ExpectedTask, result);
+        }
+
+        [Fact]
+        public void IfDelegateIsNotOnIHandleEvent_InvokesWithoutArg()
+        {
+            // Arrange
+            var didInvoke = false;
+            Action handler = () => { didInvoke = true; };
+
+            // Act
+            var result = ComponentEvents.InvokeEventHandler(handler, "ignored arg");
+
+            // Assert
+            Assert.True(didInvoke);
+            Assert.Same(Task.CompletedTask, result);
+        }
+
+        [Fact]
+        public void IfDelegateIsNotOnIHandleEvent_InvokesWithArg()
+        {
+            // Arrange
+            TestArg receivedArg = null;
+            var expectedArg = new TestArg();
+            Action<TestArg> handler = arg => { receivedArg = arg; };
+
+            // Act
+            var result = ComponentEvents.InvokeEventHandler(handler, expectedArg);
+
+            // Assert
+            Assert.Same(expectedArg, receivedArg);
+            Assert.Same(Task.CompletedTask, result);
+        }
+
+        [Fact]
+        public void IfDelegateIsNotOnIHandleEvent_InvokesWithArgLateBound()
+        {
+            // In this case where the delegate type isn't statically known to accept
+            // the arg type but does so at runtime, it has to go through the slower
+            // DynamicInvoke path but it still works.
+
+            // Arrange
+            object receivedArg = null;
+            var expectedArg = new TestArgSubtype();
+            Action<TestArgSubtype> handler = arg => { receivedArg = arg; };
+
+            // Act
+            var result = ComponentEvents.InvokeEventHandler(handler, (TestArg)expectedArg);
+
+            // Assert
+            Assert.Same(expectedArg, receivedArg);
+            Assert.Same(Task.CompletedTask, result);
+        }
+
+        [Fact]
+        public void IfDelegateIsNotOnIHandleEvent_InvokesAsyncWithoutArg()
+        {
+            // Arrange
+            var didInvoke = false;
+            var expectedTask = new Task(() => { });
+            Func<Task> handler = () => { didInvoke = true; return expectedTask; };
+
+            // Act
+            var result = ComponentEvents.InvokeEventHandler(handler, "ignored arg");
+
+            // Assert
+            Assert.True(didInvoke);
+            Assert.Same(expectedTask, result);
+        }
+
+        [Fact]
+        public void IfDelegateIsNotOnIHandleEvent_InvokesAsyncWithArg()
+        {
+            // Arrange
+            TestArg receivedArg = null;
+            var expectedArg = new TestArg();
+            var expectedTask = new Task(() => { });
+            Func<TestArg, Task> handler = arg => { receivedArg = arg; return expectedTask; };
+
+            // Act
+            var result = ComponentEvents.InvokeEventHandler(handler, expectedArg);
+
+            // Assert
+            Assert.Same(expectedArg, receivedArg);
+            Assert.Same(expectedTask, result);
+        }
+
+        [Fact]
+        public void IfDelegateIsNotOnIHandleEvent_InvokesAsyncWithArgLateBound()
+        {
+            // In this case where the delegate type isn't statically known to accept
+            // the arg type but does so at runtime, it has to go through the slower
+            // DynamicInvoke path but it still works.
+
+            // Arrange
+            TestArgSubtype receivedArg = null;
+            var expectedArg = new TestArgSubtype();
+            var expectedTask = new Task(() => { });
+            Func<TestArgSubtype, Task> handler = arg => { receivedArg = arg; return expectedTask; };
+
+            // Act
+            var result = ComponentEvents.InvokeEventHandler(handler, (TestArg)expectedArg);
+
+            // Assert
+            Assert.Same(expectedArg, receivedArg);
+            Assert.Same(expectedTask, result);
+        }
+
+        class TestArg { }
+        class TestArgSubtype : TestArg { }
+
+        class TestHandleEvent : IHandleEvent
+        {
+            public bool DidCallHandleEvent { get; private set; }
+            public TestArg ReceivedArg { get; private set; }
+            public Task ExpectedTask { get; } = new Task(() => { });
+
+            public void MyMethod(TestArg arg)
+            {
+                ReceivedArg = arg;
+            }
+
+            public Task MyMethodAsync(TestArg arg)
+            {
+                ReceivedArg = arg;
+                return ExpectedTask;
+            }
+
+            Task IHandleEvent.HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg eventArgs)
+            {
+                DidCallHandleEvent = true;
+                return binding.Invoke(eventArgs);
+            }
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
@@ -1203,9 +1203,9 @@ namespace Microsoft.AspNetCore.Blazor.Test
                 builder.AddContent(6, $"Render count: {++renderCount}");
             }
 
-            public Task HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg args)
+            public Task HandleEvent<TArg>(EventHandlerInvoker<TArg> invoker, TArg args)
             {
-                binding.Invoke(args);
+                invoker.Invoke(args);
                 return null;
             }
         }
@@ -1273,9 +1273,9 @@ namespace Microsoft.AspNetCore.Blazor.Test
                 Render();
             }
 
-            public Task HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg args)
+            public Task HandleEvent<TArg>(EventHandlerInvoker<TArg> invoker, TArg args)
             {
-                var task = binding.Invoke(args);
+                var task = invoker.Invoke(args);
                 Render();
                 return task;
             }
@@ -1318,9 +1318,9 @@ namespace Microsoft.AspNetCore.Blazor.Test
             public bool CheckboxEnabled;
             public string SomeStringProperty;
 
-            public Task HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg args)
+            public Task HandleEvent<TArg>(EventHandlerInvoker<TArg> invoker, TArg args)
             {
-                binding.Invoke(args);
+                invoker.Invoke(args);
                 TriggerRender();
                 return null;
             }
@@ -1376,10 +1376,10 @@ namespace Microsoft.AspNetCore.Blazor.Test
             public bool DidCallClickHandler { get; private set; }
             public bool DidCallHandleEvent { get; private set; }
 
-            public Task HandleEvent<TArg>(EventHandlerInvoker<TArg> binding, TArg args)
+            public Task HandleEvent<TArg>(EventHandlerInvoker<TArg> invoker, TArg args)
             {
                 DidCallHandleEvent = true;
-                binding.Invoke(args);
+                invoker.Invoke(args);
                 return null;
             }
 

--- a/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
@@ -173,7 +173,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
                 OnTest = args => { receivedArgs = args; }
             };
-            var componentId = renderer.AssignRootComponentId(component);
+            renderer.AssignRootComponentId(component);
             component.TriggerRender();
 
             var eventHandlerId = renderer.Batches.Single()
@@ -186,7 +186,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIEventArgs();
-            renderer.DispatchEvent(componentId, eventHandlerId, eventArgs);
+            renderer.DispatchEvent(eventHandlerId, eventArgs);
             Assert.Same(eventArgs, receivedArgs);
         }
 
@@ -201,7 +201,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
                 OnClick = args => { receivedArgs = args; }
             };
-            var componentId = renderer.AssignRootComponentId(component);
+            renderer.AssignRootComponentId(component);
             component.TriggerRender();
 
             var eventHandlerId = renderer.Batches.Single()
@@ -214,7 +214,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIMouseEventArgs();
-            renderer.DispatchEvent(componentId, eventHandlerId, eventArgs);
+            renderer.DispatchEvent(eventHandlerId, eventArgs);
             Assert.Same(eventArgs, receivedArgs);
         }
 
@@ -229,7 +229,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
                 OnClickAction = () => { receivedArgs = new object(); }
             };
-            var componentId = renderer.AssignRootComponentId(component);
+            renderer.AssignRootComponentId(component);
             component.TriggerRender();
 
             var eventHandlerId = renderer.Batches.Single()
@@ -242,7 +242,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIMouseEventArgs();
-            renderer.DispatchEvent(componentId, eventHandlerId, eventArgs);
+            renderer.DispatchEvent(eventHandlerId, eventArgs);
             Assert.NotNull(receivedArgs);
         }
 
@@ -267,7 +267,6 @@ namespace Microsoft.AspNetCore.Blazor.Test
                 .Single(frame => frame.FrameType == RenderTreeFrameType.Component);
             var nestedComponent = (EventComponent)nestedComponentFrame.Component;
             nestedComponent.OnTest = args => { receivedArgs = args; };
-            var nestedComponentId = nestedComponentFrame.ComponentId;
             nestedComponent.TriggerRender();
 
             // Find nested component's event handler ID
@@ -281,7 +280,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIEventArgs();
-            renderer.DispatchEvent(nestedComponentId, eventHandlerId, eventArgs);
+            renderer.DispatchEvent(eventHandlerId, eventArgs);
             Assert.Same(eventArgs, receivedArgs);
         }
 
@@ -298,7 +297,6 @@ namespace Microsoft.AspNetCore.Blazor.Test
             var nestedComponentFrame = renderer.Batches.Single()
                 .ReferenceFrames
                 .Single(frame => frame.FrameType == RenderTreeFrameType.Component);
-            var nestedComponentId = nestedComponentFrame.ComponentId;
             var eventHandlerId = renderer.Batches[0]
                 .ReferenceFrames
                 .First(frame => frame.FrameType == RenderTreeFrameType.Attribute && frame.AttributeName == "oncustomclick")
@@ -310,7 +308,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert: Event can be fired
             var eventArgs = new UIEventArgs();
-            renderer.DispatchEvent(nestedComponentId, eventHandlerId, eventArgs);
+            renderer.DispatchEvent(eventHandlerId, eventArgs);
             Assert.True(parentComponent.DidCallClickHandler);
             Assert.True(parentComponent.DidCallHandleEvent);
         }
@@ -331,7 +329,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
                 numRenders++;
             });
 
-            var componentId = renderer.AssignRootComponentId(component);
+            renderer.AssignRootComponentId(component);
             component.TriggerRender();
             Assert.Equal(1, numRenders);
 
@@ -342,7 +340,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             var eventArgs = new UIEventArgs();
 
             // Act: Trigger event
-            renderer.DispatchEvent(componentId, eventHandlerId, eventArgs);
+            renderer.DispatchEvent(eventHandlerId, eventArgs);
 
             // Assert
             Assert.Same(eventArgs, handlerReceivedArgs);
@@ -350,7 +348,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
         }
 
         [Fact]
-        public void CannotDispatchEventsToUnknownComponents()
+        public void CannotDispatchEventsToUnknownHandlers()
         {
             // Arrange
             var renderer = new TestRenderer();
@@ -358,7 +356,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act/Assert
             Assert.Throws<ArgumentException>(() =>
             {
-                renderer.DispatchEvent(123, 0, new UIEventArgs());
+                renderer.DispatchEvent(123, new UIEventArgs());
             });
         }
 
@@ -567,7 +565,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             var eventCount = 0;
             Action<UIEventArgs> origEventHandler = args => { eventCount++; };
             var component = new EventComponent { OnTest = origEventHandler };
-            var componentId = renderer.AssignRootComponentId(component);
+            renderer.AssignRootComponentId(component);
             component.TriggerRender();
             var origEventHandlerId = renderer.Batches.Single()
                 .ReferenceFrames
@@ -577,7 +575,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+            renderer.DispatchEvent(origEventHandlerId, args: null);
             Assert.Equal(1, eventCount);
 
             // Now change the attribute value
@@ -588,11 +586,11 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act/Assert 2: Can no longer fire the original event, but can fire the new event
             Assert.Throws<ArgumentException>(() =>
             {
-                renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+                renderer.DispatchEvent(origEventHandlerId, args: null);
             });
             Assert.Equal(1, eventCount);
             Assert.Equal(0, newEventCount);
-            renderer.DispatchEvent(componentId, origEventHandlerId + 1, args: null);
+            renderer.DispatchEvent(origEventHandlerId + 1, args: null);
             Assert.Equal(1, newEventCount);
         }
 
@@ -604,7 +602,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             var eventCount = 0;
             Action<UIEventArgs> origEventHandler = args => { eventCount++; };
             var component = new EventComponent { OnTest = origEventHandler };
-            var componentId = renderer.AssignRootComponentId(component);
+            renderer.AssignRootComponentId(component);
             component.TriggerRender();
             var origEventHandlerId = renderer.Batches.Single()
                 .ReferenceFrames
@@ -614,7 +612,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+            renderer.DispatchEvent(origEventHandlerId, args: null);
             Assert.Equal(1, eventCount);
 
             // Now remove the event attribute
@@ -624,7 +622,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act/Assert 2: Can no longer fire the original event
             Assert.Throws<ArgumentException>(() =>
             {
-                renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+                renderer.DispatchEvent(origEventHandlerId, args: null);
             });
             Assert.Equal(1, eventCount);
         }
@@ -653,7 +651,6 @@ namespace Microsoft.AspNetCore.Blazor.Test
                 .Select(e => batch.ReferenceFrames[e.ReferenceFrameIndex])
                 .Where(f => f.FrameType == RenderTreeFrameType.Component)
                 .Single();
-            var childComponentId = childComponentFrame.ComponentId;
             var childComponentDiff = batch.DiffsByComponentId[childComponentFrame.ComponentId].Single();
             var eventHandlerId = batch.ReferenceFrames
                 .Skip(childComponentDiff.Edits[0].ReferenceFrameIndex) // Search from where the child component frames start
@@ -663,7 +660,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            renderer.DispatchEvent(childComponentId, eventHandlerId, args: null);
+            renderer.DispatchEvent(eventHandlerId, args: null);
             Assert.Equal(1, eventCount);
 
             // Now remove the EventComponent
@@ -673,7 +670,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act/Assert 2: Can no longer fire the original event
             Assert.Throws<ArgumentException>(() =>
             {
-                renderer.DispatchEvent(eventHandlerId, eventHandlerId, args: null);
+                renderer.DispatchEvent(eventHandlerId, args: null);
             });
             Assert.Equal(1, eventCount);
         }
@@ -686,7 +683,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             var eventCount = 0;
             Action<UIEventArgs> origEventHandler = args => { eventCount++; };
             var component = new EventComponent { OnTest = origEventHandler };
-            var componentId = renderer.AssignRootComponentId(component);
+            renderer.AssignRootComponentId(component);
             component.TriggerRender();
             var origEventHandlerId = renderer.Batches.Single()
                 .ReferenceFrames
@@ -696,7 +693,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act/Assert 1: Event handler fires when we trigger it
             Assert.Equal(0, eventCount);
-            renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+            renderer.DispatchEvent(origEventHandlerId, args: null);
             Assert.Equal(1, eventCount);
 
             // Now remove the ancestor element
@@ -706,7 +703,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act/Assert 2: Can no longer fire the original event
             Assert.Throws<ArgumentException>(() =>
             {
-                renderer.DispatchEvent(componentId, origEventHandlerId, args: null);
+                renderer.DispatchEvent(origEventHandlerId, args: null);
             });
             Assert.Equal(1, eventCount);
         }
@@ -746,7 +743,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             Assert.Single(renderer.Batches);
 
             // Act
-            renderer.DispatchEvent(childComponentId, origEventHandlerId, args: null);
+            renderer.DispatchEvent(origEventHandlerId, args: null);
 
             // Assert
             Assert.Equal(2, renderer.Batches.Count);
@@ -926,11 +923,6 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             var componentId = renderer.AssignRootComponentId(component);
             component.TriggerRender();
-            var childComponentId = renderer.Batches.Single()
-                .ReferenceFrames
-                .Where(f => f.ComponentId != 0)
-                .Single()
-                .ComponentId;
             var origEventHandlerId = renderer.Batches.Single()
                 .ReferenceFrames
                 .Where(f => f.FrameType == RenderTreeFrameType.Attribute && f.AttributeName == "onclick")
@@ -939,7 +931,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act
             // The fact that there's no error here is the main thing we're testing
-            renderer.DispatchEvent(childComponentId, origEventHandlerId, args: null);
+            renderer.DispatchEvent(origEventHandlerId, args: null);
 
             // Assert: correct render result
             var newBatch = renderer.Batches.Skip(1).Single();
@@ -970,7 +962,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
 
             // Act: Toggle the checkbox
             var eventArgs = new UIChangeEventArgs { Value = true };
-            renderer.DispatchEvent(componentId, checkboxChangeEventHandlerId, eventArgs);
+            renderer.DispatchEvent(checkboxChangeEventHandlerId, eventArgs);
             var latestBatch = renderer.Batches.Last();
             var latestDiff = latestBatch.DiffsInOrder.Single();
             var referenceFrames = latestBatch.ReferenceFrames;

--- a/test/shared/TestRenderer.cs
+++ b/test/shared/TestRenderer.cs
@@ -27,8 +27,8 @@ namespace Microsoft.AspNetCore.Blazor.Test.Helpers
         public new int AssignRootComponentId(IComponent component)
             => base.AssignRootComponentId(component);
 
-        public new void DispatchEvent(int componentId, int eventHandlerId, UIEventArgs args)
-            => base.DispatchEvent(componentId, eventHandlerId, args);
+        public new void DispatchEvent(int eventHandlerId, UIEventArgs args)
+            => base.DispatchEvent(eventHandlerId, args);
 
         public T InstantiateComponent<T>() where T : IComponent
             => (T)InstantiateComponent(typeof(T));

--- a/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueSupplier.cshtml
+++ b/test/testapps/BasicTestApp/CascadingValueTest/CascadingValueSupplier.cshtml
@@ -16,7 +16,7 @@
     </CascadingValue>
 </CascadingValue>
 
-<p><button id="increment-count" onclick=@counterState.IncrementCount>Increment</button></p>
+<p><button id="increment-count" onclick=@(() => counterState.IncrementCount())>Increment</button></p>
 <p><label><input type="checkbox" id="toggle-flag-1" bind=currentFlagValue1 /> Flag 1</label></p>
 <p><label><input type="checkbox" id="toggle-flag-2" bind=currentFlagValue2 /> Flag 2</label></p>
 


### PR DESCRIPTION
This fixes multiple issues and potential areas of confusion related to event routing (in effect, the scenarios where you have to call `StateHasChanged` or not).

Previously, if one component passed an event handler (e.g., an `Action`, `Func<Task>`, `MulticastDelegate`, etc.) through to another component, either as a `[Parameter]` or simply by including it in some `ChildContent`, then when the event was fired it would be routed not to the component that owns the event handler, but the one that rendered it into the tree.

### Example

MyButton.cshtml:

```
<button onclick=@OnClick>Click me<button>
@functions {
    [Parameter] Action OnClick { get; set; }
}
```

Consumer:

```
<MyButton OnClick=@SomeMethod /> or <MyButton OnClick=@(() => { clickCount++; }) />

Clicks: @clickCount

@functions {
    int clickCount = 0;

    void SomeMethod()
    {
        clickCount++;
    }
}
```

You'd expect that clicking the button would update the click count, but it wouldn't. You'd have to fix it by calling `StateHasChanged` manually in the consumer's `SomeMethod` or the lambda. This was annoying and confusing.

### Example 2:

PassthroughComponent.cshtml:

```
@ChildContent

@functions {
    [Parameter] RenderFragment ChildContent { get; set; }
}
```

Consumer.cshtml:

```
<PassthroughComponent>
    <button OnClick=@(() => { clickCount++; })>Click me</button>
</PassthroughComponent>

Clicks: @clickCount

@functions {
    int clickCount = 0;
}
```

Again, clicking the button would seem to have no effect, unless you manually put `StateHasChanged` into the lambda.

### Fix

We now route events to the component matching `eventHandlerDelegate.Target`, not the component that inserted the delegate into the render tree. This fixes both of the common cases above, and works with event handlers expressed as both methods and lambdas.

This also simplifies cases around binding. Components that expose custom bindables can now trigger updates in their consumers easily.

### New API

In the case where a custom component wants to trigger a supplied event handler delegate indirectly (e.g., inside one of its own methods), there's now a public static API:

```
ComponentEvents.InvokeEventHandler(someDelegate, eventArgs)
```

This works with delegates that are `Action`, `Action<T>`, `Func<Task>`, `Func<T, Task>` (the fast paths), or arbitrary `MulticastDelgate` (slower path). It automatically causes the recipient to trigger its own re-rendering logic, including responses to async tasks (i.e., if it's a `Func<Task>`, then the recipient renders once synchronously, then again asynchronously after the task, just like normal event handlers).

### Breaking change

There's one scenario where this may break something people were already doing, i.e., relying on the older strange behavior. Example:

```
<button onclick=@SomeOtherObject.SomeMethod>Click me</button>
```

Previously, this would run `SomeOtherObject.SomeMethod` and then re-render the component. That might be useful if this method updated some global state that you read back during rendering.

Now it will no longer re-render the component, because `SomeMethod` isn't on that component. If you actually do want to re-render the component in this case, the solution is to ensure you're actually calling one of its methods or lambdas, e.g.:

```
<button onclick=@(() => SomeOtherObject.SomeMethod())>Click me</button>
```

Alternatively, if you're actually updating some global state container, it's better still to have the state container raise some event that triggers all the necessary UI updates on all components, not just the one that raised the action.

Although it's a slight drawback to have this breaking change, I still think this is the right thing to do. The new rules about when events update components are much simpler and easier to reason about (i.e., we re-render the component that owns the event handler method/lambda, regardless of who passed it where).