### PR TITLE
Handle overlapping events

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Blazor.Performance/RenderTreeDiffBuilderBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Blazor.Performance/RenderTreeDiffBuilderBenchmark.cs
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.Blazor.Performance
             {
             }
 
-            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => Task.CompletedTask;
         }
 

--- a/benchmarks/Microsoft.AspNetCore.Blazor.Performance/RenderTreeDiffBuilderBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Blazor.Performance/RenderTreeDiffBuilderBenchmark.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Blazor.Components;
 using Microsoft.AspNetCore.Blazor.Rendering;
@@ -92,9 +93,8 @@ namespace Microsoft.AspNetCore.Blazor.Performance
             {
             }
 
-            protected override void UpdateDisplay(in RenderBatch renderBatch)
-            {
-            }
+            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+                => Task.CompletedTask;
         }
 
         private class TestServiceProvider : IServiceProvider

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
@@ -65,8 +65,8 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
             var componentId = AssignRootComponentId(component);
 
             // The only reason we're calling this synchronously is so that, if it throws,
-            // we get the exception back *before* attempting the first UpdateDisplay
-            // (otherwise the logged exception will come from UpdateDisplay instead of here)
+            // we get the exception back *before* attempting the first UpdateDisplayAsync
+            // (otherwise the logged exception will come from UpdateDisplayAsync instead of here)
             // When implementing support for out-of-process runtimes, we'll need to call this
             // asynchronously and ensure we surface any exceptions correctly.
             ((IJSInProcessRuntime)JSRuntime.Current).Invoke<object>(
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         }
 
         /// <inheritdoc />
-        protected override Task UpdateDisplay(in RenderBatch batch)
+        protected override Task UpdateDisplayAsync(in RenderBatch batch)
         {
             if (JSRuntime.Current is MonoWebAssemblyJSRuntime mono)
             {

--- a/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Browser/Rendering/BrowserRenderer.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Blazor.Rendering;
 using Microsoft.JSInterop;
 using Mono.WebAssembly.Interop;
 using System;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
 {
@@ -86,7 +87,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         }
 
         /// <inheritdoc />
-        protected override void UpdateDisplay(in RenderBatch batch)
+        protected override Task UpdateDisplay(in RenderBatch batch)
         {
             if (JSRuntime.Current is MonoWebAssemblyJSRuntime mono)
             {
@@ -94,12 +95,12 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
                     "Blazor._internal.renderBatch",
                     _browserRendererId,
                     batch);
+                return Task.CompletedTask;
             }
             else
             {
-                // When implementing support for an out-of-process JS runtime, we'll need to
-                // do something here to serialize and transmit the RenderBatch efficiently.
-                throw new NotImplementedException("TODO: Support BrowserRenderer.UpdateDisplay on other runtimes.");
+                // This renderer is not used for server-side Blazor.
+                throw new NotImplementedException($"{nameof(BrowserRenderer)} is supported only with in-process JS runtimes.");
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Blazor.Server/BlazorHub.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/BlazorHub.cs
@@ -78,6 +78,14 @@ namespace Microsoft.AspNetCore.Blazor.Server
             EnsureCircuitHost().BeginInvokeDotNetFromJS(callId, assemblyName, methodIdentifier, dotNetObjectId, argsJson);
         }
 
+        /// <summary>
+        /// Intended for framework use only. Applications should not call this method directly.
+        /// </summary>
+        public void OnRenderCompleted(long renderId, string errorMessageOrNull)
+        {
+            EnsureCircuitHost().Renderer.OnRenderCompleted(renderId, errorMessageOrNull);
+        }
+
         private async void CircuitHost_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
             var circuitHost = (CircuitHost)sender;

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/AutoCancelTaskCompletionSource.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/AutoCancelTaskCompletionSource.cs
@@ -5,7 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
+namespace Microsoft.AspNetCore.Blazor.Server.Circuits
 {
     /// <summary>
     /// Behaves like a <see cref="TaskCompletionSource{T}"/>, but automatically times out

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/AutoCancelTaskCompletionSource.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/AutoCancelTaskCompletionSource.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
+{
+    /// <summary>
+    /// Behaves like a <see cref="TaskCompletionSource{T}"/>, but automatically times out
+    /// the underlying task after a given period if not already completed.
+    /// </summary>
+    internal class AutoCancelTaskCompletionSource<T>
+    {
+        private readonly TaskCompletionSource<T> _completionSource;
+        private readonly CancellationTokenSource _timeoutSource;
+
+        public AutoCancelTaskCompletionSource(int timeoutMilliseconds)
+        {
+            _completionSource = new TaskCompletionSource<T>();
+            _timeoutSource = new CancellationTokenSource();
+            _timeoutSource.CancelAfter(timeoutMilliseconds);
+            _timeoutSource.Token.Register(() => _completionSource.TrySetCanceled());
+        }
+
+        public Task Task => _completionSource.Task;
+
+        public void TrySetResult(T result)
+        {
+            if (_completionSource.TrySetResult(result))
+            {
+                _timeoutSource.Dispose(); // We're not going to time out
+            }
+        }
+
+        public void TrySetException(Exception exception)
+        {
+            if (_completionSource.TrySetException(exception))
+            {
+                _timeoutSource.Dispose(); // We're not going to time out
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRenderer.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         }
 
         /// <inheritdoc />
-        protected override Task UpdateDisplay(in RenderBatch batch)
+        protected override Task UpdateDisplayAsync(in RenderBatch batch)
         {
             // Prepare to track the render process with a timeout
             var renderId = Interlocked.Increment(ref _nextRenderId);

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRenderer.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Threading;
 using System.Threading.Tasks;
 using MessagePack;
 using Microsoft.AspNetCore.Blazor.Components;
@@ -14,10 +16,17 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
 {
     internal class RemoteRenderer : Renderer
     {
+        // The purpose of the timeout is just to ensure server resources are released at some
+        // point if the client disconnects without sending back an ACK after a render
+        private const int TimeoutMilliseconds = 60 * 1000;
+
         private readonly int _id;
         private readonly IClientProxy _client;
         private readonly IJSRuntime _jsRuntime;
         private readonly RendererRegistry _rendererRegistry;
+        private readonly ConcurrentDictionary<long, AutoCancelTaskCompletionSource<object>> _pendingRenders
+            = new ConcurrentDictionary<long, AutoCancelTaskCompletionSource<object>>();
+        private long _nextRenderId = 1;
 
         /// <summary>
         /// Notifies when a rendering exception occured.
@@ -89,7 +98,13 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         /// <inheritdoc />
         protected override Task UpdateDisplay(in RenderBatch batch)
         {
+            // Prepare to track the render process with a timeout
+            var renderId = Interlocked.Increment(ref _nextRenderId);
+            var pendingRenderInfo = new AutoCancelTaskCompletionSource<object>(TimeoutMilliseconds);
+            _pendingRenders[renderId] = pendingRenderInfo;
+
             // Send the render batch to the client
+            // If the "send" operation fails, abort the whole render with that exception
             // Note that we have to capture the data as a byte[] synchronously here, because
             // SignalR's SendAsync can wait an arbitrary duration before serializing the params.
             // The RenderBatch buffer will get reused by subsequent renders, so we need to
@@ -97,9 +112,39 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
             // TODO: Consider using some kind of array pool instead of allocating a new
             //       buffer on every render.
             var batchBytes = MessagePackSerializer.Serialize(batch, RenderBatchFormatterResolver.Instance);
-            var task = _client.SendAsync("JS.RenderBatch", _id, batchBytes);
-            CaptureAsyncExceptions(task);
-            return task;
+            _client.SendAsync("JS.RenderBatch", _id, renderId, batchBytes).ContinueWith(sendTask =>
+            {
+                if (sendTask.IsFaulted)
+                {
+                    pendingRenderInfo.TrySetException(sendTask.Exception);
+                }
+            });
+
+            // When the render is completed (success, fail, or timeout), stop tracking it
+            return pendingRenderInfo.Task.ContinueWith(task =>
+            {
+                _pendingRenders.TryRemove(renderId, out var ignored);
+                if (task.IsFaulted)
+                {
+                    UnhandledException?.Invoke(this, task.Exception);
+                }
+            });
+        }
+
+        public void OnRenderCompleted(long renderId, string errorMessageOrNull)
+        {
+            if (_pendingRenders.TryGetValue(renderId, out var pendingRenderInfo))
+            {
+                if (errorMessageOrNull == null)
+                {
+                    pendingRenderInfo.TrySetResult(null);
+                }
+                else
+                {
+                    pendingRenderInfo.TrySetException(
+                        new RemoteRendererException(errorMessageOrNull));
+                }
+            }
         }
 
         private void CaptureAsyncExceptions(Task task)

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRenderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRenderer.cs
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
         }
 
         /// <inheritdoc />
-        protected override void UpdateDisplay(in RenderBatch batch)
+        protected override Task UpdateDisplay(in RenderBatch batch)
         {
             // Send the render batch to the client
             // Note that we have to capture the data as a byte[] synchronously here, because
@@ -99,6 +99,7 @@ namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
             var batchBytes = MessagePackSerializer.Serialize(batch, RenderBatchFormatterResolver.Instance);
             var task = _client.SendAsync("JS.RenderBatch", _id, batchBytes);
             CaptureAsyncExceptions(task);
+            return task;
         }
 
         private void CaptureAsyncExceptions(Task task)

--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRendererException.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/RemoteRendererException.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Blazor.Browser.Rendering
+{
+    /// <summary>
+    /// Represents an exception related to remote rendering.
+    /// </summary>
+    public class RemoteRendererException : Exception
+    {
+        /// <summary>
+        /// Constructs an instance of <see cref="RemoteRendererException"/>.
+        /// </summary>
+        /// <param name="message">The exception message.</param>
+        public RemoteRendererException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Blazor/RenderTree/ArrayRange.cs
+++ b/src/Microsoft.AspNetCore.Blazor/RenderTree/ArrayRange.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -41,5 +41,16 @@ namespace Microsoft.AspNetCore.Blazor.RenderTree
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()
             => ((IEnumerable)new ArraySegment<T>(Array, 0, Count)).GetEnumerator();
+
+        /// <summary>
+        /// Creates a shallow clone of the instance.
+        /// </summary>
+        /// <returns></returns>
+        public ArrayRange<T> Clone()
+        {
+            var buffer = new T[Count];
+            System.Array.Copy(Array, buffer, Count);
+            return new ArrayRange<T>(buffer, Count);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Blazor.Components;
 using Microsoft.AspNetCore.Blazor.RenderTree;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Blazor.Rendering
 {
@@ -77,7 +79,8 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// Updates the visible UI.
         /// </summary>
         /// <param name="renderBatch">The changes to the UI since the previous call.</param>
-        protected abstract void UpdateDisplay(in RenderBatch renderBatch);
+        /// <returns>A <see cref="Task"/> to represent the UI update process.</returns>
+        protected abstract Task UpdateDisplay(in RenderBatch renderBatch);
 
         /// <summary>
         /// Notifies the specified component that an event has occurred.
@@ -169,6 +172,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         private void ProcessRenderQueue()
         {
             _isBatchInProgress = true;
+            var updateDisplayTask = Task.CompletedTask;
 
             try
             {
@@ -180,12 +184,12 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
                 }
 
                 var batch = _batchBuilder.ToBatch();
-                UpdateDisplay(batch);
+                updateDisplayTask = UpdateDisplay(batch);
                 InvokeRenderCompletedCalls(batch.UpdatedComponents);
             }
             finally
             {
-                RemoveEventHandlerIds(_batchBuilder.DisposedEventHandlerIds.ToRange());
+                RemoveEventHandlerIds(_batchBuilder.DisposedEventHandlerIds.ToRange(), updateDisplayTask);
                 _batchBuilder.Clear();
                 _isBatchInProgress = false;
             }
@@ -217,13 +221,31 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
             }
         }
 
-        private void RemoveEventHandlerIds(ArrayRange<int> eventHandlerIds)
+        private void RemoveEventHandlerIds(ArrayRange<int> eventHandlerIds, Task afterTask)
         {
-            var array = eventHandlerIds.Array;
-            var count = eventHandlerIds.Count;
-            for (var i = 0; i < count; i++)
+            if (eventHandlerIds.Count == 0)
             {
-                _eventBindings.Remove(array[i]);
+                return;
+            }
+
+            if (afterTask.IsCompleted)
+            {
+                var array = eventHandlerIds.Array;
+                var count = eventHandlerIds.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    _eventBindings.Remove(array[i]);
+                }
+            }
+            else
+            {
+                // We need to delay the actual removal (e.g., until we've confirmed the client
+                // has processed the batch and hence can be sure not to reuse the handler IDs
+                // any further). We must clone the data because the underlying RenderBatchBuilder
+                // may be reused and hence modified by an unrelated subsequent batch.
+                var eventHandlerIdsClone = eventHandlerIds.Clone();
+                afterTask.ContinueWith(_ =>
+                    RemoveEventHandlerIds(eventHandlerIdsClone, Task.CompletedTask));
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
         /// </summary>
         /// <param name="renderBatch">The changes to the UI since the previous call.</param>
         /// <returns>A <see cref="Task"/> to represent the UI update process.</returns>
-        protected abstract Task UpdateDisplay(in RenderBatch renderBatch);
+        protected abstract Task UpdateDisplayAsync(in RenderBatch renderBatch);
 
         /// <summary>
         /// Notifies the specified component that an event has occurred.
@@ -184,7 +184,7 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
                 }
 
                 var batch = _batchBuilder.ToBatch();
-                updateDisplayTask = UpdateDisplay(batch);
+                updateDisplayTask = UpdateDisplayAsync(batch);
                 InvokeRenderCompletedCalls(batch.UpdatedComponents);
             }
             finally

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorIntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorIntegrationTestBase.cs
@@ -371,7 +371,7 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             public void AttachComponent(IComponent component)
                 => AssignRootComponentId(component);
 
-            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
             {
                 LatestBatchReferenceFrames = renderBatch.ReferenceFrames.ToArray();
                 return Task.CompletedTask;

--- a/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorIntegrationTestBase.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Build.Test/RazorIntegrationTestBase.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Blazor.Components;
 using Microsoft.AspNetCore.Blazor.Razor;
 using Microsoft.AspNetCore.Blazor.Rendering;
@@ -370,9 +371,10 @@ namespace Microsoft.AspNetCore.Blazor.Build.Test
             public void AttachComponent(IComponent component)
                 => AssignRootComponentId(component);
 
-            protected override void UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplay(in RenderBatch renderBatch)
             {
                 LatestBatchReferenceFrames = renderBatch.ReferenceFrames.ToArray();
+                return Task.CompletedTask;
             }
         }
 

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeBuilderTest.cs
@@ -1061,7 +1061,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
             }
 
-            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => throw new NotImplementedException();
         }
     }

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeBuilderTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Blazor.RenderTree;
 using Microsoft.AspNetCore.Blazor.Test.Helpers;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Blazor.Test
@@ -1060,7 +1061,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
             }
 
-            protected override void UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplay(in RenderBatch renderBatch)
                 => throw new NotImplementedException();
         }
     }

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
@@ -1531,7 +1531,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
             }
 
-            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => Task.CompletedTask;
         }
 

--- a/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RenderTreeDiffBuilderTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Blazor.Test.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Blazor.Test
@@ -1530,9 +1531,8 @@ namespace Microsoft.AspNetCore.Blazor.Test
             {
             }
 
-            protected override void UpdateDisplay(in RenderBatch renderBatch)
-            {
-            }
+            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+                => Task.CompletedTask;
         }
 
         private class FakeComponent : IComponent

--- a/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
@@ -1148,7 +1148,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             public new int AssignRootComponentId(IComponent component)
                 => base.AssignRootComponentId(component);
 
-            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => Task.CompletedTask;
         }
 
@@ -1402,9 +1402,9 @@ namespace Microsoft.AspNetCore.Blazor.Test
         {
             public Task NextUpdateDisplayReturnTask { get; set; }
 
-            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
             {
-                base.UpdateDisplay(renderBatch);
+                base.UpdateDisplayAsync(renderBatch);
                 return NextUpdateDisplayReturnTask;
             }
         }

--- a/test/Microsoft.AspnetCore.Blazor.Server.Test/Circuits/RenderBatchWriterTest.cs
+++ b/test/Microsoft.AspnetCore.Blazor.Server.Test/Circuits/RenderBatchWriterTest.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Blazor.Server
@@ -376,7 +377,7 @@ namespace Microsoft.AspNetCore.Blazor.Server
             {
             }
 
-            protected override void UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplay(in RenderBatch renderBatch)
                 => throw new NotImplementedException();
         }
     }

--- a/test/Microsoft.AspnetCore.Blazor.Server.Test/Circuits/RenderBatchWriterTest.cs
+++ b/test/Microsoft.AspnetCore.Blazor.Server.Test/Circuits/RenderBatchWriterTest.cs
@@ -377,7 +377,7 @@ namespace Microsoft.AspNetCore.Blazor.Server
             {
             }
 
-            protected override Task UpdateDisplay(in RenderBatch renderBatch)
+            protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
                 => throw new NotImplementedException();
         }
     }

--- a/test/shared/TestRenderer.cs
+++ b/test/shared/TestRenderer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNetCore.Blazor.Test.Helpers
         public T InstantiateComponent<T>() where T : IComponent
             => (T)InstantiateComponent(typeof(T));
 
-        protected override Task UpdateDisplay(in RenderBatch renderBatch)
+        protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
         {
             OnUpdateDisplay?.Invoke(renderBatch);
 
@@ -52,7 +52,7 @@ namespace Microsoft.AspNetCore.Blazor.Test.Helpers
             capturedBatch.DisposedComponentIDs = renderBatch.DisposedComponentIDs.ToList();
 
             // This renderer updates the UI synchronously, like the WebAssembly one.
-            // To test async UI updates, subclass TestRenderer and override UpdateDisplay.
+            // To test async UI updates, subclass TestRenderer and override UpdateDisplayAsync.
             return Task.CompletedTask;
         }
     }

--- a/test/shared/TestRenderer.cs
+++ b/test/shared/TestRenderer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Blazor.Components;
 using Microsoft.AspNetCore.Blazor.Rendering;
 
@@ -33,7 +34,7 @@ namespace Microsoft.AspNetCore.Blazor.Test.Helpers
         public T InstantiateComponent<T>() where T : IComponent
             => (T)InstantiateComponent(typeof(T));
 
-        protected override void UpdateDisplay(in RenderBatch renderBatch)
+        protected override Task UpdateDisplay(in RenderBatch renderBatch)
         {
             OnUpdateDisplay?.Invoke(renderBatch);
 
@@ -49,6 +50,10 @@ namespace Microsoft.AspNetCore.Blazor.Test.Helpers
             // Clone other data, as underlying storage will get reused by later batches
             capturedBatch.ReferenceFrames = renderBatch.ReferenceFrames.ToArray();
             capturedBatch.DisposedComponentIDs = renderBatch.DisposedComponentIDs.ToList();
+
+            // This renderer updates the UI synchronously, like the WebAssembly one.
+            // To test async UI updates, subclass TestRenderer and override UpdateDisplay.
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
This is to fix the general issue with server-side Blazor that the client can trigger events more rapidly than they get processed and the results flushed back to the client. A typical scenario would be when the user is typing and triggering `input` events on each keystroke.

Previously, if the client triggered the same event multiple times in quick succession, then the server might handle the first instance by re-rendering a component and hence disposing an event handler, then it might try to process the next instance and fail because the event handler was already disposed.

With this PR, the server delays the event handler disposals until it gets confirmation from the client that it's finished updating the UI with whatever renderbatch contains the disposal.

This should eliminate the issue, because once the client has updated the UI with whatever renderbatch contains the disposal, it can no longer legitimately try to trigger new instances of the event (the client knows it has gone from the UI). Also since client/server message delivery order is guaranteed, there's no way that an earlier event triggering message could come through *after* the client's message to confirm the completion of the renderbatch in which the event is disposed.