### PR TITLE
Ignore non-public setters in analyzer

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Analyzers/ComponentParametersShouldNotBePublicAnalyzer.cs
+++ b/src/Microsoft.AspNetCore.Blazor.Analyzers/ComponentParametersShouldNotBePublicAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Blazor.Shared;
@@ -61,6 +61,16 @@ namespace Microsoft.AspNetCore.Blazor.Analyzers
         }
 
         private static bool IsPublic(PropertyDeclarationSyntax declaration)
-            => declaration.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword));
+        {
+            // If the property explicitly specifies a non-public setter, then it's valid
+            var setter = declaration.AccessorList?.Accessors.SingleOrDefault(x => x.Keyword.IsKind(SyntaxKind.SetKeyword));
+            if (setter != null && setter.Modifiers.Any(x => !x.IsKind(SyntaxKind.PublicKeyword)))
+            {
+                return false;
+            }
+
+            // Otherwise fallback to the property declaration modifiers
+            return declaration.Modifiers.Any(x => x.IsKind(SyntaxKind.PublicKeyword));
+        }
     }
 }

--- a/test/Microsoft.AspNetCore.Blazor.Analyzers.Test/ComponentParametersShouldNotBePublicTest.cs
+++ b/test/Microsoft.AspNetCore.Blazor.Analyzers.Test/ComponentParametersShouldNotBePublicTest.cs
@@ -106,6 +106,24 @@ namespace Microsoft.AspNetCore.Blazor.Analyzers.Test
     }" + BlazorParameterSource);
         }
 
+        [Fact]
+        public void IgnoresPublicPropertiesWithNonPublicSetterWithParameterAttribute()
+        {
+            var test = @"
+    namespace ConsoleApplication1
+    {
+        using " + typeof(ParameterAttribute).Namespace + @";
+
+        class TypeName
+        {
+            [Parameter] public string BadProperty1 { get; private set; }
+            [Parameter] public object BadProperty2 { get; protected set; }
+        }
+    }" + BlazorParameterSource;
+
+            VerifyCSharpDiagnostic(test);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new ComponentParametersShouldNotBePublicCodeFixProvider();


### PR DESCRIPTION
Currently if you have a property like:

```
[Parameter] public string Foo { get; private set; }
```

The analzyer emits a warning about public properties with a `[Parameter]` attribute specified.  Since the reason for this warning is about calling the setter (and mutating state at improper points in the rendering cycle) explicit non-public setters should be ignored.

See https://github.com/aspnet/Blazor/issues/1388#issuecomment-439650736 for more elaboration