### PR TITLE
[wasm][framework] Add mono wasm framework libraries to build.

### DIFF
--- a/src/Microsoft.AspNetCore.Blazor.Mono/HowToUpgradeMono.md
+++ b/src/Microsoft.AspNetCore.Blazor.Mono/HowToUpgradeMono.md
@@ -20,8 +20,10 @@
 
 1. Replace the contents of `Blazor\src\mono\incoming` with the equivalents from the new Mono build:
 
-   * In Blazor's `src\mono\incoming\wasm` dir, replace `mono.wasm` and `mono.js` with the new files from Mono's `release` dir
-   * In Blazor's `src\mono\incoming\bcl`, delete all the `.dll` files (including from the `Facades` subdirectory), and copy in all the new `.dll` files from Mono's `wasm-bcl\wasm` dir. **Note:** We *only* need the `.dll` files, so don't include `.pdb`/`.cs`/`.tmp`/`.stamp` or others. Also you can omit `nunitlite.dll` - we don't need that either.
+   * In Blazor's `src\Microsoft.AspNetCore.Blazor.Mono\incoming\wasm` dir, replace `mono.wasm` and `mono.js` with the new files from Mono's `release` dir
+   * In Blazor's `src\Microsoft.AspNetCore.Blazor.Mono\incoming\bcl`, delete all the `.dll` files (including from the `Facades` subdirectory), and copy in all the new `.dll` files from Mono's `wasm-bcl\wasm` dir. **Note:** We *only* need the `.dll` files, so don't include `.pdb`/`.cs`/`.tmp`/`.stamp` or others. Also you can omit `nunitlite.dll` - we don't need that either.
+   * In Blazor's `src\Microsoft.AspNetCore.Blazor.Mono\incoming\framework` dir, replace `WebAssembly.Bindings.dll`, `WebAssembly.Net.Http.dll` and `WebAssembly.Net.WebSockets.dll` with the new files from Mono's `framework` dir
+
 
 The net effect is that you're replacing everything with the newer versions, including adding any new `.dll` files and removing any older `.dll` files that are no longer involved.
 

--- a/src/Microsoft.AspNetCore.Blazor.Mono/HowToUpgradeMono.md
+++ b/src/Microsoft.AspNetCore.Blazor.Mono/HowToUpgradeMono.md
@@ -14,11 +14,11 @@
 
 **Shortcut:** Browse directly to https://jenkins.mono-project.com/job/test-mono-mainline-wasm/255/label=ubuntu-1804-amd64/Azure/, replacing the number 255 with the desired build number.
 
-## Updating Blazor's `src\mono\incoming` directory
+## Updating Blazor's `src\Microsoft.AspNetCore.Blazor.Mono\incoming` directory
 
 1. Extract the contents of the Mono build .zip file to a temporary directory.
 
-1. Replace the contents of `Blazor\src\mono\incoming` with the equivalents from the new Mono build:
+1. Replace the contents of `Blazor\src\Microsoft.AspNetCore.Blazor.Mono\incoming` with the equivalents from the new Mono build:
 
    * In Blazor's `src\Microsoft.AspNetCore.Blazor.Mono\incoming\wasm` dir, replace `mono.wasm` and `mono.js` with the new files from Mono's `release` dir
    * In Blazor's `src\Microsoft.AspNetCore.Blazor.Mono\incoming\bcl`, delete all the `.dll` files (including from the `Facades` subdirectory), and copy in all the new `.dll` files from Mono's `wasm-bcl\wasm` dir. **Note:** We *only* need the `.dll` files, so don't include `.pdb`/`.cs`/`.tmp`/`.stamp` or others. Also you can omit `nunitlite.dll` - we don't need that either.

--- a/src/Microsoft.AspNetCore.Blazor.Mono/Microsoft.AspNetCore.Blazor.Mono.csproj
+++ b/src/Microsoft.AspNetCore.Blazor.Mono/Microsoft.AspNetCore.Blazor.Mono.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <WasmItemsToCopy Include="$(MonoIncomingDir)wasm\**" />
     <BclItemsToCopy Include="$(MonoIncomingDir)bcl\**" />
+    <FrameworkItemsToCopy Include="$(MonoIncomingDir)framework\**" />
     <BclWipeSpecFiles Include="$(BclWipeSpecDir)**" />
   </ItemGroup>
 
@@ -38,8 +39,12 @@
     <Copy SourceFiles="@(BclItemsToCopy)" DestinationFiles="@(BclItemsToCopy->'$(MonoDistDir)bcl\%(RecursiveDir)%(FileName)%(Extension)')">
       <Output TaskParameter="CopiedFiles" ItemName="_BclFilesCopied" />
     </Copy>
+    <Copy SourceFiles="@(FrameworkItemsToCopy)" DestinationFiles="@(FrameworkItemsToCopy->'$(MonoDistDir)framework\%(RecursiveDir)%(FileName)%(Extension)')">
+      <Output TaskParameter="CopiedFiles" ItemName="_FrameworkFilesCopied" />
+    </Copy>
     <Exec Command="&quot;$(DotNetTool)&quot; &quot;$(BlazorBuildToolsExe)&quot; ilwipe -s &quot;$(BclWipeSpecDir.TrimEnd('\'))&quot; -i &quot;$(MonoIncomingDir)bcl&quot; -o &quot;$(MonoDistDir)bcl&quot;" />
     <Touch Files="@(_BclFilesCopied)" /> <!-- Make incremental builds work -->
+    <Touch Files="@(_FrameworkFilesCopied)" /> <!-- Make incremental builds work -->
   </Target>
 
 </Project>

--- a/src/Microsoft.AspNetCore.Blazor.Mono/Microsoft.AspNetCore.Blazor.Mono.nuspec
+++ b/src/Microsoft.AspNetCore.Blazor.Mono/Microsoft.AspNetCore.Blazor.Mono.nuspec
@@ -6,7 +6,8 @@
   <files>
     <file src="..\..\THIRD-PARTY-NOTICES.txt" />
     <file src="build\**" target="build" />
-    <file src="dist\**\*" target="tools\mono"  />
+    <file src="dist\**\*" target="tools\mono" exclude="dist\framework\*" />
     <file src="tools\binaries\illink\**\*.*" target="tools\illink" />
+    <file src="dist\framework\*" target="lib\netstandard1.0"  />
   </files>
 </package>

--- a/src/Microsoft.AspNetCore.Blazor.Mono/build/netstandard1.0/Microsoft.AspNetCore.Blazor.Mono.props
+++ b/src/Microsoft.AspNetCore.Blazor.Mono/build/netstandard1.0/Microsoft.AspNetCore.Blazor.Mono.props
@@ -5,5 +5,6 @@
     <MonoBaseClassLibraryPath>$(BlazorMonoRuntimeBasePath)tools/mono/bcl/</MonoBaseClassLibraryPath>
     <MonoBaseClassLibraryFacadesPath>$(BlazorMonoRuntimeBasePath)tools/mono/bcl/Facades/</MonoBaseClassLibraryFacadesPath>
     <MonoWasmRuntimePath>$(BlazorMonoRuntimeBasePath)tools/mono/wasm/</MonoWasmRuntimePath>
+    <MonoWasmFrameworkPath>$(BlazorMonoRuntimeBasePath)lib/netstandard1.0/</MonoWasmFrameworkPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Incorporating libraries necessary to start using mono's HTTP handler and WebSocket interfaces.