### PR TITLE
Fix intermittent render omissions. Fixes #1223.

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/MessagePackBufferStream.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/MessagePackBufferStream.cs
@@ -8,28 +8,19 @@ using System.IO;
 namespace Microsoft.AspNetCore.Blazor.Server.Circuits
 {
     /// <summary>
-    /// A write-only stream that outputs its data to an underlying expandable
-    /// buffer in the format for a MessagePack 'Bin32' block. Supports writing
-    /// into buffers up to 2GB in length.
+    /// Provides Stream APIs for writing to a MessagePack-supplied expandable buffer.
     /// </summary>
-    internal class MessagePackBinaryBlockStream : Stream
+    internal class MessagePackBufferStream : Stream
     {
-        // MessagePack Bin32 block
-        // https://github.com/msgpack/msgpack/blob/master/spec.md#bin-format-family
-        const int HeaderLength = 5;
-
         private byte[] _buffer;
         private int _headerStartOffset;
         private int _bodyLength;
 
-        public MessagePackBinaryBlockStream(byte[] buffer, int offset)
+        public MessagePackBufferStream(byte[] buffer, int offset)
         {
             _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
             _headerStartOffset = offset;
             _bodyLength = 0;
-
-            // Leave space for header
-            MessagePackBinary.EnsureCapacity(ref _buffer, _headerStartOffset, HeaderLength);
         }
 
         public byte[] Buffer => _buffer;
@@ -38,8 +29,8 @@ namespace Microsoft.AspNetCore.Blazor.Server.Circuits
         public override bool CanSeek => false;
         public override bool CanWrite => true;
 
-        // Length is the complete number of bytes being output, including header
-        public override long Length => _bodyLength + HeaderLength;
+        // Length is the complete number of bytes being output
+        public override long Length => _bodyLength;
 
         // Position is the index into the writable body (i.e., so position zero
         // is the first byte you can actually write a value to)
@@ -65,24 +56,10 @@ namespace Microsoft.AspNetCore.Blazor.Server.Circuits
 
         public override void Write(byte[] src, int srcOffset, int count)
         {
-            var outputOffset = _headerStartOffset + HeaderLength + _bodyLength;
+            var outputOffset = _headerStartOffset + _bodyLength;
             MessagePackBinary.EnsureCapacity(ref _buffer, outputOffset, count);
             System.Buffer.BlockCopy(src, srcOffset, _buffer, outputOffset, count);
             _bodyLength += count;
-        }
-
-        public override void Close()
-        {
-            // Write the header into the space we reserved at the beginning
-            // This format matches the MessagePack spec
-            unchecked
-            {
-                _buffer[_headerStartOffset] = MessagePackCode.Bin32;
-                _buffer[_headerStartOffset + 1] = (byte)(_bodyLength >> 24);
-                _buffer[_headerStartOffset + 2] = (byte)(_bodyLength >> 16);
-                _buffer[_headerStartOffset + 3] = (byte)(_bodyLength >> 8);
-                _buffer[_headerStartOffset + 4] = (byte)(_bodyLength);
-            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Blazor.Server/DependencyInjection/ServerSideBlazorServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/DependencyInjection/ServerSideBlazorServiceCollectionExtensions.cs
@@ -126,10 +126,7 @@ namespace Microsoft.Extensions.DependencyInjection
             // method on ISignalRServerBuilder so the developer always has to chain it onto
             // their own AddSignalR call. For now we're keeping it like this because it's
             // simpler for developers in common cases.
-            services.AddSignalR().AddMessagePackProtocol(options =>
-            {
-                options.FormatterResolvers.Insert(0, new RenderBatchFormatterResolver());
-            });
+            services.AddSignalR().AddMessagePackProtocol();
         }
     }
 }

--- a/test/Microsoft.AspnetCore.Blazor.Server.Test/Circuits/MessagePackBufferStreamTest.cs
+++ b/test/Microsoft.AspnetCore.Blazor.Server.Test/Circuits/MessagePackBufferStreamTest.cs
@@ -1,39 +1,23 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using MessagePack;
 using Microsoft.AspNetCore.Blazor.Server.Circuits;
 using System;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Blazor.Server
 {
-    public class MessagePackBinaryBlockStreamTest
+    public class MessagePackBufferStreamTest
     {
         [Fact]
         public void NullBuffer_Throws()
         {
             var ex = Assert.Throws<ArgumentNullException>(() =>
             {
-                new MessagePackBinaryBlockStream(null, 0);
+                new MessagePackBufferStream(null, 0);
             });
 
             Assert.Equal("buffer", ex.ParamName);
-        }
-
-        [Fact]
-        public void WithNoWrites_JustOutputsHeader()
-        {
-            // Arrange
-            var buffer = new byte[100];
-            var offset = 58; // Arbitrary
-
-            // Act
-            new MessagePackBinaryBlockStream(buffer, offset).Dispose();
-
-            // Assert
-            Assert.Equal(MessagePackCode.Bin32, buffer[offset]);
-            Assert.Equal(0, ReadBigEndianInt32(buffer, offset + 1));
         }
 
         [Fact]
@@ -44,32 +28,30 @@ namespace Microsoft.AspNetCore.Blazor.Server
             var offset = 58; // Arbitrary
 
             // Act/Assert
-            using (var stream = new MessagePackBinaryBlockStream(buffer, offset))
+            using (var stream = new MessagePackBufferStream(buffer, offset))
             {
                 stream.Write(new byte[] { 10, 20, 30, 40 }, 1, 2); // Write 2 bytes
                 stream.Write(new byte[] { 101 }, 0, 1); // Write another 1 byte
                 stream.Close();
 
-                Assert.Equal(MessagePackCode.Bin32, buffer[offset]);
-                Assert.Equal(3, ReadBigEndianInt32(buffer, offset + 1));
-                Assert.Equal(20, buffer[offset + 5]);
-                Assert.Equal(30, buffer[offset + 6]);
-                Assert.Equal(101, buffer[offset + 7]);
+                Assert.Equal(20, buffer[offset]);
+                Assert.Equal(30, buffer[offset + 1]);
+                Assert.Equal(101, buffer[offset + 2]);
             }
         }
 
         [Fact]
-        public void LengthIncludesHeaderButPositionDoesNot()
+        public void LengthAndPositionAreEquivalent()
         {
             // Arrange
             var buffer = new byte[20];
             var offset = 3;
 
             // Act/Assert
-            using (var stream = new MessagePackBinaryBlockStream(buffer, offset))
+            using (var stream = new MessagePackBufferStream(buffer, offset))
             {
                 stream.Write(new byte[] { 0x01, 0x02 }, 0, 2);
-                Assert.Equal(7, stream.Length);
+                Assert.Equal(2, stream.Length);
                 Assert.Equal(2, stream.Position);
             }
         }
@@ -78,15 +60,15 @@ namespace Microsoft.AspNetCore.Blazor.Server
         public void WithWrites_ExpandsBufferWhenNeeded()
         {
             // Arrange
-            var origBuffer = new byte[15];
+            var origBuffer = new byte[10];
             var offset = 6;
             origBuffer[0] = 123; // So we can check it was retained during expansion
 
             // Act/Assert
-            using (var stream = new MessagePackBinaryBlockStream(origBuffer, offset))
+            using (var stream = new MessagePackBufferStream(origBuffer, offset))
             {
-                // We can fit the 6-byte offset plus 5-byte header plus 3 written bytes
-                // into the original 15-byte buffer
+                // We can fit the 6-byte offset plus 3 written bytes
+                // into the original 10-byte buffer
                 stream.Write(new byte[] { 10, 20, 30 }, 0, 3);
                 Assert.Same(origBuffer, stream.Buffer);
 
@@ -98,13 +80,11 @@ namespace Microsoft.AspNetCore.Blazor.Server
                 // Check the expanded buffer has the expected contents
                 stream.Close();
                 Assert.Equal(123, stream.Buffer[0]); // Retains other values from original buffer
-                Assert.Equal(MessagePackCode.Bin32, stream.Buffer[offset]);
-                Assert.Equal(5, ReadBigEndianInt32(stream.Buffer, offset + 1));
-                Assert.Equal(10, stream.Buffer[offset + 5]);
-                Assert.Equal(20, stream.Buffer[offset + 6]);
-                Assert.Equal(30, stream.Buffer[offset + 7]);
-                Assert.Equal(40, stream.Buffer[offset + 8]);
-                Assert.Equal(50, stream.Buffer[offset + 9]);
+                Assert.Equal(10, stream.Buffer[offset]);
+                Assert.Equal(20, stream.Buffer[offset + 1]);
+                Assert.Equal(30, stream.Buffer[offset + 2]);
+                Assert.Equal(40, stream.Buffer[offset + 3]);
+                Assert.Equal(50, stream.Buffer[offset + 4]);
             }
         }
 


### PR DESCRIPTION
As per #1223, there were some timing-based cases where server-side rendering would just fail to apply certain updates to the UI.

The underlying reason turned out to be a misunderstanding about how the SignalR APIs work: I thought that `SendAsync` would at least *send* the data synchronously, and that the returned `Task` represented the network transfer. In fact I was wrong, and `SendAsync` doesn't necessarily serialize the inputs synchronously - if the network channel is currently busy, it waits until it's free before serializing. This was problematic because we reuse `RenderBatch` instances and their buffers for subsequent renders, so if multiple renders occurred sufficiently close together in time, the 2nd or later render could have its data overwritten by the 3rd or later render before its data was dispatched to the client.

The fix here is the obvious one, i.e., to snapshot the `RenderBatch` data synchronously at the time when `UpdateDisplay` is called. This has the drawback that we are now allocating an extra `byte[]` on every render. Later on, we should consider putting in some kind of object pool for this.