### PR TITLE
Attempt to fix build flakiness using "npm ci"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ init:
   - git config --global core.autocrlf true
 install:
   - git submodule update --init --recursive
-  - ps: Install-Product node 8 x64
+  - ps: Install-Product node 10 x64
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_install:
   /usr/local/lib/; fi
 install:
   - . $HOME/.nvm/nvm.sh
-  - nvm install 8.9.4
-  - nvm use 8.9.4
+  - nvm install 10.13.0
+  - nvm use 10.13.0
   - npm install -g selenium-standalone
   - selenium-standalone install
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export TEST_CHROME_BINARY=`which google-chrome-stable`; fi

--- a/src/Microsoft.AspNetCore.Components.Browser.JS/Microsoft.AspNetCore.Components.Browser.JS.csproj
+++ b/src/Microsoft.AspNetCore.Components.Browser.JS/Microsoft.AspNetCore.Components.Browser.JS.csproj
@@ -18,7 +18,7 @@
 
   <Target Name="EnsureNpmRestored" Condition="!Exists('node_modules')">
     <Message Importance="high" Text="Restoring dependencies using 'npm'. This may take several minutes..." />
-    <Exec Command="npm install" />
+    <Exec Command="npm ci" />
   </Target>
 
   <Target Name="RunWebpack" AfterTargets="ResolveReferences" Inputs="@(WebpackInputs)" Outputs="dist\blazor.webassembly.js;dist\blazor.server.js" DependsOnTargets="EnsureNpmRestored">


### PR DESCRIPTION
The main complexity is that we need NPM 5.7.0+, hence having to ensure all the CI systems are using a recent-enough version of Node.