### PR TITLE
Serialize server-side renders. Fixes #1573

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Server/Circuits/DefaultCircuitFactory.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Server/Circuits/DefaultCircuitFactory.cs
@@ -40,8 +40,8 @@ namespace Microsoft.AspNetCore.Blazor.Server.Circuits
             var scope = _scopeFactory.CreateScope();
             var jsRuntime = new RemoteJSRuntime(client);
             var rendererRegistry = new RendererRegistry();
-            var renderer = new RemoteRenderer(scope.ServiceProvider, rendererRegistry, jsRuntime, client);
             var synchronizationContext = new CircuitSynchronizationContext();
+            var renderer = new RemoteRenderer(scope.ServiceProvider, rendererRegistry, jsRuntime, client, synchronizationContext);
 
             var circuitHost = new CircuitHost(
                 scope,

--- a/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
+++ b/src/Microsoft.AspNetCore.Blazor/Rendering/Renderer.cs
@@ -140,7 +140,13 @@ namespace Microsoft.AspNetCore.Blazor.Rendering
             frame = frame.WithAttributeEventHandlerId(id);
         }
 
-        internal void AddToRenderQueue(int componentId, RenderFragment renderFragment)
+        /// <summary>
+        /// Schedules a render for the specified <paramref name="componentId"/>. Its display
+        /// will be populated using the specified <paramref name="renderFragment"/>.
+        /// </summary>
+        /// <param name="componentId">The ID of the component to render.</param>
+        /// <param name="renderFragment">A <see cref="RenderFragment"/> that will supply the updated UI contents.</param>
+        protected internal virtual void AddToRenderQueue(int componentId, RenderFragment renderFragment)
         {
             var componentState = GetOptionalComponentState(componentId);
             if (componentState == null)

--- a/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.E2ETest/Tests/ComponentRenderingTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Configuration.Assemblies;
 using System.Linq;
 using System.Numerics;
+using System.Threading.Tasks;
 using BasicTestApp;
 using BasicTestApp.HierarchicalImportsTest.Subdir;
 using Microsoft.AspNetCore.Blazor.E2ETest.Infrastructure;
@@ -532,6 +533,23 @@ namespace Microsoft.AspNetCore.Blazor.E2ETest.Tests
                 e => Assert.Equal("The", e.Text),
                 e => Assert.Equal("", e.Text),
                 e => Assert.Equal("End", e.Text));
+        }
+
+        [Fact]
+        public async Task CanAcceptSimultaneousRenderRequests()
+        {
+            var expectedOutput = string.Join(
+                string.Empty,
+                Enumerable.Range(0, 100).Select(_ => "😊"));
+
+            var appElement = MountTestComponent<ConcurrentRenderParent>();
+
+            // It's supposed to pause the rendering for this long. The WaitAssert below
+            // allows it to take up extra time if needed.
+            await Task.Delay(1000);
+
+            var outputElement = appElement.FindElement(By.Id("concurrent-render-output"));
+            WaitAssert.Equal(expectedOutput, () => outputElement.Text);
         }
 
         static IAlert SwitchToAlert(IWebDriver driver)

--- a/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Test/RendererTest.cs
@@ -1130,7 +1130,7 @@ namespace Microsoft.AspNetCore.Blazor.Test
             // Act/Assert 3: After we complete the first UI update in which a given
             // event handler ID is disposed, we can no longer reuse that event handler ID
             render1TCS.SetResult(null);
-            await Task.Delay(100); // From here we can't see when the async disposal is completed. Just give it plenty of time (Task.Yield isn't enough).
+            await Task.Delay(500); // From here we can't see when the async disposal is completed. Just give it plenty of time (Task.Yield isn't enough).
             var ex = Assert.Throws<ArgumentException>(() =>
             {
                 renderer.DispatchEvent(componentId, eventHandlerId, new UIEventArgs());

--- a/test/testapps/BasicTestApp/ConcurrentRenderChild.cshtml
+++ b/test/testapps/BasicTestApp/ConcurrentRenderChild.cshtml
@@ -1,0 +1,16 @@
+<span>@(isAfterDelay ? "😊" :"WAITING")</span>
+@functions
+{
+    protected bool isAfterDelay;
+
+    protected override async Task OnInitAsync()
+    {
+        // If there are lots of instances of this component, the following delay
+        // will result in a lot of them triggering a re-render simultaneously
+        // on different threads.
+        // This test is to verify that the renderer correctly accepts all the
+        // simultaneous render requests.
+        await Task.Delay(1000);
+        isAfterDelay = true;
+    }
+}

--- a/test/testapps/BasicTestApp/ConcurrentRenderParent.cshtml
+++ b/test/testapps/BasicTestApp/ConcurrentRenderParent.cshtml
@@ -1,0 +1,7 @@
+<p>
+    After a 1 second delay, the output should be 100x😊, with no remaining "WAITING" markers.
+</p>
+
+<div id="concurrent-render-output">
+    @for (var i = 0; i < 100; i++) {<ConcurrentRenderChild />}
+</div>

--- a/test/testapps/BasicTestApp/Index.cshtml
+++ b/test/testapps/BasicTestApp/Index.cshtml
@@ -42,6 +42,7 @@
         <option value="BasicTestApp.RazorTemplates">Razor Templates</option>
         <option value="BasicTestApp.MultipleChildContent">Multiple child content</option>
         <option value="BasicTestApp.CascadingValueTest.CascadingValueSupplier">Cascading values</option>
+        <option value="BasicTestApp.ConcurrentRenderParent">Concurrent rendering</option>
     </select>
 
   @if (SelectedComponentType != null)


### PR DESCRIPTION
Another case where the asynchrony of server-side rendering needed some extra work to ensure the correct behaviors. This was a simple thread safety issue inside `Renderer`.

To a first approximation, I could have fixed it just by putting a `lock(_renderer) { ... }` around `RenderHandle`'s call to `_renderer.AddToRenderQueue`. However that could lead to deadlock because rendering can be re-entrant (a child can cause its own parent to re-render, e.g., by invoking some callback passed by the parent).

The solution here is to enqueue render calls on the circuit sync context. This causes some extra allocations per-render but provides an easy-to-reason-about solution. Plus it ensures that component lifecycle methods such as `Init` (which is invoked by the renderer) get executed serially within the sync context, which better matches up with the WebAssembly execution style.