### PR TITLE
Update SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
   "sdk": {
-    "version": "5.0.100-alpha1-014696"
+    "version": "5.0.100-alpha1-015536"
   },
   "tools": {
-    "dotnet": "5.0.100-alpha1-014696",
+    "dotnet": "5.0.100-alpha1-015536",
     "runtimes": {
       "dotnet": [
         "2.1.11"


### PR DESCRIPTION
Should fix the "Could not load file or assembly 'NuGet.Common, Version=5.3.0.4," issue on ci builds.

Same as https://github.com/aspnet/Extensions/pull/2602